### PR TITLE
Callback sink

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -6,6 +6,7 @@
 // spdlog usage example
 //
 #include "spdlog/spdlog.h"
+#include "spdlog/sinks/callback_sink.h"
 
 #include <cstdlib> // EXIT_FAILURE
 #include <iostream>
@@ -13,6 +14,7 @@
 
 void async_example();
 void syslog_example();
+void callback_example();
 
 namespace spd = spdlog;
 int main(int, char*[])
@@ -68,6 +70,8 @@ int main(int, char*[])
         // syslog example. linux/osx only..
         syslog_example();
 
+        // Callback example.
+        callback_example();
 
         // Release and close all loggers
         spdlog::drop_all();
@@ -114,5 +118,30 @@ void custom_class_example()
     some_class c;
     spdlog::get("console")->info("custom class with operator<<: {}..", c);
     spdlog::get("console")->info() << "custom class with operator<<: " << c << "..";
+}
+
+// Example of callback sink
+void callback_function(void* /*userdata*/,
+                       const char* logger_name,
+                       int level,
+                       size_t thread_id,
+                       const char* msg)
+{
+    // Normally this callback function would be used to redirect the log output
+    // to some other location (e.g., another logging system that isn't yet
+    // directly supported by spdlog).
+    std::cout << "--------------------" << std::endl;
+    std::cout << "Logger name: " << logger_name << std::endl;
+    std::cout << "Level: "       << level       << std::endl;
+    std::cout << "Thread ID: "   << thread_id   << std::endl;
+    std::cout << "Message: "     << msg;
+    std::cout << "--------------------" << std::endl;
+}
+
+void callback_example()
+{
+    auto callback_logger = spdlog::create<spdlog::sinks::callback_sink_mt>("callback_logger", &callback_function);
+    callback_logger->info("info sent to callback sink");
+    callback_logger->error("error sent to callback sink");
 }
 

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2016 Kevin M. Godby.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+//
+
+#pragma once
+
+//
+// This sink will call a callback function any time it's told to log something.
+//
+
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/common.h>
+#include <spdlog/details/log_msg.h>
+
+#include <mutex>
+
+namespace spdlog {
+namespace sinks {
+
+typedef void(*LogCallback)(void* /*userdata*/,
+                           const char* /*logger_name*/,
+                           int /*level*/,
+                           size_t /*thread_id*/,
+                           const char* /*msg*/);
+
+
+template<class Mutex>
+class callback_sink : public base_sink<Mutex> {
+public:
+    callback_sink(LogCallback callback = nullptr, void* userdata = nullptr) : _callback(callback), _userdata(userdata)
+    {
+        // do nothing
+    }
+
+    // noncopyable
+    callback_sink(const callback_sink&) = delete;
+    callback_sink& operator=(const callback_sink&) = delete;
+
+    virtual ~callback_sink() = default;
+
+    virtual void flush() override
+    {
+        // do nothing
+    }
+
+    void set_callback(LogCallback& callback, void* userdata)
+    {
+        _callback = callback;
+        _userdata = userdata;
+    }
+
+protected:
+    void _sink_it(const details::log_msg& msg) override
+    {
+        if (!_callback)
+            return;
+
+        _callback(_userdata, msg.logger_name.c_str(),
+                  static_cast<int>(msg.level), msg.thread_id,
+                  msg.formatted.c_str());
+    }
+
+    LogCallback _callback;
+    void* _userdata;
+};
+
+typedef callback_sink<std::mutex> callback_sink_mt;
+typedef callback_sink<details::null_mutex> callback_sink_st;
+
+} // end namespace sinks
+} // end namespace spdlog
+


### PR DESCRIPTION
This PR adds a callback sink and an example to show its usage.

The intended use of this sink is to allow for redirection of log output to a different logging system. For example, log output may be captured in the callback and sent to an on-screen GUI window instead of just the console or a file.
