### PR TITLE
use std::abs from cstdlib which fixes a warning that occurs when compiling with clang 3.5 on 64-bit linux

### DIFF
--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -305,7 +305,7 @@ public:
         std::lock_guard<std::mutex> l(_mutex);
         using namespace std::chrono;
         auto diff = msg.time - _last_update;
-        auto secs_diff = abs((duration_cast<seconds>(diff)).count());
+        auto secs_diff = std::abs((duration_cast<seconds>(diff)).count());
         if (secs_diff >= 2)
         {
             _value = get_value(msg);


### PR DESCRIPTION
in file included from ../include/spdlog/sinks/../formatter.h:57:
../include/spdlog/details/pattern_formatter_impl.h:308:26: warning: absolute value function 'abs' given an argument of type 'rep' (aka 'long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        auto secs_diff = abs((duration_cast<seconds>(diff)).count());
                         ^
../include/spdlog/details/pattern_formatter_impl.h:308:26: note: use function 'std::abs' instead
        auto secs_diff = abs((duration_cast<seconds>(diff)).count());
                         ^~~
                         std::abs
1 warning generated.
