### PR TITLE
Add zf_log to performance tests

### DIFF
--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,9 +1,9 @@
 CXX	?= g++
-CXXFLAGS	= -march=native -Wall -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include 
-CXX_RELEASE_FLAGS = -O3 -flto
+CXXFLAGS	= -march=native -Wall -Wextra -pedantic -std=c++11 -pthread -Wl,--no-as-needed  -I../include
+CXX_RELEASE_FLAGS = -O3 -flto -DNDEBUG
 
 
-binaries=spdlog-bench spdlog-bench-mt spdlog-async boost-bench boost-bench-mt glog-bench glog-bench-mt g2log-async easylogging-bench easylogging-bench-mt
+binaries=spdlog-bench spdlog-bench-mt spdlog-async zf_log-bench zf_log-bench-mt boost-bench boost-bench-mt glog-bench glog-bench-mt g2log-async easylogging-bench easylogging-bench-mt
 
 all: $(binaries)
 
@@ -15,9 +15,17 @@ spdlog-bench-mt: spdlog-bench-mt.cpp
 	
 spdlog-async: spdlog-async.cpp
 	$(CXX) spdlog-async.cpp -o spdlog-async  $(CXXFLAGS) $(CXX_RELEASE_FLAGS)
+
+
+ZF_LOG_FLAGS = -I../../zf_log.git/zf_log/
+zf_log-bench: zf_log-bench.cpp
+	$(CXX) zf_log-bench.cpp -o zf_log-bench  $(CXXFLAGS) $(CXX_RELEASE_FLAGS) $(ZF_LOG_FLAGS)
+
+zf_log-bench-mt: zf_log-bench-mt.cpp
+	$(CXX) zf_log-bench-mt.cpp -o zf_log-bench-mt  $(CXXFLAGS) $(CXX_RELEASE_FLAGS) $(ZF_LOG_FLAGS)
 	
 
-BOOST_FLAGS	= -DBOOST_LOG_DYN_LINK  -I/usr/include -lboost_log  -lboost_log_setup -lboost_filesystem -lboost_system -lboost_thread -lboost_regex -lboost_date_time -lboost_chrono	
+BOOST_FLAGS	= -DBOOST_LOG_DYN_LINK  -I/usr/include -lboost_log  -lboost_log_setup -lboost_filesystem -lboost_system -lboost_thread -lboost_regex -lboost_date_time -lboost_chrono
 
 boost-bench: boost-bench.cpp
 	$(CXX) boost-bench.cpp -o boost-bench $(CXXFLAGS) $(BOOST_FLAGS) $(CXX_RELEASE_FLAGS)

