### PR TITLE
syslog_sink.h: add <array> include (gcc 4.7 compatibility)

### DIFF
--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -26,6 +26,7 @@
 
 #ifdef __linux__
 
+#include <array>
 #include <string>
 #include <syslog.h>
 


### PR DESCRIPTION
Thanks for this library. I consider using it in my projects.

The syslog_sink uses the std::array type but does not include it.

This PR fixes the following error when compiling with GCC 4.7:

```
g++ example.cpp -o example -march=native -Wall -Wshadow -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include  -O3 -flto
In file included from ../include/spdlog/details/spdlog_impl.h:33:0,
                 from ../include/spdlog/spdlog.h:143,
                 from example.cpp:29:
../include/spdlog/details/../sinks/syslog_sink.h:83:25: error: field ‘_priorities’ has incomplete type
../include/spdlog/details/../sinks/syslog_sink.h: In constructor ‘spdlog::sinks::syslog_sink::syslog_sink(const string&, int, int)’:
../include/spdlog/details/../sinks/syslog_sink.h:53:9: error: ‘_priorities’ was not declared in this scope
../include/spdlog/details/../sinks/syslog_sink.h: In member function ‘int spdlog::sinks::syslog_sink::syslog_prio_from_level(const spdlog::details::log_msg&) const’:
../include/spdlog/details/../sinks/syslog_sink.h:92:16: error: ‘_priorities’ was not declared in this scope
../include/spdlog/details/../sinks/syslog_sink.h:93:5: warning: control reaches end of non-void function [-Wreturn-type]
make: *** [example] Error 1
```

GCC Version:

```
$ g++ --version
g++ (Debian 4.7.2-5) 4.7.2
Copyright (C) 2012 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

With this change spdlog is compatible to GCC >=4.7.
(at least the examples compile and do what I expect them to do)
