### PR TITLE
travis-ci automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,31 +27,28 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.5
 
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang35
 
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
-
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
-
-    # Uncomment these to test without AddressSanitizer
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang35
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang35
 
     # Test clang-3.6: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
     - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
@@ -65,31 +62,28 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise-3.6
 
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang36
 
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
-
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
-
-    # Uncomment these to test without AddressSanitizer
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang36
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang36
 
     # Test clang-3.7: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
     - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
@@ -103,33 +97,27 @@ matrix:
             - ubuntu-toolchain-r-test
             - llvm-toolchain-precise
 
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
-
-    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
-    #   os: linux
-    #   addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang37
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+      os: linux
+      addons: *clang37
 
     # Test gcc-4.9: C++11, Build=Debug/Release, ASAN=Off
     - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
@@ -142,32 +130,9 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
 
-    # - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: *gcc49
-
-    # Test gcc-5.0: C++11/14, Build=Debug/Release, ASAN=Off
-    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: &gcc5
-    #     apt:
-    #       packages:
-    #         - gcc-5
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-
-    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: *gcc5
-
-    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: *gcc5
-
-    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: *gcc5
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: *gcc49
 
 # Install dependencies
 before_install:
@@ -196,10 +161,12 @@ install:
   - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
   - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
+  - CXX_FLAGS="${CXX_FLAGS} -std=${CPP}"
 
   # Build examples
   - cd example
-  - make CXXFLAGS="${CXX_FLAGS} ${CXX_LINKER_FLAGS}" VERBOSE=1
+  - if [ "$BUILD_TYPE" == "Release" ]; then make CXXFLAGS="${CXX_FLAGS} ${CXX_LINKER_FLAGS}" VERBOSE=1; fi
+  - if [ "$BUILD_TYPE" == "Debug" ]; then make debug CXXFLAGS="${CXX_FLAGS} ${CXX_LINKER_FLAGS}" VERBOSE=1; fi
 
 script:
   - ./example

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ language: cpp
 matrix:
   include:
     # Test clang-3.5: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
-    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: &clang35
-    #     apt:
-    #       packages:
-    #         - clang-3.5
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-precise-3.5
+    - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: &clang35
+        apt:
+          packages:
+            - clang-3.5
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.5
 
     # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
     #   os: linux
@@ -54,16 +54,16 @@ matrix:
     #   addons: *clang35
 
     # Test clang-3.6: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
-    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
-    #   os: linux
-    #   addons: &clang36
-    #     apt:
-    #       packages:
-    #         - clang-3.6
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-precise-3.6
+    - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: &clang36
+        apt:
+          packages:
+            - clang-3.6
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
 
     # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
     #   os: linux
@@ -132,15 +132,15 @@ matrix:
     #   addons: *clang37
 
     # Test gcc-4.9: C++11, Build=Debug/Release, ASAN=Off
-    # - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
-    #   os: linux
-    #   addons: &gcc49
-    #     apt:
-    #       packages:
-    #         - g++-4.9
-    #         - valgrind
-    #       sources:
-    #         - ubuntu-toolchain-r-test
+    - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+      os: linux
+      addons: &gcc49
+        apt:
+          packages:
+            - g++-4.9
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
 
     # - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
     #   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,211 @@
