### PR TITLE
Fix compilation on Android.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Auto generated files 
+# Auto generated files
 *.slo
 *.lo
 *.o
@@ -46,6 +46,7 @@ example/*
 !example/example.vcxproj
 !example/CMakeLists.txt
 !example/multisink.cpp
+!example/jni
 
 # generated files
 generated

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -13,6 +13,7 @@
 
 void async_example();
 void syslog_example();
+void android_example();
 void user_defined_example();
 void err_handler_example();
 
@@ -48,7 +49,6 @@ int main(int, char*[])
         auto my_logger = spd::basic_logger_mt("basic_logger", "logs/basic.txt");
         my_logger->info("Some log message");
 
-
         // Create a file rotating logger with 5mb size max and 3 rotated files
         auto rotating_logger = spd::rotating_logger_mt("some_logger_name", "logs/mylogfile", 1048576 * 5, 3);
         for (int i = 0; i < 10; ++i)
@@ -75,6 +75,9 @@ int main(int, char*[])
 
         // syslog example. linux/osx only
         syslog_example();
+
+        // android example. compile with NDK
+        android_example();
 
         // Log user-defined types example
         user_defined_example();
@@ -119,6 +122,16 @@ void syslog_example()
 #endif
 }
 
+// Android example
+void android_example()
+{
+#if defined(__ANDROID__)
+    std::string tag = "spdlog-android";
+    auto android_logger = spd::android_logger("android", tag);
+    android_logger->critical("Use \"adb shell logcat\" to view this message.");
+#endif
+}
+
 // user defined types logging by implementing operator<<
 struct my_type
 {
@@ -148,4 +161,3 @@ void err_handler_example()
     });
     spd::get("console")->info("some invalid message to trigger an error {}{}{}{}", 3);
 }
-

--- a/example/jni/Android.mk
+++ b/example/jni/Android.mk
@@ -1,0 +1,15 @@
+# Setup a project
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := example
+LOCAL_SRC_FILES := example.cpp
+LOCAL_CPPFLAGS += -Wall -Wshadow -Wextra -pedantic -std=c++11 -fPIE -pie
+LOCAL_LDFLAGS +=  -fPIE -pie
+
+# Add exception support and set path for spdlog's headers
+LOCAL_CPPFLAGS += -fexceptions -I../include
+# Use android's log library
+LOCAL_LDFLAGS += -llog
+
+include $(BUILD_EXECUTABLE)

--- a/example/jni/Application.mk
+++ b/example/jni/Application.mk
@@ -1,0 +1,2 @@
+# Exceptions are used in spdlog. Link to an exception-ready C++ runtime.
+APP_STL = gnustl_static

--- a/example/jni/example.cpp
+++ b/example/jni/example.cpp
@@ -1,0 +1,1 @@
+../example.cpp

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -342,7 +342,9 @@ inline std::string errno_str(int err_num)
     else
         return "Unkown error";
 
-#elif defined(__FreeBSD__) || defined(__APPLE__) || ((_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE) // posix version
+#elif defined(__FreeBSD__) || defined(__APPLE__) || defined(ANDROID) || \
+      ((_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE) // posix version
+
     if (strerror_r(err_num, buf, buf_size) == 0)
         return std::string(buf);
     else
@@ -356,5 +358,3 @@ inline std::string errno_str(int err_num)
 } //os
 } //details
 } //spdlog
-
-

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -14,6 +14,7 @@
 #include <spdlog/sinks/stdout_sinks.h>
 #include <spdlog/sinks/syslog_sink.h>
 #include <spdlog/sinks/ansicolor_sink.h>
+#include <spdlog/sinks/android_sink.h>
 
 #include <chrono>
 #include <functional>
@@ -101,6 +102,13 @@ inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const std::strin
 inline std::shared_ptr<spdlog::logger> spdlog::syslog_logger(const std::string& logger_name, const std::string& syslog_ident, int syslog_option)
 {
     return create<spdlog::sinks::syslog_sink>(logger_name, syslog_ident, syslog_option);
+}
+#endif
+
+#if defined(__ANDROID__)
+inline std::shared_ptr<spdlog::logger> spdlog::android_logger(const std::string& logger_name, const std::string& tag)
+{
+  return create<spdlog::sinks::android_sink>(logger_name, tag);
 }
 #endif
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -101,6 +101,9 @@ std::shared_ptr<logger> stderr_logger_st(const std::string& logger_name, bool co
 std::shared_ptr<logger> syslog_logger(const std::string& logger_name, const std::string& ident = "", int syslog_option = 0);
 #endif
 
+#if defined(__ANDROID__)
+std::shared_ptr<logger> android_logger(const std::string& logger_name, const std::string& tag = "spdlog");
+#endif
 
 // Create and register a logger a single sink
 std::shared_ptr<logger> create(const std::string& logger_name, const sink_ptr& sink);


### PR DESCRIPTION
2 errors will occur during `ndk-build`, in the original version.

```
In file included from spdlog/include/spdlog/details/log_msg.h:9:0,
                 from spdlog/include/spdlog/sinks/sink.h:9,
                 from spdlog/include/spdlog/sinks/base_sink.h:13,
                 from spdlog/include/spdlog/logger.h:15,
                 from spdlog/include/spdlog/spdlog.h:13,
spdlog/include/spdlog/details/os.h: In function 'std::string spdlog::details::os::errno_str(int)':
spdlog/include/spdlog/details/os.h:352:57: error: invalid conversion from 'int' to 'const char*' [-fpermissive]
     return std::string(strerror_r(err_num, buf, buf_size));
```

```
spdlog/include/spdlog/fmt/bundled/format.h:3263: error: undefined reference to 'localeconv'
```

The pull request fixes the errors above.