### PR TITLE
Header tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
+option(SPDLOG_BUILD_TESTS "Build tests" OFF)
 
 target_include_directories(
     spdlog
@@ -20,9 +21,15 @@ target_include_directories(
     "$<INSTALL_INTERFACE:include>"
 )
 
+set(HEADER_BASE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+include(CTest)
 if(SPDLOG_BUILD_EXAMPLES)
-  enable_testing()
-  add_subdirectory(example)
+    add_subdirectory(example)
+endif()
+
+if(SPDLOG_BUILD_TESTS)
+    add_subdirectory(tests)
 endif()
 
 ### Install ###

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
 
 #include <cstdio>
 #include <memory>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Tests
+#
+
+enable_testing()
+
+# Build Catch unit tests
+add_library(catch INTERFACE)
+target_include_directories(catch INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+file(GLOB catch_tests LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+add_executable(catch_tests ${catch_tests})
+target_link_libraries(catch_tests spdlog)
+add_test(NAME catch_tests COMMAND catch_tests)
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
+
+# Ensure headers include their own dependencies
+add_subdirectory(header_dependencies)
+

--- a/tests/header_dependencies/CMakeLists.txt
+++ b/tests/header_dependencies/CMakeLists.txt
@@ -1,0 +1,58 @@
+#
+# Ensure all headers include all dependencies
+#
+
+set(IGNORED_HEADERS "")
+
+set(COMMON_TEST_LIBRARIES spdlog)
+
+add_custom_target(header_dependencies)
+
+file(GLOB_RECURSE headers RELATIVE "${HEADER_BASE}" ${HEADER_BASE}/*.h)
+set(test_index 0)
+foreach(HEADER ${headers})
+    # Sample of relevant variables computed here
+    # HEADER: details/line_logger_impl.h
+    # symbolname: spdlog_details_line_logger_impl
+
+    # Compute symbolname
+    string(REPLACE ".h" "" symbolname "${HEADER}")
+    string(MAKE_C_IDENTIFIER "${symbolname}" symbolname)
+
+    list(FIND IGNORED_HEADERS "${HEADER}" _index)
+    # If we didn't explicitly ignore this and if we built this target
+    if(${_index} EQUAL -1)
+        #message(STATUS "${HEADER}: '${symbolname}'")
+
+        set(extension cpp)
+
+        # Name the test and output file with a number, to dodge Windows path length limits.
+        # Call it header, instead of test, to avoid polluting the 'executable namespace'
+        set(test_name "header_${extension}_${test_index}")
+
+        set(source_file "${CMAKE_CURRENT_SOURCE_DIR}/main.${extension}")
+
+        add_executable(${test_name} "${source_file}")
+        target_compile_definitions(${test_name} PRIVATE HEADER_TO_TEST="${HEADER}")
+        target_include_directories(${test_name}
+            PRIVATE
+            ${BUILDTREE_HEADER_BASE}
+            ${HEADER_BASE})
+
+        set_target_properties(${test_name} PROPERTIES
+            FOLDER "Header dependency tests")
+
+        target_link_libraries(${test_name}
+            PRIVATE
+            ${COMMON_TEST_LIBRARIES}
+            ${LIBRARIES_${symbolname}}
+            ${LIBRARIES_${libname}})
+
+        add_test(NAME ${test_name}_builds COMMAND ${test_name})
+        add_dependencies(header_dependencies ${test_name})
+
+        math(EXPR test_index "${test_index} + 1")
+    endif()
+endforeach()
+
+

--- a/tests/header_dependencies/main.c
+++ b/tests/header_dependencies/main.c
@@ -1,0 +1,7 @@
+
+#include HEADER_TO_TEST
+
+int main(int argc, char** argv)
+{
+    return 0;
+}

--- a/tests/header_dependencies/main.cpp
+++ b/tests/header_dependencies/main.cpp
@@ -1,0 +1,4 @@
+
+#include HEADER_TO_TEST
+
+int main(int argc, char *argv[]) { return 0; }


### PR DESCRIPTION
* Added `SPDLOG_BUILD_TESTS` build option. CMake can now build the tests found in the `tests/` subdirectory. You may also run the tests using `make test`.
* Added a test that automatically compiles each spdlog header in isolation to ensure it isn't missing any dependencies (missing `#include` directives). This test is enabled with the `SPDLOG_BUILD_TESTS` option.
* Fixed a bug discovered by the new header dependency tests.

**Example usage:**
```
$ git clone --recursive https://github.com/gabime/spdlog.git
$ cd spdlog
$ mkdir build
$ cd build
$ cmake .. -DSPDLOG_BUILD_TESTS=1
$ make test
```
