### PR TITLE
Automatically flush log if message level is above certain severity.

### DIFF
--- a/include/spdlog/details/line_logger_impl.h
+++ b/include/spdlog/details/line_logger_impl.h
@@ -46,11 +46,6 @@ inline spdlog::details::line_logger::~line_logger()
 #endif
         _callback_logger->_log_msg(_log_msg);
     }
-
-    if (_log_msg.level >= _callback_logger->_flush_level)
-    {
-        _callback_logger->flush();
-    }
 }
 
 //

--- a/include/spdlog/details/line_logger_impl.h
+++ b/include/spdlog/details/line_logger_impl.h
@@ -46,6 +46,11 @@ inline spdlog::details::line_logger::~line_logger()
 #endif
         _callback_logger->_log_msg(_log_msg);
     }
+
+    if (_log_msg.level >= _callback_logger->_flush_level)
+    {
+        _callback_logger->flush();
+    }
 }
 
 //

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -21,6 +21,7 @@ inline spdlog::logger::logger(const std::string& logger_name, const It& begin, c
 
     // no support under vs2013 for member initialization for std::atomic
     _level = level::info;
+    _flush_level = level::off;
 }
 
 // ctor with sinks as init list
@@ -264,6 +265,11 @@ inline const std::string& spdlog::logger::name() const
 inline void spdlog::logger::set_level(spdlog::level::level_enum log_level)
 {
     _level.store(log_level);
+}
+
+inline void spdlog::logger::flush_on(level::level_enum log_level)
+{
+    _flush_level.store(log_level);
 }
 
 inline spdlog::level::level_enum spdlog::logger::level() const

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -290,6 +290,10 @@ inline void spdlog::logger::_log_msg(details::log_msg& msg)
     _formatter->format(msg);
     for (auto &sink : _sinks)
         sink->log(msg);
+
+    const auto flush_level = _flush_level.load(std::memory_order_relaxed);
+    if (msg.level >= flush_level)
+        flush();
 }
 
 inline void spdlog::logger::_set_pattern(const std::string& pattern)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -41,6 +41,9 @@ public:
     const std::string& name() const;
     bool should_log(level::level_enum) const;
 
+    // automatically call flush() after a message of level log_level or higher is emitted
+    void flush_on(level::level_enum log_level);
+
     // logger.info(cppformat_string, arg1, arg2, arg3, ...) call style
     template <typename... Args> details::line_logger trace(const char* fmt, const Args&... args);
     template <typename... Args> details::line_logger debug(const char* fmt, const Args&... args);
@@ -104,6 +107,7 @@ protected:
     std::vector<sink_ptr> _sinks;
     formatter_ptr _formatter;
     spdlog::level_t _level;
+    spdlog::level_t _flush_level;
 };
 }
 


### PR DESCRIPTION
Example usage:
```
auto logger = spd::get("some_async_logger");
logger->flush_on(spd::level::error);
logger->info("won't cause flush");
logger->error("will cause flush");
```
The end result is that messages with a log level of error or above will cause the log to be flushed after each message. This ensure that important events are logged while still maintaining performance for more verbose and less critical messages.

This patch maintains backward compatibility. By default the `flush_on()` value is set to `spd::level::off` so that no messages cause a flush.