### PR TITLE
In async mode, teardown callback on worker thread exit

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -13,7 +13,7 @@
 //    1. Checks if its log level is enough to log the message
 //    2. Push a new copy of the message to a queue (or block the caller until space is available in the queue)
 //    3. will throw spdlog_ex upon log exceptions
-// Upong destruction, logs all remaining messages in the queue before destructing..
+// Upon destruction, logs all remaining messages in the queue before destructing..
 
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
@@ -41,21 +41,24 @@ public:
                  size_t queue_size,
                  const async_overflow_policy overflow_policy =  async_overflow_policy::block_retry,
                  const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
+                 const std::function<void()>& worker_teardown_cb = nullptr);
 
     async_logger(const std::string& logger_name,
                  sinks_init_list sinks,
                  size_t queue_size,
                  const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
                  const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
+                 const std::function<void()>& worker_teardown_cb = nullptr);
 
     async_logger(const std::string& logger_name,
                  sink_ptr single_sink,
                  size_t queue_size,
                  const async_overflow_policy overflow_policy =  async_overflow_policy::block_retry,
                  const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
+                 const std::function<void()>& worker_teardown_cb = nullptr);
 
 
     void flush() override;
@@ -71,4 +74,3 @@ private:
 
 
 #include <spdlog/details/async_logger_impl.h>
-

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -23,9 +23,10 @@ inline spdlog::async_logger::async_logger(const std::string& logger_name,
         size_t queue_size,
         const  async_overflow_policy overflow_policy,
         const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms) :
+        const std::chrono::milliseconds& flush_interval_ms,
+        const std::function<void()>& worker_teardown_cb) :
     logger(logger_name, begin, end),
-    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms))
+    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb))
 {
 }
 
@@ -34,19 +35,21 @@ inline spdlog::async_logger::async_logger(const std::string& logger_name,
         size_t queue_size,
         const  async_overflow_policy overflow_policy,
         const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms) :
-    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms) {}
+        const std::chrono::milliseconds& flush_interval_ms,
+        const std::function<void()>& worker_teardown_cb) :
+    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb) {}
 
 inline spdlog::async_logger::async_logger(const std::string& logger_name,
         sink_ptr single_sink,
         size_t queue_size,
         const  async_overflow_policy overflow_policy,
         const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms) :
+        const std::chrono::milliseconds& flush_interval_ms,
+        const std::function<void()>& worker_teardown_cb) :
     async_logger(logger_name,
 {
     single_sink
-}, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms) {}
+      }, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb) {}
 
 
 inline void spdlog::async_logger::flush()

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -132,9 +132,9 @@ inline void spdlog::set_level(level::level_enum log_level)
 }
 
 
-inline void spdlog::set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb, const std::chrono::milliseconds& flush_interval_ms)
+inline void spdlog::set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb, const std::chrono::milliseconds& flush_interval_ms, const std::function<void()>& worker_teardown_cb)
 {
-    details::registry::instance().set_async_mode(queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms);
+    details::registry::instance().set_async_mode(queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb);
 }
 
 inline void spdlog::set_sync_mode()
@@ -146,4 +146,3 @@ inline void spdlog::drop_all()
 {
     details::registry::instance().drop_all();
 }
-

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -53,7 +53,10 @@ void set_level(level::level_enum log_level);
 // worker_warmup_cb (optional):
 //     callback function that will be called in worker thread upon start (can be used to init stuff like thread affinity)
 //
-void set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy = async_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr, const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
+// worker_teardown_cb (optional):
+//     callback function that will be called in worker thread upon exit
+//
+void set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy = async_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr, const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(), const std::function<void()>& worker_teardown_cb = nullptr);
 
 // Turn off async mode
 void set_sync_mode();


### PR DESCRIPTION
Hello Gabime,

I need to write a customized sink that invokes a JNI callback. As you may know, such calls require that running thread was previously attached to JVM.
This is fine, and I can use warmup callback to attach it.
However, it's also required to detach thread from JVM upon its exit. That's why I'm suggesting adding a new teardown callback that would be invoked before worker thread exit.

Please let me know what you think about this new feature.

Have a good day !