+# Adapted from various sources, including:
+# - Louis Dionne's Hana: https://github.com/ldionne/hana
+# - Paul Fultz II's FIT: https://github.com/pfultz2/Fit
+# - Eric Niebler's range-v3: https://github.com/ericniebler/range-v3
+language: cpp
+
+# Test matrix:
+# - Build matrix per compiler: C++11/C++14 + Debug/Release
+# - Optionally: AddressSanitizer (ASAN)
+# - Valgrind: all release builds are also tested with valgrind
+# - clang 3.4, 3.5, 3.6, trunk
+#   - Note: 3.4 and trunk are tested with/without ASAN,
+#     the rest is only tested with ASAN=On.
+# - gcc 4.9, 5.0
+#
+matrix:
+  include:
+    # Test clang-3.5: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: &clang35
+    #     apt:
+    #       packages:
+    #         - clang-3.5
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.5
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # Uncomment these to test without AddressSanitizer
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+    # - env: CLANG_VERSION=3.5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang35
+
+    # Test clang-3.6: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: &clang36
+    #     apt:
+    #       packages:
+    #         - clang-3.6
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-precise-3.6
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # Uncomment these to test without AddressSanitizer
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+    # - env: CLANG_VERSION=3.6 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang36
+
+    # Test clang-3.7: C++11/C++14, Buidd=Debug/Release, ASAN=On/Off
+    - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=On LIBCXX=On
+      os: linux
+      addons: &clang37
+        apt:
+          packages:
+            - clang-3.7
+            - valgrind
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=On LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # - env: CLANG_VERSION=3.7 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=On
+    #   os: linux
+    #   addons: *clang37
+
+    # Test gcc-4.9: C++11, Build=Debug/Release, ASAN=Off
+    # - env: GCC_VERSION=4.9 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: &gcc49
+    #     apt:
+    #       packages:
+    #         - g++-4.9
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+
+    # - env: GCC_VERSION=4.9 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc49
+
+    # Test gcc-5.0: C++11/14, Build=Debug/Release, ASAN=Off
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: &gcc5
+    #     apt:
+    #       packages:
+    #         - gcc-5
+    #         - valgrind
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=11 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Debug CPP=14 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+    # - env: GCC_VERSION=5 BUILD_TYPE=Release CPP=14 ASAN=Off LIBCXX=Off
+    #   os: linux
+    #   addons: *gcc5
+
+# Install dependencies
+before_install:
+  - export CHECKOUT_PATH=`pwd`;
+  - if [ -n "$GCC_VERSION" ]; then export CXX="g++-${GCC_VERSION}" CC="gcc-${GCC_VERSION}"; fi
+  - if [ -n "$CLANG_VERSION" ]; then export CXX="clang++-${CLANG_VERSION}" CC="clang-${CLANG_VERSION}"; fi
+  - if [ "$CLANG_VERSION" == "3.4" ]; then export CXX="/usr/local/clang-3.4/bin/clang++" CC="/usr/local/clang-3.4/bin/clang"; fi
+  - which $CXX
+  - which $CC
+  - which valgrind
+  - if [ -n "$CLANG_VERSION" ]; then sudo CXX=$CXX CC=$CC ./install_libcxx.sh; fi
+
+install:
+  - cd $CHECKOUT_PATH
+
+  # Workaround for valgrind bug: https://bugs.kde.org/show_bug.cgi?id=326469.
+  # It is fixed in valgrind 3.10 so this won't be necessary if someone
+  # replaces the current valgrind (3.7) with valgrind-3.10
+  - sed -i 's/march=native/msse4.2/' example/Makefile
+
+  - if [ ! -d build ]; then mkdir build; fi
+  - export CXX_FLAGS=""
+  - export CXX_LINKER_FLAGS=""
+  - if [ -z "$BUILD_TYPE" ]; then export BUILD_TYPE=Release; fi
+  - if [ "$ASAN" == "On"]; then export CXX_FLAGS="${CXX_FLAGS} -fsanitize=address,undefined,integer -fno-omit-frame-pointer -fno-sanitize=unsigned-integer-overflow"; fi
+  - if [ -n "$CLANG_VERSION" ]; then CXX_FLAGS="${CXX_FLAGS} -D__extern_always_inline=inline"; fi
+  - if [ "$LIBCXX" == "On" ]; then CXX_FLAGS="${CXX_FLAGS} -stdlib=libc++ -I/usr/include/c++/v1/"; fi
+  - if [ "$LIBCXX" == "On" ]; then CXX_LINKER_FLAGS="${CXX_FLAGS} -L/usr/lib/ -lc++"; fi
+
+  # Build examples
+  - cd example
+  - make CXXFLAGS="${CXX_FLAGS} ${CXX_LINKER_FLAGS}" VERBOSE=1
+
+script:
+  - ./example
+  - ./bench
+  - valgrind --trace-children=yes --leak-check=full ./example
+  - valgrind --trace-children=yes --leak-check=full ./bench
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spdlog
 
