### PR TITLE
Async task queue

### DIFF
--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -58,7 +58,6 @@ class async_log_helper
         async_msg() = default;
         ~async_msg() = default;
 
-
         async_msg(async_msg&& other) SPDLOG_NOEXCEPT:
             logger_name(std::move(other.logger_name)),
             level(std::move(other.level)),
@@ -81,7 +80,6 @@ class async_log_helper
             return *this;
         }
 
-        // never copy or assign. should only be moved..
         async_msg(const async_msg&) = default;
         async_msg& operator=(async_msg& other) = default;
 


### PR DESCRIPTION
Hi,

accidentally and for reasons I completely ignore, I might have improved the speed to the asyn_logger.

I modified the lock free queue. Instead of an `async_msg`, it now contains a `std::function<void()>` that works as a "packaged task" that executes the method equivalent to `process_next_msg`.

These changes are needed to implement a thread pool (https://github.com/gabime/spdlog/issues/275), but when I executed the unit tests and benchmark, I realized that the outpout is (apparently) the same but the speed of async is considerably higher... on my computer!


