### PR TITLE
Add support for clearing file_sink current contents

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -297,3 +297,9 @@ inline void spdlog::logger::flush()
     for (auto& sink : _sinks)
         sink->flush();
 }
+
+inline void spdlog::logger::clear()
+{
+    for (auto& sink : _sinks)
+        sink->clear();
+}

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -89,6 +89,7 @@ public:
     void set_formatter(formatter_ptr);
 
     virtual void flush();
+    virtual void clear();
 
 protected:
     virtual void _log_msg(details::log_msg&);

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -32,6 +32,10 @@ public:
     {
     }
 
+    void clear() override
+    {
+    }
+
 protected:
     void _sink_it(const details::log_msg& msg) override
     {

--- a/include/spdlog/sinks/file_sinks.h
+++ b/include/spdlog/sinks/file_sinks.h
@@ -33,6 +33,11 @@ public:
         _file_helper.flush();
     }
 
+    void clear() override
+    {
+        _file_helper.reopen(true);
+    }
+
 protected:
     void _sink_it(const details::log_msg& msg) override
     {
@@ -69,6 +74,11 @@ public:
     void flush() override
     {
         _file_helper.flush();
+    }
+
+    void clear() override
+    {
+        _file_helper.reopen(true);
     }
 
 protected:
@@ -161,6 +171,11 @@ public:
     void flush() override
     {
         _file_helper.flush();
+    }
+
+    void clear() override
+    {
+        _file_helper.reopen(true);
     }
 
 protected:

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -24,6 +24,8 @@ protected:
     void flush() override
     {}
 
+    void clear() override
+    {}
 };
 typedef null_sink<details::null_mutex> null_sink_st;
 typedef null_sink<std::mutex> null_sink_mt;

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -38,6 +38,10 @@ protected:
         _ostream.flush();
     }
 
+    void clear() override
+    {
+    }
+
     std::ostream& _ostream;
     bool _force_flush;
 };

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -18,6 +18,7 @@ public:
     virtual ~sink() {}
     virtual void log(const details::log_msg& msg) = 0;
     virtual void flush() = 0;
+    virtual void clear() = 0;
 };
 }
 }

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -63,6 +63,10 @@ public:
     {
     }
 
+    void clear() override
+    {
+    }
+
 
 private:
     std::array<int, 10> _priorities;


### PR DESCRIPTION
This pull request adds `clear()` virtual function to the logger class and implements it for `file_sink` by calling `reopen(true)` on the `file_helper`. 
One should implement similar function for the other sinks. Some sink will not have a `clear` function (e.g. null_sink).