### PR TITLE
Add default null sink based logger

### DIFF
--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -147,6 +147,11 @@ inline void spdlog::set_sync_mode()
     details::registry::instance().set_sync_mode();
 }
 
+inline void spdlog::set_default_logger(std::shared_ptr<spdlog::logger> logger)
+{
+    details::registry::instance().set_default_logger(logger);
+}
+
 inline void spdlog::drop_all()
 {
     details::registry::instance().drop_all();

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -74,6 +74,12 @@ void set_async_mode(size_t queue_size, const async_overflow_policy overflow_poli
 void set_sync_mode();
 
 //
+// Set default logger
+// Current default use a null sink
+//
+void set_default_logger(std::shared_ptr<logger> logger);
+
+//
 // Create and register multi/single threaded rotating file logger
 //
 std::shared_ptr<logger> rotating_logger_mt(const std::string& logger_name, const std::string& filename, size_t max_file_size, size_t max_files, bool force_flush = false);


### PR DESCRIPTION
Proposal to add a default logger.
Allow `spdlog::get` to return an usable logger when trying to get an unregistered logger.