### PR TITLE
Add CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,80 @@
+# *************************************************************************/
+# * Copyright (c) 2015 Ruslan Baratov.                                    */
+# *                                                                       */
+# * Permission is hereby granted, free of charge, to any person obtaining */
+# * a copy of this software and associated documentation files (the       */
+# * "Software"), to deal in the Software without restriction, including   */
+# * without limitation the rights to use, copy, modify, merge, publish,   */
+# * distribute, sublicense, and/or sell copies of the Software, and to    */
+# * permit persons to whom the Software is furnished to do so, subject to */
+# * the following conditions:                                             */
+# *                                                                       */
+# * The above copyright notice and this permission notice shall be        */
+# * included in all copies or substantial portions of the Software.       */
+# *                                                                       */
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+# * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+# * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+# * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+# * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+# * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+# *************************************************************************/
+
+cmake_minimum_required(VERSION 3.0)
+project(spdlog VERSION 1.0.0)
+
+add_library(spdlog INTERFACE)
+
+option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
+
+target_include_directories(
+    spdlog
+    INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+
+if(SPDLOG_BUILD_EXAMPLES)
+  enable_testing()
+  add_subdirectory(example)
+endif()
+
+### Install ###
+# * https://github.com/forexample/package-example
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(include_install_dir "include")
+
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Note: use 'targets_export_name'
+configure_file("cmake/Config.cmake.in" "${project_config}" @ONLY)
+
+install(
+    TARGETS spdlog
+    EXPORT "${targets_export_name}"
+    INCLUDES DESTINATION "${include_install_dir}"
+)
+
+install(DIRECTORY "include/spdlog" DESTINATION "${include_install_dir}")
+
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,24 @@
+# *************************************************************************/
+# * Copyright (c) 2015 Ruslan Baratov.                                    */
+# *                                                                       */
+# * Permission is hereby granted, free of charge, to any person obtaining */
+# * a copy of this software and associated documentation files (the       */
+# * "Software"), to deal in the Software without restriction, including   */
+# * without limitation the rights to use, copy, modify, merge, publish,   */
+# * distribute, sublicense, and/or sell copies of the Software, and to    */
+# * permit persons to whom the Software is furnished to do so, subject to */
+# * the following conditions:                                             */
+# *                                                                       */
+# * The above copyright notice and this permission notice shall be        */
+# * included in all copies or substantial portions of the Software.       */
+# *                                                                       */
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+# * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+# * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+# * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+# * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+# * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+# *************************************************************************/
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,44 @@
+# *************************************************************************/
+# * Copyright (c) 2015 Ruslan Baratov.                                    */
+# *                                                                       */
+# * Permission is hereby granted, free of charge, to any person obtaining */
+# * a copy of this software and associated documentation files (the       */
+# * "Software"), to deal in the Software without restriction, including   */
+# * without limitation the rights to use, copy, modify, merge, publish,   */
+# * distribute, sublicense, and/or sell copies of the Software, and to    */
+# * permit persons to whom the Software is furnished to do so, subject to */
+# * the following conditions:                                             */
+# *                                                                       */
+# * The above copyright notice and this permission notice shall be        */
+# * included in all copies or substantial portions of the Software.       */
+# *                                                                       */
+# * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+# * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+# * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+# * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+# * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+# * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+# * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+# *************************************************************************/
+
+cmake_minimum_required(VERSION 3.0)
+project(SpdlogExamples)
+
+if(TARGET spdlog)
+  # Part of the main project
+  add_library(spdlog::spdlog ALIAS spdlog)
+else()
+  # Stand-alone build
+  find_package(spdlog CONFIG REQUIRED)
+endif()
+
+add_executable(example example.cpp)
+target_link_libraries(example spdlog::spdlog)
+
+add_executable(benchmark bench.cpp)
+target_link_libraries(benchmark spdlog::spdlog)
+
+enable_testing()
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
+add_test(NAME RunExample COMMAND example)
+add_test(NAME RunBenchmark COMMAND benchmark)


### PR DESCRIPTION
With this CMake code library can be installed and found by `find_package` like this:

```cmake
find_package(spdlog CONFIG REQUIRED)

add_executable(example example.cpp)
target_link_libraries(example spdlog::spdlog)
```

also tests can be run using CTest.

I see no releases so version set to `1.0.0`.