### PR TITLE
discard policies on queue overflow

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -38,6 +38,7 @@
 #include <functional>
 #include "common.h"
 #include "logger.h"
+#include "spdlog.h"
 
 
 namespace spdlog
@@ -52,9 +53,9 @@ class async_logger :public logger
 {
 public:
     template<class It>
-    async_logger(const std::string& name, const It& begin, const It& end, size_t queue_size, const std::function<void()>& worker_warmup_cb = nullptr);
-    async_logger(const std::string& logger_name, sinks_init_list sinks, size_t queue_size, const std::function<void()>& worker_warmup_cb = nullptr);
-    async_logger(const std::string& logger_name, sink_ptr single_sink, size_t queue_size, const std::function<void()>& worker_warmup_cb = nullptr);
+    async_logger(const std::string& name, const It& begin, const It& end, size_t queue_size, const async_queue_overflow_policy overflow_policy = async_queue_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr);
+    async_logger(const std::string& logger_name, sinks_init_list sinks, size_t queue_size, const async_queue_overflow_policy overflow_policy = async_queue_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr);
+    async_logger(const std::string& logger_name, sink_ptr single_sink, size_t queue_size, const async_queue_overflow_policy overflow_policy = async_queue_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr);
 
 
 protected:

--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -125,9 +125,9 @@ private:
 
     // last exception thrown from the worker thread
     std::shared_ptr<spdlog_ex> _last_workerthread_ex;
-	
-	// overflow policy
-	const async_queue_overflow_policy _overflow_policy;
+
+    // overflow policy
+    const async_queue_overflow_policy _overflow_policy;
 
     // worker thread warmup callback - one can set thread priority, affinity, etc
     const std::function<void()> _worker_warmup_cb;
@@ -157,7 +157,7 @@ inline spdlog::details::async_log_helper::async_log_helper(formatter_ptr formatt
     _formatter(formatter),
     _sinks(sinks),
     _q(queue_size),
-	_overflow_policy(overflow_policy),
+    _overflow_policy(overflow_policy),
     _worker_warmup_cb(worker_warmup_cb),
     _worker_thread(&async_log_helper::worker_loop, this)
 {}

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -34,17 +34,17 @@
 
 
 template<class It>
-inline spdlog::async_logger::async_logger(const std::string& logger_name, const It& begin, const It& end, size_t queue_size, const std::function<void()>& worker_warmup_cb) :
+inline spdlog::async_logger::async_logger(const std::string& logger_name, const It& begin, const It& end, size_t queue_size, const async_queue_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb) :
     logger(logger_name, begin, end),
-    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, worker_warmup_cb))
+    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, overflow_policy, worker_warmup_cb))
 {
 }
 
-inline spdlog::async_logger::async_logger(const std::string& logger_name, sinks_init_list sinks, size_t queue_size, const std::function<void()>& worker_warmup_cb) :
-    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, worker_warmup_cb) {}
+inline spdlog::async_logger::async_logger(const std::string& logger_name, sinks_init_list sinks, size_t queue_size, const async_queue_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb) :
+    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, overflow_policy, worker_warmup_cb) {}
 
-inline spdlog::async_logger::async_logger(const std::string& logger_name, sink_ptr single_sink, size_t queue_size, const std::function<void()>& worker_warmup_cb) :
-    async_logger(logger_name, { single_sink }, queue_size, worker_warmup_cb) {}
+inline spdlog::async_logger::async_logger(const std::string& logger_name, sink_ptr single_sink, size_t queue_size, const async_queue_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb) :
+    async_logger(logger_name, { single_sink }, queue_size, overflow_policy, worker_warmup_cb) {}
 
 
 inline void spdlog::async_logger::_set_formatter(spdlog::formatter_ptr msg_formatter)

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -125,8 +125,8 @@ public:
         std::lock_guard<std::mutex> lock(_mutex);
         _async_mode = true;
         _async_q_size = q_size;
-		_overflow_policy = overflow_policy;
-		_worker_warmup_cb = worker_warmup_cb;
+        _overflow_policy = overflow_policy;
+        _worker_warmup_cb = worker_warmup_cb;
     }
 
     void set_sync_mode()