-Very fast, header only, C++ logging library.
+Very fast, header only, C++ logging library. [![Build Status](https://travis-ci.org/gabime/spdlog.svg?branch=master)](https://travis-ci.org/gabime/spdlog)
 
 ## Install
 Just copy the files to your build tree and use a C++11 compiler
@@ -9,7 +9,7 @@ Just copy the files to your build tree and use a C++11 compiler
  * Linux (gcc 4.8.1+, clang 3.5+)
  * Windows (visual studio 2013+, mingw with g++ 4.9.1+)
  * Mac OSX (clang 3.5+)
- 
+
 ##Features
 * Very fast - performance is the primary goal (see [benchmarks](#benchmarks) below).
 * Headers only.
@@ -31,7 +31,7 @@ Just copy the files to your build tree and use a C++11 compiler
 
 ## Benchmarks
 
-Below are some [benchmarks](bench) comparing popular log libraries under Ubuntu 64 bit, Intel i7-4770 CPU @ 3.40GHz 
+Below are some [benchmarks](bench) comparing popular log libraries under Ubuntu 64 bit, Intel i7-4770 CPU @ 3.40GHz
 
 #### Synchronous mode
 Time needed to log 1,000,000 lines in synchronous mode (in seconds, the best of 3 runs):
@@ -43,7 +43,7 @@ Time needed to log 1,000,000 lines in synchronous mode (in seconds, the best of 
 |100|     15.008  |1.139s |4.512s     |0.497s|
 
 
-#### Asynchronous mode 
+#### Asynchronous mode
 Time needed to log 1,000,000 lines in asynchronous mode, i.e. the time it takes to put them in the async queue (in seconds, the best of 3 runs):
 
 |threads|g2log <sup>async logger</sup>   |spdlog <sup>async mode</sup>|
@@ -70,7 +70,7 @@ int main(int, char* [])
         console->info("Welcome to spdlog!") ;
         console->info("An info message example {}..", 1);
         console->info() << "Streams are supported too  " << 1;
-	
+
         //Formatting examples
         console->info("Easy padding in numbers like {:08d}", 12);
         console->info("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
@@ -80,7 +80,7 @@ int main(int, char* [])
         console->info("{:<30}", "left aligned");
         console->info("{:>30}", "right aligned");
         console->info("{:^30}", "centered");
-        
+
         //
         // Runtime log levels
         //
@@ -88,7 +88,7 @@ int main(int, char* [])
         console->debug("This message shold not be displayed!");
         console->set_level(spd::level::debug); // Set specific logger's log level
         console->debug("Now it should..");
-  
+
         //
         // Create a file rotating logger with 5mb size max and 3 rotated files
         //
@@ -100,8 +100,8 @@ int main(int, char* [])
         // Create a daily logger - a new file is created every day on 2:30am
         //
         auto daily_logger = spd::daily_logger_mt("daily_logger", "logs/daily", 2, 30);
-        
-        // 
+
+        //
         // Customize msg format for all messages
         //
         spd::set_pattern("*** [%H:%M:%S %z] [thread %t] %v ***");
@@ -115,7 +115,7 @@ int main(int, char* [])
         //
         SPDLOG_TRACE(console, "Enabled only #ifdef SPDLOG_TRACE_ON..{} ,{}", 1, 3.23);
         SPDLOG_DEBUG(console, "Enabled only #ifdef SPDLOG_DEBUG_ON.. {} ,{}", 1, 3.23);
-        
+
         //
         // Asynchronous logging is very fast..
         // Just call spdlog::set_async_mode(q_size) and all created loggers from now on will be asynchronous..
@@ -124,14 +124,14 @@ int main(int, char* [])
         spdlog::set_async_mode(q_size);
         auto async_file= spd::daily_logger_st("async_file_logger", "logs/async_log.txt");
         async_file->info() << "This is async log.." << "Should be very fast!";
-          
-        //      
+
+        //
         // syslog example. linux only..
         //
         #ifdef __linux__
         std::string ident = "spdlog-example";
         auto syslog_logger = spd::syslog_logger("syslog", ident, LOG_PID);
-        syslog_logger->warn("This is warning that will end up in syslog. This is Linux only!");       
+        syslog_logger->warn("This is warning that will end up in syslog. This is Linux only!");
         #endif
     }
     catch (const spd::spdlog_ex& ex)
@@ -155,4 +155,3 @@ void custom_class_example()
 
 ## Documentation
 Documentation can be found in the [wiki](https://github.com/gabime/spdlog/wiki/1.-QuickStart) pages.
-

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,32 +1,29 @@
 CXX	?= g++
-CXXFLAGS	= -march=native -Wall -Wshadow -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
-CXX_RELEASE_FLAGS = -O3 -flto
-CXX_DEBUG_FLAGS= -g 
+CXXFLAGS	=
+CXX_FLAGS = -Wall -Wshadow -Wextra -pedantic -std=c++11 -pthread -I../include
+CXX_RELEASE_FLAGS = -O3 -march=native
+CXX_DEBUG_FLAGS= -g
 
 
 all:	example bench
 debug:	example-debug bench-debug
 
 example: example.cpp
-	$(CXX) example.cpp -o example $(CXXFLAGS) $(CXX_RELEASE_FLAGS)
+	$(CXX) example.cpp -o example $(CXX_FLAGS) $(CXX_RELEASE_FLAGS) $(CXXFLAGS)
 
 bench: bench.cpp
-	$(CXX) bench.cpp -o bench $(CXXFLAGS) $(CXX_RELEASE_FLAGS)
-	
+	$(CXX) bench.cpp -o bench $(CXX_FLAGS) $(CXX_RELEASE_FLAGS) $(CXXFLAGS)
+
 
 example-debug: example.cpp
-	$(CXX) example.cpp -o example-debug $(CXXFLAGS) $(CXX_DEBUG_FLAGS)
-	
+	$(CXX) example.cpp -o example-debug $(CXX_FLAGS) $(CXX_DEBUG_FLAGS) $(CXXFLAGS)
+
 bench-debug: bench.cpp
-	$(CXX) bench.cpp -o bench-debug $(CXXFLAGS) $(CXX_DEBUG_FLAGS)	
-
-
+	$(CXX) bench.cpp -o bench-debug $(CXX_FLAGS) $(CXX_DEBUG_FLAGS) $(CXXFLAGS)
 
 clean:
-	rm -f *.o logs/*.txt example example-debug bench bench-debug 
+	rm -f *.o logs/*.txt example example-debug bench bench-debug
 
 
 rebuild: clean all
 rebuild-debug: clean debug
-
-

--- a/install_libcxx.sh
+++ b/install_libcxx.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Install libc++ under travis
+
+svn --quiet co http://llvm.org/svn/llvm-project/libcxx/trunk libcxx
+mkdir libcxx/build
+(cd libcxx/build && cmake .. -DLIBCXX_CXX_ABI=libstdc++ -DLIBCXX_CXX_ABI_INCLUDE_PATHS="/usr/include/c++/4.6;/usr/include/c++/4.6/x86_64-linux-gnu")
+make -C libcxx/build cxx -j2
+sudo cp libcxx/build/lib/libc++.so.1.0 /usr/lib/
+sudo cp -r libcxx/build/include/c++/v1 /usr/include/c++/v1/
+sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so
+sudo ln -sf /usr/lib/libc++.so.1.0 /usr/lib/libc++.so.1


### PR DESCRIPTION
- add travis-ci automated testing
- only for the examples
- compiles with clang-3.5, 3.6, 3.7 (using libc++), and gcc 4.9 (using libstdc++)
- with and without address sanitizer
- in c++11 and c++14 `-std=` modes
- runs example and bench with and without valgrind

Note: the only thing one can get right now from this is that the code compiles successfully. 
To check that is doing the right thing one would need to add unit/regression tests.