### PR TITLE
Add custom format strings to pattern_formatter

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -55,6 +55,10 @@ int main(int, char*[])
         spd::set_pattern("*** [%H:%M:%S %z] [thread %t] %v ***");
         file_logger->info("This is another message with custom format");
 
+        auto formatter = std::make_shared<spd::pattern_formatter>("%k: %v");
+        formatter->add_customer_formatter('k', [](spd::details::log_msg &msg){ msg.formatted << "Channel 1"; });
+        file_logger->set_formatter(formatter);
+        file_logger->info("This is another message with another custom format using a custom flag");
 
         // Compile time debug or trace macros.
         // Enabled #ifdef SPDLOG_DEBUG_ON or #ifdef SPDLOG_TRACE_ON

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -10,6 +10,8 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <unordered_map>
+#include <functional>
 
 namespace spdlog
 {
@@ -25,16 +27,20 @@ public:
     virtual void format(details::log_msg& msg) = 0;
 };
 
+typedef std::function<void(details::log_msg& msg)> custom_flag_formatter;
+
 class pattern_formatter : public formatter
 {
-
 public:
     explicit pattern_formatter(const std::string& pattern);
     pattern_formatter(const pattern_formatter&) = delete;
     pattern_formatter& operator=(const pattern_formatter&) = delete;
     void format(details::log_msg& msg) override;
+    void add_customer_formatter(char sig, custom_flag_formatter formatter);
+
 private:
     const std::string _pattern;
+    std::unordered_map<char, custom_flag_formatter> _custom_formatters;
     std::vector<std::unique_ptr<details::flag_formatter>> _formatters;
     void handle_flag(char flag);
     void compile_pattern(const std::string& pattern);


### PR DESCRIPTION
I need custom logging attributes and this method seemed easiest. Thought you might want it back. 