### PR TITLE
Renamed "Windows.h" to "windows.h" for building spdlog on MinGW using case-sensitive file system.

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -31,7 +31,7 @@
 # ifndef WIN32_LEAN_AND_MEAN
 #  define WIN32_LEAN_AND_MEAN
 # endif
-# include <Windows.h>
+# include <windows.h>
 
 #ifdef __MINGW32__
 #include <share.h>


### PR DESCRIPTION
In Linux (Ubuntu 15.10) version of MinGW-w64 "windows.h" is named with small letter first. As Linux uses case-sensitive FS by default, the compiler could not find it under the name "Windows.h".