### PR TITLE
respect user-set compiler name

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,4 +1,4 @@
-CXX	= g++
+CXX	?= g++
 CXXFLAGS	= -march=native -Wall -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
 CXX_RELEASE_FLAGS = -O3 -flto
 

--- a/bench/Makefile.mingw
+++ b/bench/Makefile.mingw
@@ -1,4 +1,4 @@
-CXX	= g++
+CXX	?= g++
 CXXFLAGS	= -D_WIN32_WINNT=0x600 -march=native -Wall -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
 CXX_RELEASE_FLAGS = -O3 -flto
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,4 +1,4 @@
-CXX	= g++
+CXX	?= g++
 CXXFLAGS	= -march=native -Wall -Wshadow -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
 CXX_RELEASE_FLAGS = -O3 -flto
 CXX_DEBUG_FLAGS= -g 

--- a/example/Makefile.clang
+++ b/example/Makefile.clang
@@ -1,4 +1,4 @@
-CXX	= clang++
+CXX	?= clang++
 CXXFLAGS	= -march=native -Wall -Wextra -Wshadow -pedantic -std=c++11 -pthread -I../include
 CXX_RELEASE_FLAGS = -O2
 CXX_DEBUG_FLAGS= -g 

--- a/example/Makefile.mingw
+++ b/example/Makefile.mingw
@@ -1,4 +1,4 @@
-CXX	= g++
+CXX	?= g++
 CXXFLAGS	=  -D_WIN32_WINNT=0x600 -march=native -Wall -Wextra -Wshadow -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
 CXX_RELEASE_FLAGS = -O3 
 CXX_DEBUG_FLAGS= -g 


### PR DESCRIPTION
What if, for example, my clang compiler executable name is not clang but clang-3.5?