### PR TITLE
Performance improvement of stdout sink 

### DIFF
--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -5,10 +5,9 @@
 
 #pragma once
 
-#include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/details/null_mutex.h>
 
-#include <iostream>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 
@@ -18,15 +17,26 @@ namespace sinks
 {
 
 template <class Mutex>
-class stdout_sink : public ostream_sink<Mutex>
+class stdout_sink : public base_sink<Mutex>
 {
     using MyType = stdout_sink<Mutex>;
 public:
-    stdout_sink() : ostream_sink<Mutex>(std::cout, true) {}
+    stdout_sink() {}
     static std::shared_ptr<MyType> instance()
     {
         static std::shared_ptr<MyType> instance = std::make_shared<MyType>();
         return instance;
+    }
+
+    void _sink_it(const details::log_msg& msg) override
+    {
+        fwrite(msg.formatted.data(), sizeof(char), msg.formatted.size(), stdout);
+        flush();
+    }
+
+    void flush() override
+    {
+        fflush(stdout);
     }
 };
 
@@ -35,17 +45,27 @@ typedef stdout_sink<std::mutex> stdout_sink_mt;
 
 
 template <class Mutex>
-class stderr_sink : public ostream_sink<Mutex>
+class stderr_sink : public base_sink<Mutex>
 {
     using MyType = stderr_sink<Mutex>;
 public:
-    stderr_sink() : ostream_sink<Mutex>(std::cerr, true) {}
+    stderr_sink() {}
     static std::shared_ptr<MyType> instance()
     {
         static std::shared_ptr<MyType> instance = std::make_shared<MyType>();
         return instance;
     }
+    
+    void _sink_it(const details::log_msg& msg) override
+    {
+        fwrite(msg.formatted.data(), sizeof(char), msg.formatted.size(), stderr);
+        flush();
+    }
 
+    void flush() override
+    {
+        fflush(stderr);
+    }
 };
 
 typedef stderr_sink<std::mutex> stderr_sink_mt;

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -12,4 +12,5 @@
 
 #include "../include/spdlog/spdlog.h"
 #include "../include/spdlog/sinks/null_sink.h"
+#include "../include/spdlog/sinks/ostream_sink.h"
 


### PR DESCRIPTION
The current implementation of stdout sink uses std::cout.write, which is really slow.
Writing to stdout via fwrite can increase performance.
I wrote a simple benchmark to compare performance of fwrite(..., stdout) and std::cout.write. fwrite works  more than 28x faster (90 ms VS 2926 ms) in my configuration (Intel Core i7 2630QM, Windows 10, Visual Studio 2015).
Code of benchmark:
```C++
#include <iostream>
#include <chrono>

int main() {
    constexpr int howmany = 1000;
    const std::string message("spdlog message #: This is some text for your pleasure\n");
    
    // warm up
    for (int i = 0; i < howmany; ++i) {
        fwrite(message.c_str(), sizeof(char), message.size(), stdout);
        fflush(stdout);

        std::cout.write(message.c_str(), message.size());
        std::cout.flush();
    }

    const auto fwrite_start = std::chrono::steady_clock::now();
    for (int i = 0; i < howmany; ++i) {
        fwrite(message.c_str(), sizeof(char), message.size(), stdout);
        fflush(stdout);
    }
    const auto fwrite_end = std::chrono::steady_clock::now();

    const auto cout_start = std::chrono::steady_clock::now();
    for (int i = 0; i < howmany; ++i) {
        std::cout.write(message.c_str(), message.size());
        std::cout.flush();
    }
    const auto cout_end = std::chrono::steady_clock::now();

    std::cout << "fwrite: "<< std::chrono::duration_cast<std::chrono::milliseconds>(fwrite_end - fwrite_start).count() << " ms" << std::endl;
    std::cout << "std::cout: " << std::chrono::duration_cast<std::chrono::milliseconds>(cout_end - cout_start).count() << " ms" << std::endl;

    return 0;
}
```