### PR TITLE
Fix broken examples in run from arbitrary dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ example/*
 !example/makefile
 !example/makefile.clang
 
-
+*.log

--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -69,9 +69,9 @@ int main(int argc, char* argv[])
         cout << "Single thread, " << format(howmany)  << " iterations, auto flush=" << auto_flush << endl;
         cout << "*******************************************************************************\n";
 
-        auto rotating_st = spdlog::rotating_logger_st("rotating_st", "logs/rotating_st", file_size, rotating_files, auto_flush);
+        auto rotating_st = spdlog::rotating_logger_st("rotating_st", "rotating_st.log", file_size, rotating_files, auto_flush);
         bench(howmany, rotating_st);
-        auto daily_st = spdlog::daily_logger_st("daily_st", "logs/daily_st", auto_flush);
+        auto daily_st = spdlog::daily_logger_st("daily_st", "daily_st.log", auto_flush);
         bench(howmany, daily_st);
         bench(howmany, spdlog::create<null_sink_st>("null_st"));
 
@@ -79,11 +79,11 @@ int main(int argc, char* argv[])
         cout << threads << " threads sharing same logger, " << format(howmany)  << " iterations, auto_flush=" << auto_flush << endl;
         cout << "*******************************************************************************\n";
 
-        auto rotating_mt = spdlog::rotating_logger_mt("rotating_mt", "logs/rotating_mt", file_size, rotating_files, auto_flush);
+        auto rotating_mt = spdlog::rotating_logger_mt("rotating_mt", "rotating_mt.log", file_size, rotating_files, auto_flush);
         bench_mt(howmany, rotating_mt, threads);
 
 
-        auto daily_mt = spdlog::daily_logger_mt("daily_mt", "logs/daily_mt", auto_flush);
+        auto daily_mt = spdlog::daily_logger_mt("daily_mt", "daily_mt.log", auto_flush);
         bench_mt(howmany, daily_mt, threads);
         bench(howmany, spdlog::create<null_sink_st>("null_mt"));
 
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 
         for(int i = 0; i < 3; ++i)
         {
-            auto as = spdlog::daily_logger_st("as", "logs/daily_async", auto_flush);
+            auto as = spdlog::daily_logger_st("as", "daily_async.log", auto_flush);
             bench_mt(howmany, as, threads);
             spdlog::drop("as");
         }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -53,7 +53,7 @@ int main(int, char* [])
         console->info("{:^30}", "centered");
 
         // Create a file rotating logger with 5mb size max and 3 rotated files
-        auto file_logger = spd::rotating_logger_mt("file_logger", "logs/mylogfile", 1048576 * 5, 3);
+        auto file_logger = spd::rotating_logger_mt("file_logger", "mylogfile.log", 1048576 * 5, 3);
         file_logger->set_level(spd::level::info);
         for(int i = 0; i < 10; ++i)
             file_logger->info("{} * {} equals {:>10}", i, i, i*i);
@@ -71,7 +71,7 @@ int main(int, char* [])
         // Just call spdlog::set_async_mode(q_size) and all created loggers from now on will be asynchronous..
         size_t q_size = 1048576; //queue size must be power of 2
         spdlog::set_async_mode(q_size);
-        auto async_file= spd::daily_logger_st("async_file_logger", "logs/async_log.txt");
+        auto async_file= spd::daily_logger_st("async_file_logger", "async_log.log");
         async_file->info() << "This is async log.." << "Should be very fast!";
 
         // syslog example. linux only..

--- a/example/logs/.gitignore
+++ b/example/logs/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
Examples work fine when run from example/, as in

```bash
$ cd example/
$ ./example
```

but otherwise break:

```bash
$ cd
$ ~/path/to/spdlog/example/bench
```

The above would fail on trying to open the logs/somefile for writing if the logs directory doesn't exist in the current directory.

Let's not assume there is a logs/ directory and just write our logs in the current directory. We can suffix the logs with .log so they're easy to find in .gitignore for cleanup.

And with that, we don't need the logs direcory, or the .gitignore inside it that keeps it hanging.
