### PR TITLE
Replaced throw() with noexcept and removed some unneeded ';'.

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -71,8 +71,8 @@ inline const char* to_str(spdlog::level::level_enum l)
 class spdlog_ex : public std::exception
 {
 public:
-    spdlog_ex(const std::string& msg) :_msg(msg) {};
-    const char* what() const throw() override
+    spdlog_ex(const std::string& msg) :_msg(msg) {}
+    const char* what() const noexcept override
     {
         return _msg.c_str();
     }

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -51,7 +51,7 @@ public:
     explicit file_helper(bool auto_flush):
         _fd(nullptr),
         _auto_flush(auto_flush)
-    {};
+    {}
 
     file_helper(const file_helper&) = delete;
     file_helper& operator=(const file_helper&) = delete;

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -56,7 +56,7 @@ public:
     {
         std::lock_guard<Mutex> lock(_mutex);
         _sink_it(msg);
-    };
+    }
 
 
 protected:

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -75,7 +75,7 @@ public:
     void log(const details::log_msg &msg) override
     {
         ::syslog(syslog_prio_from_level(msg), "%s", msg.formatted.str().c_str());
-    };
+    }
 
 
 


### PR DESCRIPTION
Just a small update that fixes some warnings on with my very pedantic compiler setting.
