### PR TITLE
coarse clock, short log level

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -71,9 +71,16 @@ typedef enum
 
 static const char* level_names[] { "trace", "debug", "info", "notice", "warning", "error", "critical", "alert", "emerg", "off"};
 
+static const char* short_level_names[] { "T", "D", "I", "N", "W", "E", "C", "A", "M", "O"};
+
 inline const char* to_str(spdlog::level::level_enum l)
 {
     return level_names[l];
+}
+
+inline const char* to_short_str(spdlog::level::level_enum l)
+{
+    return short_level_names[l];
 }
 } //level
 

--- a/include/spdlog/details/line_logger.h
+++ b/include/spdlog/details/line_logger.h
@@ -26,6 +26,9 @@
 
 #include "../common.h"
 #include "../logger.h"
+#ifdef SPDLOG_CLOCK_COARSE
+#include <time.h>
+#endif
 
 
 // Line logger class - aggregates operator<< calls to fast ostream
@@ -64,7 +67,15 @@ public:
         if (_enabled)
         {
             _log_msg.logger_name = _callback_logger->name();
+#ifndef SPDLOG_CLOCK_COARSE
             _log_msg.time = log_clock::now();
+#else
+			timespec ts;
+			::clock_gettime(CLOCK_REALTIME_COARSE, &ts);
+			_log_msg.time = std::chrono::time_point<log_clock, typename log_clock::duration>(
+				std::chrono::duration_cast<typename log_clock::duration>(
+					std::chrono::seconds(ts.tv_sec) + std::chrono::nanoseconds(ts.tv_nsec)));
+#endif
             _callback_logger->_log_msg(_log_msg);
         }
     }

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -69,6 +69,15 @@ class level_formatter :public flag_formatter
     }
 };
 
+// short log level appender
+class short_level_formatter :public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        msg.formatted << level::to_short_str(msg.level);
+    }
+};
+
 ///////////////////////////////////////////////////////////////////////
 // Date time pattern appenders
 ///////////////////////////////////////////////////////////////////////
@@ -478,6 +487,10 @@ inline void spdlog::pattern_formatter::handle_flag(char flag)
         _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::level_formatter()));
         break;
 
+    case 'L':
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::short_level_formatter()));
+        break;
+		
     case('t') :
         _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::t_formatter()));
         break;


### PR DESCRIPTION
There are two changes here - short (one letter) level name which is to me important (less space / more efficient / better readability due to constant prefix length).

And another is performance optimization - if SPDLOG_CLOCK_COARSE is defined than COARSE clock is used. Which makes HUGE impact.

W/o COARSE (normal logging)
`[denis@centosvm example]$ ./bench 
*******************************************************************************
Single thread, 1,048,576 iterations, auto flush=0
*******************************************************************************
rotating_st...		895,865/sec
daily_st...		790,050/sec
null_st...		2,152,852/sec

*******************************************************************************
10 threads sharing same logger, 1,048,576 iterations, auto_flush=0
*******************************************************************************
rotating_mt...		1,303,881/sec
daily_mt...		1,112,445/sec
null_mt...		2,111,470/sec

*******************************************************************************
async logging.. 10 threads sharing same logger, 1,048,576 iterations, auto_flush=0
*******************************************************************************
as...		2,254,303/sec
as...		2,735,628/sec
as...		2,716,915/sec`

With COARSE
`[denis@centosvm example]$ ./bench 
*******************************************************************************
Single thread, 1,048,576 iterations, auto flush=0
*******************************************************************************
rotating_st...		966,354/sec
daily_st...		862,434/sec
null_st...		2,835,814/sec

*******************************************************************************
10 threads sharing same logger, 1,048,576 iterations, auto_flush=0
*******************************************************************************
rotating_mt...		1,492,719/sec
daily_mt...		1,248,143/sec
null_mt...		2,209,334/sec

*******************************************************************************
async logging.. 10 threads sharing same logger, 1,048,576 iterations, auto_flush=0
*******************************************************************************
as...		2,841,635/sec
as...		4,245,019/sec
as...		4,100,125/sec`

Huge bust in async case because most of the time is spent on getting the clock value