### PR TITLE
Add NOTICE, ALERT and EMERG log level.

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -49,14 +49,18 @@ typedef enum
     TRACE,
     DEBUG,
     INFO,
+    NOTICE,
     WARN,
     ERR,
     CRITICAL,
+    ALERT,
+    EMERG,
     ALWAYS,
     OFF
 } level_enum;
 
-static const char* level_names[] { "trace", "debug", "info", "warning", "error", "critical", "", ""};
+static const char* level_names[] { "trace", "debug", "info", "notice", "warning", "error", "critical",
+        "alert", "emerg", "", ""};
 inline const char* to_str(spdlog::level::level_enum l)
 {
     return level_names[l];

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -102,6 +102,12 @@ inline spdlog::details::line_logger spdlog::logger::info(const Args&... args)
 }
 
 template <typename... Args>
+inline spdlog::details::line_logger spdlog::logger::notice(const Args&... args)
+{
+    return log(level::NOTICE, args...);
+}
+
+template <typename... Args>
 inline spdlog::details::line_logger spdlog::logger::warn(const Args&... args)
 {
     return log(level::WARN, args...);
@@ -117,6 +123,18 @@ template <typename... Args>
 inline spdlog::details::line_logger spdlog::logger::critical(const Args&... args)
 {
     return log(level::CRITICAL, args...);
+}
+
+template <typename... Args>
+inline spdlog::details::line_logger spdlog::logger::alert(const Args&... args)
+{
+    return log(level::ALERT, args...);
+}
+
+template <typename... Args>
+inline spdlog::details::line_logger spdlog::logger::emerg(const Args&... args)
+{
+    return log(level::EMERG, args...);
 }
 
 inline const std::string& spdlog::logger::name() const

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -75,9 +75,12 @@ public:
     template <typename... Args> details::line_logger trace(const Args&... args);
     template <typename... Args> details::line_logger debug(const Args&... args);
     template <typename... Args> details::line_logger info(const Args&... args);
+    template <typename... Args> details::line_logger notice(const Args&... args);
     template <typename... Args> details::line_logger warn(const Args&... args);
     template <typename... Args> details::line_logger error(const Args&... args);
     template <typename... Args> details::line_logger critical(const Args&... args);
+    template <typename... Args> details::line_logger alert(const Args&... args);
+    template <typename... Args> details::line_logger emerg(const Args&... args);
 
 
 private:


### PR DESCRIPTION
Hello,

I am planning on writing a `syslog` sink. It would be great if we could have those 3 log level, so spdlog log level could be matched to syslog's. 

See commit msg.