--- a/bench/run_all.sh
+++ b/bench/run_all.sh
@@ -24,13 +24,13 @@ bench_async ()
 		rm  -f logs/*
 		sleep 3
 	done;
-}  
+}
 
 
 echo "----------------------------------------------------------"
 echo "Single threaded benchmarks.. (1 thread,  1,000,000 lines)"
 echo "----------------------------------------------------------"
-for exe in boost-bench glog-bench easylogging-bench spdlog-bench;
+for exe in boost-bench glog-bench easylogging-bench zf_log-bench spdlog-bench;
 do
 	bench_exe $exe 1
 done;
@@ -38,7 +38,7 @@ done;
 echo "----------------------------------------------------------"
 echo "Multi threaded benchmarks.. (10 threads,  1,000,000 lines)"
 echo "----------------------------------------------------------"
-for exe in boost-bench-mt glog-bench-mt easylogging-bench-mt spdlog-bench-mt;
+for exe in boost-bench-mt glog-bench-mt easylogging-bench-mt zf_log-bench-mt spdlog-bench-mt;
 do
 	bench_exe $exe 10
 done;
@@ -46,11 +46,10 @@ done;
 echo "----------------------------------------------------------"
 echo "Multi threaded benchmarks.. (100 threads,  1,000,000 lines)"
 echo "----------------------------------------------------------"
-for exe in boost-bench-mt glog-bench-mt easylogging-bench-mt spdlog-bench-mt;
+for exe in boost-bench-mt glog-bench-mt easylogging-bench-mt zf_log-bench-mt spdlog-bench-mt;
 do
 	bench_exe $exe 100
 done;
-	
 
 echo "---------------------------------------------------------------"
 echo "Async, single threaded benchmark.. (1 thread,  1,000,000 lines)"
@@ -68,7 +67,6 @@ do
 	bench_async $exe 10
 done;
 
-
 echo "---------------------------------------------------------------"
 echo "Async, multi threaded benchmark.. (100 threads,  1,000,000 lines)"
 echo "---------------------------------------------------------------"
@@ -76,6 +74,3 @@ for exe in spdlog-async g2log-async
 do
 	bench_async $exe 100
 done;
-
-
-

--- a/bench/zf_log-bench-mt.cpp
+++ b/bench/zf_log-bench-mt.cpp
@@ -1,0 +1,56 @@
+#include <thread>
+#include <vector>
+#include <atomic>
+#include <cstdlib>
+#include <unistd.h>
+#include <fcntl.h>
+#include <zf_log.c>
+
+const char g_path[] = "logs/zf_log.txt";
+int g_fd;
+
+static void output_callback(zf_log_message *msg)
+{
+	*msg->p = '\n';
+	write(g_fd, msg->buf, msg->p - msg->buf + 1);
+}
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+	g_fd = open(g_path, O_APPEND|O_CREAT|O_WRONLY);
+	if (0 > g_fd)
+	{
+		ZF_LOGE_AUX(ZF_LOG_STDERR, "Failed to open log file: %s", g_path);
+		return -1;
+	}
+	zf_log_set_output_callback(ZF_LOG_PUT_STD, output_callback);
+
+    int thread_count = 10;
+    if(argc > 1)
+        thread_count = std::atoi(argv[1]);
+    int howmany = 1000000;
+    std::atomic<int > msg_counter {0};
+    vector<thread> threads;
+
+    for (int t = 0; t < thread_count; ++t)
+    {
+        threads.push_back(std::thread([&]()
+        {
+            while (true)
+            {
+                int counter = ++msg_counter;
+                if (counter > howmany) break;
+				ZF_LOGI("zf_log message #%i: This is some text for your pleasure", counter);
+            }
+        }));
+    }
+
+    for (auto &t:threads)
+    {
+        t.join();
+    };
+	close(g_fd);
+    return 0;
+}

--- a/bench/zf_log-bench.cpp
+++ b/bench/zf_log-bench.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <zf_log.c>
+
+const char g_path[] = "logs/zf_log.txt";
+static FILE *g_f;
+
+static void output_callback(zf_log_message *msg)
+{
+	*msg->p = '\n';
+	fwrite(msg->buf, msg->p - msg->buf + 1, 1, g_f);
+}
+
+int main(int, char* [])
+{
+	g_f = fopen(g_path, "wb");
+	if (!g_f) {
+		ZF_LOGE_AUX(ZF_LOG_STDERR, "Failed to open log file: %s", g_path);
+		return -1;
+	}
+	zf_log_set_output_callback(ZF_LOG_PUT_STD, output_callback);
+
+    const int howmany = 1000000;
+    for(int i  = 0 ; i < howmany; ++i)
+		ZF_LOGI("zf_log message #%i: This is some text for your pleasure", i);
+	fclose(g_f);
+    return 0;
+}


### PR DESCRIPTION
Adding [zf_log](https://github.com/wonder-mice/zf_log) to performance tests. On my machine (MacBook Pro 2.8GHz Core i7) I'm getting following results (real time, best of 3):
```
        1 thread   10 threads   100 threads
zf_log   0.466s     2.711s       2.608s
spdlog   0.747s     5.121s       5.376s
```