### PR TITLE
Fix throwing exception if DYNAMIC_TIME_ZONE_INFORMATION fails

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -209,7 +209,7 @@ inline int utc_minutes_offset(const std::tm& tm = details::os::localtime())
     auto rv = GetDynamicTimeZoneInformation(&tzinfo);
 #endif
     if (rv == TIME_ZONE_ID_INVALID)
-        throw spdlog::spdlog_ex("Failed getting timezone info. Last error: " + GetLastError());
+        throw spdlog::spdlog_ex("Failed getting timezone info. Last error: " + std::to_string(GetLastError()));
 
     int offset = -tzinfo.Bias;
     if (tm.tm_isdst)


### PR DESCRIPTION
under windows.