### PR TITLE
Expose line_logger enabled state for custom types in stream operators

### DIFF
--- a/include/spdlog/details/line_logger.h
+++ b/include/spdlog/details/line_logger.h
@@ -206,6 +206,11 @@ public:
         _enabled = false;
     }
 
+    bool is_enabled()
+    {
+        return _enabled;
+    }
+
 
 private:
     logger* _callback_logger;

--- a/include/spdlog/details/line_logger.h
+++ b/include/spdlog/details/line_logger.h
@@ -206,7 +206,7 @@ public:
         _enabled = false;
     }
 
-    bool is_enabled()
+    bool is_enabled() const
     {
         return _enabled;
     }


### PR DESCRIPTION
Custom stream operators for line_logger need to be able to check line_logger.enabled and skip execution if it's false.