### PR TITLE
Allow syslog logger on Mac OS X

### DIFF
--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -71,7 +71,7 @@ inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const std::strin
     return details::registry::instance().create(logger_name, spdlog::sinks::stderr_sink_st::instance());
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 // Create syslog logger
 inline std::shared_ptr<spdlog::logger> spdlog::syslog_logger(const std::string& logger_name, const std::string& syslog_ident, int syslog_option)
 {

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 
 #include <array>
 #include <string>

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -78,7 +78,7 @@ std::shared_ptr<logger> stderr_logger_st(const std::string& logger_name);
 //
 // Create and register a syslog logger
 //
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 std::shared_ptr<logger> syslog_logger(const std::string& logger_name, const std::string& ident = "", int syslog_option = 0);
 #endif
 


### PR DESCRIPTION
Syslog is supported on Mac OS X, so there is no reason disallowing it. https://github.com/gabime/spdlog/issues/177