@@ -152,8 +152,8 @@ private:
     level::level_enum _level = level::info;
     bool _async_mode = false;
     size_t _async_q_size = 0;
-	async_queue_overflow_policy _overflow_policy = async_queue_overflow_policy::block_retry;
-	std::function<void()> _worker_warmup_cb = nullptr;
+    async_queue_overflow_policy _overflow_policy = async_queue_overflow_policy::block_retry;
+    std::function<void()> _worker_warmup_cb = nullptr;
 };
 }
 }

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -62,7 +62,7 @@ public:
             return found->second;
         std::shared_ptr<logger> new_logger;
         if (_async_mode)
-            new_logger = std::make_shared<async_logger>(logger_name, sinks_begin, sinks_end, _async_q_size, _worker_warmup_cb);
+            new_logger = std::make_shared<async_logger>(logger_name, sinks_begin, sinks_end, _async_q_size, _overflow_policy, _worker_warmup_cb);
         else
             new_logger = std::make_shared<logger>(logger_name, sinks_begin, sinks_end);
 
@@ -120,12 +120,13 @@ public:
             l.second->set_level(log_level);
     }
 
-    void set_async_mode(size_t q_size, const std::function<void()>& worker_warmup_cb = nullptr)
+    void set_async_mode(size_t q_size, const async_queue_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb)
     {
         std::lock_guard<std::mutex> lock(_mutex);
         _async_mode = true;
         _async_q_size = q_size;
-        _worker_warmup_cb = worker_warmup_cb;
+		_overflow_policy = overflow_policy;
+		_worker_warmup_cb = worker_warmup_cb;
     }
 
     void set_sync_mode()
@@ -151,7 +152,8 @@ private:
     level::level_enum _level = level::info;
     bool _async_mode = false;
     size_t _async_q_size = 0;
-    std::function<void()> _worker_warmup_cb = nullptr;
+	async_queue_overflow_policy _overflow_policy = async_queue_overflow_policy::block_retry;
+	std::function<void()> _worker_warmup_cb = nullptr;
 };
 }
 }

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -132,9 +132,9 @@ inline void spdlog::set_level(level::level_enum log_level)
 }
 
 
-inline void spdlog::set_async_mode(size_t queue_size, const std::function<void()>& worker_warmup_cb)
+inline void spdlog::set_async_mode(size_t queue_size, const async_queue_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb)
 {
-    details::registry::instance().set_async_mode(queue_size, worker_warmup_cb);
+    details::registry::instance().set_async_mode(queue_size, overflow_policy, worker_warmup_cb);
 }
 
 inline void spdlog::set_sync_mode()

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -61,9 +61,14 @@ void set_level(level::level_enum log_level);
 // Async mode - off by default.
 //
 
+enum class async_queue_overflow_policy {
+	block_retry, // Block / yield / sleep until message can be enqueued
+	discard_log_msg // Discard the message it enqueue fails
+};
+
 // Turn on async mode and set the queue size for each async_logger
 
-void set_async_mode(size_t queue_size, const std::function<void()>& worker_warmup_cb = nullptr);
+void set_async_mode(size_t queue_size, const async_queue_overflow_policy overflow_policy = async_queue_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr);
 // Turn off async mode
 void set_sync_mode();
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -61,9 +61,10 @@ void set_level(level::level_enum log_level);
 // Async mode - off by default.
 //
 
-enum class async_queue_overflow_policy {
-	block_retry, // Block / yield / sleep until message can be enqueued
-	discard_log_msg // Discard the message it enqueue fails
+enum class async_queue_overflow_policy
+{
+    block_retry, // Block / yield / sleep until message can be enqueued
+    discard_log_msg // Discard the message it enqueue fails
 };
 
 // Turn on async mode and set the queue size for each async_logger


### PR DESCRIPTION
for me it's much better to lose few lines of log vs stopping the processing thread due to buffer overflow.
maybe set_async_mode is somewhat over complicated now, feel free to suggest better design.

thx a lot