### PR TITLE
Fixed 2 macro redefinition warnings related to WIN32_LEAN_AND_MEAN.

### DIFF
--- a/include/spdlog/details/format.cc
+++ b/include/spdlog/details/format.cc
@@ -39,7 +39,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdarg>
 
 #ifdef _WIN32
-# define WIN32_LEAN_AND_MEAN
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
 # ifdef __MINGW32__
 #  include <cstring>
 # endif

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -29,8 +29,10 @@
 #include<ctime>
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <Windows.h>
 #endif
 
 namespace spdlog


### PR DESCRIPTION
Previously, you would get a warning if WIN32_LEAN_AND_MEAN was already defined before including spdlog. This pull request fixes that.