### PR TITLE
Locking standard I/O when logging from multiple threads.

### DIFF
--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -65,9 +65,11 @@ inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_st(const std::string
 
 
 // Create stdout/stderr loggers
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt(const std::string& logger_name)
+inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt(const std::string& logger_name, std::mutex *shared)
 {
-    return create<spdlog::sinks::stdout_sink_mt>(logger_name);
+   std::shared_ptr<spdlog::logger> l = create<spdlog::sinks::stdout_sink_mt>(logger_name);
+   l->set_shared_mux( shared );
+   return l;
 }
 
 inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_st(const std::string& logger_name)
@@ -75,9 +77,11 @@ inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_st(const std::strin
     return create<spdlog::sinks::stdout_sink_st>(logger_name);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt(const std::string& logger_name)
+inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt(const std::string& logger_name, std::mutex *shared)
 {
-    return create<spdlog::sinks::stderr_sink_mt>(logger_name);
+    std::shared_ptr<spdlog::logger> l = create<spdlog::sinks::stderr_sink_mt>(logger_name);
+    l->set_shared_mux( shared );
+    return l;
 }
 
 inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const std::string& logger_name)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -33,6 +33,7 @@
 
 #include<vector>
 #include<memory>
+#include<mutex>
 #include "sinks/base_sink.h"
 #include "common.h"
 
@@ -107,6 +108,7 @@ public:
     void set_pattern(const std::string&);
     void set_formatter(formatter_ptr);
 
+    void set_shared_mux( std::mutex *m ) { _shared_mux = m; }
 
 protected:
     virtual void _log_msg(details::log_msg&);
@@ -124,6 +126,7 @@ protected:
     std::vector<sink_ptr> _sinks;
     formatter_ptr _formatter;
     std::atomic_int _level;
+    std::mutex *_shared_mux;
 
 };
 }

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -29,6 +29,7 @@
 #pragma once
 
 
+#include <mutex>
 
 #include "common.h"
 #include "logger.h"
@@ -93,9 +94,9 @@ std::shared_ptr<logger> daily_logger_st(const std::string& logger_name, const st
 //
 // Create stdout/stderr loggers
 //
-std::shared_ptr<logger> stdout_logger_mt(const std::string& logger_name);
+std::shared_ptr<logger> stdout_logger_mt(const std::string& logger_name, std::mutex *shared = nullptr);
 std::shared_ptr<logger> stdout_logger_st(const std::string& logger_name);
-std::shared_ptr<logger> stderr_logger_mt(const std::string& logger_name);
+std::shared_ptr<logger> stderr_logger_mt(const std::string& logger_name, std::mutex *shared = nullptr);
 std::shared_ptr<logger> stderr_logger_st(const std::string& logger_name);
 
 


### PR DESCRIPTION
This change set allows one to use standard I/O from multiple threads as long as those threads have a reference (pointer) to a shared mutex. This is optional and the old behavior is transparently available.

I use the library from multiple threads and create loggers in each thread that have different names, but use standard I/O as the backend. In that case a mutex is required if the messages are to be delivered w/o scrambling.

Note that I did not address the posibility that multiple threads log to the same file.
