### PR TITLE
Allow custom error handling to avoid exceptions

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -13,6 +13,7 @@
 
 void async_example();
 void syslog_example();
+void test_custom_error_handler();
 
 namespace spd = spdlog;
 int main(int, char*[])
@@ -68,6 +69,7 @@ int main(int, char*[])
         // syslog example. linux/osx only..
         syslog_example();
 
+        test_custom_error_handler();
 
         // Release and close all loggers
         spdlog::drop_all();
@@ -99,6 +101,31 @@ void syslog_example()
     auto syslog_logger = spd::syslog_logger("syslog", ident, LOG_PID);
     syslog_logger->warn("This is warning that will end up in syslog. This is Linux only!");
 #endif
+}
+
+// Example of user-provided error handler
+void test_custom_error_handler()
+{
+    // Trigger default error handler
+    try {
+        spd::error("test default error handler (throw an exception)");
+    } catch (const spd::spdlog_ex& e) {
+        std::cerr << "caught spdlog_ex: " << e.what() << std::endl;
+    }
+
+    // Set custom error handler
+    spd::set_error_handler(
+        [](const std::string& message) {
+            std::cerr << "SPDLOG ERROR " << message << std::endl;
+        }
+    );
+
+    // Trigger custom error handler
+    try {
+        spd::error("test custom error handler");
+    } catch (const spd::spdlog_ex& e) {
+        std::cerr << "caught spdlog_ex: " << e.what() << std::endl;
+    }
 }
 
 

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -12,7 +12,7 @@
 // Upon each log write the logger:
 //    1. Checks if its log level is enough to log the message
 //    2. Push a new copy of the message to a queue (or block the caller until space is available in the queue)
-//    3. will throw spdlog_ex upon log exceptions
+//    3. will call error handler upon log exceptions (which, by default, will throw spdlog_ex exception)
 // Upon destruction, logs all remaining messages in the queue before destructing..
 
 #include <spdlog/common.h>

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -15,6 +15,7 @@
 #include <codecvt>
 #include <locale>
 #endif
+#include <functional>
 
 #include <spdlog/details/null_mutex.h>
 
@@ -106,6 +107,32 @@ private:
     std::string _msg;
 
 };
+
+// Function pointer to error handler. Defaults to throwing a spdlog_ex
+// exception. May be overridden by the user with set_error_handler().
+static std::function<void(const std::string&)> error_handler = [](const std::string& message) {
+    throw spdlog_ex(message);
+};
+
+// Call the user-provided error handler  when an internal spdlog error occurs.
+inline void error(const std::string& message)
+{
+    error_handler(message);
+}
+
+// Set an error handler to be called in case of errors during logging (e.g.,
+// can't write to file because the disk is full). Defaults to an error handler
+// which logs the errors to the console.
+//
+// Function must have the following signature (but can be named whatever you
+// like):
+//
+//   void error_handler(const std::string &message);
+//
+inline void set_error_handler(std::function<void(const std::string&)> func)
+{
+    error_handler = func;
+}
 
 //
 // wchar support for windows file names (SPDLOG_WCHAR_FILENAMES must be defined)

--- a/include/spdlog/details/line_logger_impl.h
+++ b/include/spdlog/details/line_logger_impl.h
@@ -70,7 +70,7 @@ inline void spdlog::details::line_logger::write(const char* fmt, const Args&... 
     }
     catch (const fmt::FormatError& e)
     {
-        throw spdlog_ex(fmt::format("formatting error while processing format string '{}': {}", fmt, e.what()));
+        error(fmt::format("formatting error while processing format string '{}': {}", fmt, e.what()));
     }
 }
 

