### PR TITLE
Update syslog_sink.h

### DIFF
--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -75,7 +75,7 @@ public:
 
     void log(const details::log_msg &msg) override
     {
-        ::syslog(syslog_prio_from_level(msg), "%s", msg.formatted.str().c_str());
+        ::syslog(syslog_prio_from_level(msg), "%s", msg.raw.str().c_str());
     }
 
     void flush() override


### PR DESCRIPTION
Syslog already adds formatting, such as the identifier set with `openlog` in the constructor, the priority, and timestamp -- using the formatted message duplicates this information in the log message. This especially causes problems when the syslog is forwarded to aggregators such as Loggly, Logstash, etc. which can parse log messages which are JSON. However, the duplicated fields which spdlog prepends interfere with this -- better to use `raw` in the syslog case I think, or perhaps add an ability to use custom formatters on individual sinks.