### PR TITLE
Add a drop() method to remove logger from the registry

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -72,6 +72,11 @@ public:
         return new_logger;
     }
 
+    void drop(const std::string &logger_name)
+    {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _loggers.erase(logger_name);
+    }
 
     std::shared_ptr<logger> create(const std::string& logger_name, sinks_init_list sinks)
     {

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -37,6 +37,10 @@ inline std::shared_ptr<spdlog::logger> spdlog::get(const std::string& name)
     return details::registry::instance().get(name);
 }
 
+inline void spdlog::drop(const std::string &name)
+{
+    details::registry::instance().drop(name);
+}
 
 // Create multi/single threaded rotating file logger
 inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_mt(const std::string& logger_name, const std::string& filename, size_t max_file_size, size_t max_files, bool auto_flush)

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -42,6 +42,10 @@ namespace spdlog
 // logger.info() << "This is another message" << x << y << z;
 std::shared_ptr<logger> get(const std::string& name);
 
+//
+// Drop the reference to this logger.
+//
+void drop(const std::string &name);
 
 //
 // Set global formatting


### PR DESCRIPTION
This commits allows the user to drop the registry reference to a
logger, allowing deletion of logger at any time.

I need this feature because I create logger from dynamically loaded object (through `dlopen()`) and I ran into trouble with the automatic deletion of logger (because it happened after `dlclose()`).
This allows me to delete my logger before closing my shared library, thus avoiding trouble.