--- a/include/spdlog/details/mpmc_bounded_q.h
+++ b/include/spdlog/details/mpmc_bounded_q.h
@@ -64,8 +64,11 @@ public:
           buffer_mask_(buffer_size - 1)
     {
         //queue size must be power of two
-        if(!((buffer_size >= 2) && ((buffer_size & (buffer_size - 1)) == 0)))
+        if(!((buffer_size >= 2) && ((buffer_size & (buffer_size - 1)) == 0))) {
+            // FIXME: call error() instead
+            // FIXME: can we just round buffer_size down to the next power of two and skip the error altogether?
             throw spdlog_ex("async logger queue size must be power of two");
+        }
 
         for (size_t i = 0; i != buffer_size; i += 1)
             buffer_[i].sequence_.store(i, std::memory_order_relaxed);

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -198,8 +198,10 @@ inline int utc_minutes_offset(const std::tm& tm = details::os::localtime())
     DYNAMIC_TIME_ZONE_INFORMATION tzinfo;
     auto rv = GetDynamicTimeZoneInformation(&tzinfo);
 #endif
-    if (rv == TIME_ZONE_ID_INVALID)
-        throw spdlog::spdlog_ex("Failed getting timezone info. Last error: " + std::to_string(GetLastError()));
+    if (rv == TIME_ZONE_ID_INVALID) {
+        error("Failed getting timezone info. Last error: " + std::to_string(GetLastError()));
+        return 0;
+    }
 
     int offset = -tzinfo.Bias;
     if (tm.tm_isdst)

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -9,6 +9,7 @@
 #include <spdlog/details/log_msg.h>
 #include <spdlog/details/os.h>
 #include <spdlog/details/format.h>
+#include <spdlog/common.h>
 
 #include <chrono>
 #include <ctime>
@@ -623,6 +624,6 @@ inline void spdlog::pattern_formatter::format(details::log_msg& msg)
     }
     catch(const fmt::FormatError& e)
     {
-        throw spdlog_ex(fmt::format("formatting error while processing format string: {}", e.what()));
+        error(fmt::format("formatting error while processing format string: {}", e.what()));
     }
 }

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -146,3 +146,4 @@ inline void spdlog::drop_all()
 {
     details::registry::instance().drop_all();
 }
+

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -9,6 +9,7 @@
 
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/details/null_mutex.h>
+#include <spdlog/common.h>
 
 #include <android/log.h>
 
@@ -48,7 +49,7 @@ protected:
         }
         else
         {
-            throw spdlog_ex("Send to Android logcat failed");
+            error("Send to Android logcat failed");
         }
     }
 
@@ -76,7 +77,8 @@ private:
         case spdlog::level::emerg:
             return ANDROID_LOG_FATAL;
         default:
-            throw spdlog_ex("Incorrect level value");
+            error("Incorrect level value");
+            return ANDROID_LOG_INFO;
         }
     }
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -112,7 +112,6 @@ void drop(const std::string &name);
 // Drop all references
 void drop_all();
 
-
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Macros to be display source file & line


### PR DESCRIPTION
**Please see PR #231 instead.** This PR targets the wrong branch.

This PR addresses issue #136 by adding the ability to replace the default error handling (i.e., throwing a `spdlog_ex` exception) with a custom error handler (e.g., one that prints the error to `STDERR`).

 * All instances of `throw spdlog_ex` have been replaced with a call to the new `spdlog::error()` function (with one exception—see Further Work below).
 * The `spdlog::error()` function takes a `std::string` argument and passes it along to the error handler.
 * The default error handler simple throws a `spdlog_ex` exception containing the string as the message.
 * The user may provide their own error handler with the following signature: `void my_error_handler(const std::string& message)`. An example error handler may simply print the message to `STDERR`.

## Further Work

 * The `mpmc_bounded_queue` constructor in the `details/mpmc_bounded_q.h` file still throws an exception because I wasn't sure how best to avoid it. If `buffer_size` isn't a power of two, can we round it down to the nearest power of two and avoid the error entirely?
 * Check to see where `fmt` may throw exceptions and ensure we catch them and pass through through the new error handler instead of allowing them to propagate up the stack.
 * Since the error handler may not throw an exception and interrupt the program flow, the library developers must assume that flow will continue after the error handler has been called. Therefore, they should take the appropriate action (e.g., return early, fall back on a sane default value). If there is no way to avoid throwing an exception, then the caller should wrap the function with a `try`...`catch` block to prevent the exception from propagating and call the error handler instead.
