### PR TITLE
New approach to async: use thread pool to consume the queues.

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -15,6 +15,7 @@
 //    3. will throw spdlog_ex upon log exceptions
 // Upon destruction, logs all remaining messages in the queue before destructing..
 
+#include <spdlog/details/thread_pool.h>
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 
@@ -39,26 +40,23 @@ public:
                  const It& begin,
                  const It& end,
                  size_t queue_size,
+                 details::thread_pool* th_pool,
                  const async_overflow_policy overflow_policy =  async_overflow_policy::block_retry,
-                 const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
-                 const std::function<void()>& worker_teardown_cb = nullptr);
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
 
     async_logger(const std::string& logger_name,
                  sinks_init_list sinks,
                  size_t queue_size,
+                 details::thread_pool* th_pool,
                  const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
-                 const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
-                 const std::function<void()>& worker_teardown_cb = nullptr);
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
 
     async_logger(const std::string& logger_name,
                  sink_ptr single_sink,
                  size_t queue_size,
+                 details::thread_pool* th_pool,
                  const async_overflow_policy overflow_policy =  async_overflow_policy::block_retry,
-                 const std::function<void()>& worker_warmup_cb = nullptr,
-                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
-                 const std::function<void()>& worker_teardown_cb = nullptr);
+                 const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero());
 
     //Wait for the queue to be empty, and flush synchronously
     //Warning: this can potentialy last forever as we wait it to complete

--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -204,7 +204,7 @@ inline spdlog::details::async_log_helper::async_log_helper(
     _terminated(false),
     _overflow_policy(overflow_policy),
     _flush_interval_ms(flush_interval_ms),
-    _thread_loop_handle( new Func( [this](){ return this->process_next_msg();} ) )
+    _thread_loop_handle( new Func( [this](){ return this->worker_loop();} ) )
 {
     th_pool->subscribe_handle(_thread_loop_handle);
 }
@@ -270,7 +270,7 @@ inline bool spdlog::details::async_log_helper::worker_loop()
     {
         _err_handler("Unknown exception");
     }
-    return true;
+    return false;
 }
 
 // process next message in the queue

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -16,40 +16,36 @@
 #include <chrono>
 #include <memory>
 
+
 template<class It>
 inline spdlog::async_logger::async_logger(const std::string& logger_name,
         const It& begin,
         const It& end,
         size_t queue_size,
+        details::thread_pool* th_pool,
         const  async_overflow_policy overflow_policy,
-        const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms,
-        const std::function<void()>& worker_teardown_cb) :
+        const std::chrono::milliseconds& flush_interval_ms ) :
     logger(logger_name, begin, end),
-    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, _err_handler, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb))
+    _async_log_helper(new details::async_log_helper(_formatter, _sinks, queue_size, _err_handler,
+                                                     th_pool, overflow_policy, flush_interval_ms))
 {
 }
 
 inline spdlog::async_logger::async_logger(const std::string& logger_name,
         sinks_init_list sinks,
         size_t queue_size,
+        details::thread_pool* th_pool,
         const  async_overflow_policy overflow_policy,
-        const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms,
-        const std::function<void()>& worker_teardown_cb) :
-    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb) {}
+        const std::chrono::milliseconds& flush_interval_ms) :
+    async_logger(logger_name, sinks.begin(), sinks.end(), queue_size, th_pool, overflow_policy, flush_interval_ms) {}
 
 inline spdlog::async_logger::async_logger(const std::string& logger_name,
         sink_ptr single_sink,
         size_t queue_size,
+        details::thread_pool* th_pool,
         const  async_overflow_policy overflow_policy,
-        const std::function<void()>& worker_warmup_cb,
-        const std::chrono::milliseconds& flush_interval_ms,
-        const std::function<void()>& worker_teardown_cb) :
-    async_logger(logger_name,
-{
-    single_sink
-}, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb) {}
+        const std::chrono::milliseconds& flush_interval_ms) :
+    async_logger(logger_name,{ single_sink }, queue_size,th_pool, overflow_policy, flush_interval_ms) {}
 
 
 inline void spdlog::async_logger::flush()

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -153,9 +153,18 @@ inline void spdlog::set_error_handler(log_err_handler handler)
 }
 
 
-inline void spdlog::set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy, const std::function<void()>& worker_warmup_cb, const std::chrono::milliseconds& flush_interval_ms, const std::function<void()>& worker_teardown_cb)
+inline void spdlog::set_async_mode(size_t queue_size,
+                                   const async_overflow_policy overflow_policy,
+                                   const std::function<void()>& worker_warmup_cb,
+                                   const std::chrono::milliseconds& flush_interval_ms,
+                                   const std::function<void()>& worker_teardown_cb,
+                                   size_t num_thread_in_pool)
 {
-    details::registry::instance().set_async_mode(queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb);
+    assert( num_thread_in_pool>=1 );
+
+    details::registry::instance().set_async_mode(
+                queue_size,num_thread_in_pool,
+                overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb);
 }
 
 inline void spdlog::set_sync_mode()

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -36,8 +36,7 @@ private:
     // the task queue
 
 
-    std::deque< weak_function_ptr > _loop_handles;
-    std::deque< bool > _busy;
+    std::deque<std::pair<bool, weak_function_ptr> > _loop_handles;
 
     // synchronization
     std::mutex _mutex;
@@ -70,54 +69,56 @@ inline thread_pool::thread_pool(size_t num_threads,
             if( _worker_warmup_cb) _worker_warmup_cb();
             while( !_stop)
             {
+
+                shared_function_ptr handle;
+                auto handle_it = _loop_handles.begin();
+                bool is_busy = false;
+
+                // find an handle
                 {
-                    shared_function_ptr handle;
-                    size_t index = 0;
-                    bool is_busy = false;
+                    std::unique_lock<std::mutex> lock(_mutex);
 
-                    // find an handle
+                    // scan the _loop_handles to find an available one.
+                    for (size_t count=0; count<_loop_handles.size(); count++)
                     {
-                        std::unique_lock<std::mutex> lock(_mutex);
+                        _index  = (_index+1) % _loop_handles.size();
+                        handle_it = _loop_handles.begin() + _index;
 
-                        // scan the _loop_handles to find an available one.
-                        for (size_t count=0; count<_loop_handles.size(); count++)
-                        {
-                            _index  = (_index+1) % _loop_handles.size();
-                            handle  = _loop_handles[index].lock();
-                            is_busy = _busy[index];
+                        is_busy = handle_it->first;
+                        handle  =  handle_it->second.lock();
 
-                            // if the weak pointer points to a delated handle, remove it
-                            if(!handle ){
-                                _loop_handles.erase( _loop_handles.begin() + index);
-                                _busy.erase ( _busy.begin()  + index);
-                                _index  = (_index) % _loop_handles.size();
-                            }
-                            else{
-                                _busy[index] = true;
-                            }
-                            if( handle && !is_busy) break;
-                        }
-                    }
-
-                    if(handle && !is_busy)
-                    {
-                        bool continue_loop = (*handle)();
-                        if(!continue_loop){
-                            _loop_handles.erase( _loop_handles.begin() + index);
-                            _busy.erase ( _busy.begin()  + index);
+                        // if the weak pointer points to a delated handle, remove it
+                        if(!handle ){
+                            _loop_handles.erase(handle_it);
+                            _index  = (_index) % _loop_handles.size();
                         }
                         else{
-                                std::unique_lock<std::mutex> lock(_mutex);
-                                _busy[index] = false;
+                            // mark as busy
+                            handle_it->first = true;
                         }
-                        // not busy anymore. notify to other threads
-                        _condition.notify_one();
+                        if( handle && !is_busy ) break;
+                    }
+                }
+
+                if(handle && !is_busy)
+                {
+                    bool continue_loop = (*handle)();
+                    if(!continue_loop){
+                        std::unique_lock<std::mutex> lock(_mutex);
+                        handle_it->first = false;
+                        _loop_handles.erase(handle_it);
                     }
                     else{
-                        // this happens when you didn't find an handle that is not busy
                         std::unique_lock<std::mutex> lock(_mutex);
-                        _condition.wait(lock);
+                        handle_it->first = false;
                     }
+                    // not busy anymore. notify to other threads
+                    _condition.notify_one();
+                }
+                else{
+                    // this happens when you didn't find an handle that is not busy
+                    std::unique_lock<std::mutex> lock(_mutex);
+                    _condition.wait(lock);
                 }
             }
             if( _worker_teardown_cb) _worker_teardown_cb();
@@ -129,8 +130,7 @@ inline void thread_pool::subscribe_handle(const shared_function_ptr &loop_handle
 {
     {
         std::unique_lock<std::mutex> lock(_mutex);
-        _loop_handles.push_back( loop_handle );
-        _busy.push_back( false );
+        _loop_handles.push_back( std::make_pair(false, weak_function_ptr(loop_handle)) );
     }
     _condition.notify_one();
 }

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -1,0 +1,148 @@
+#ifndef THREAD_POOL_H
+#define THREAD_POOL_H
+
+#include <vector>
+#include <deque>
+#include <memory>
+#include <thread>
+#include <mutex>
+#include <future>
+#include <functional>
+#include <stdexcept>
+#include <assert.h>
+
+
+typedef std::function<bool(void)> Func;
+typedef std::shared_ptr<Func> shared_function_ptr;
+typedef std::weak_ptr<Func> weak_function_ptr;
+
+namespace spdlog
+{
+namespace details
+{
+
+class thread_pool {
+public:
+    thread_pool(size_t num_threads,
+               const std::function<void()>& worker_warmup_cb = nullptr,
+               const std::function<void()>& worker_teardown_cb = nullptr);
+
+    void subscribe_handle(const shared_function_ptr& loop_handle );
+
+    ~thread_pool();
+private:
+    // need to keep track of threads so we can join them
+    std::vector< std::thread > _workers;
+    // the task queue
+
+
+    std::deque< weak_function_ptr > _loop_handles;
+    std::deque< bool > _busy;
+
+    // synchronization
+    std::mutex _mutex;
+
+    std::function<void()> _worker_warmup_cb;
+
+    std::function<void()> _worker_teardown_cb;
+
+    size_t _index;
+
+    bool _stop;
+};
+
+// the constructor just launches some amount of workers
+inline thread_pool::thread_pool(size_t num_threads,
+                              const std::function<void()>& worker_warmup_cb,
+                              const std::function<void()>& worker_teardown_cb):
+    _worker_warmup_cb(worker_warmup_cb),
+    _worker_teardown_cb(worker_teardown_cb),
+    _index(0),
+    _stop(false)
+{
+    assert(num_threads > 0);
+
+    for(size_t i = 0;i<num_threads;++i)
+        _workers.emplace_back( [this]()
+        {
+            if( _worker_warmup_cb) _worker_warmup_cb();
+            while( !_stop)
+            {
+                if(  _loop_handles.empty()){
+                    std::this_thread::sleep_for( std::chrono::microseconds(100) );
+                }
+                else
+                {
+                    shared_function_ptr loop;
+                    size_t index = 0;
+                    bool busy = false;
+
+                    {
+                        std::unique_lock<std::mutex> lock(_mutex);
+
+                        // scan the _loop_handles to find an available one.
+                        for (size_t count=0; count<_loop_handles.size(); count++)
+                        {
+                            _index = (_index+1) % _loop_handles.size();
+                            loop = _loop_handles[index].lock();
+                            busy = _busy[index];
+
+                            // if the weak pointer points to a delated handle, remove it
+                            if(!loop ){
+                                _loop_handles.erase( _loop_handles.begin() + index);
+                                _busy.erase ( _busy.begin()  + index);
+                            }
+                            else{
+                                _busy[index] = true;
+                            }
+                            if( loop && !busy) break;
+                        }
+                    }
+
+                    if(loop && !busy)
+                    {
+                        bool continue_loop = (*loop)();
+                        if(!continue_loop){
+                            _loop_handles.erase( _loop_handles.begin() + index);
+                            _busy.erase ( _busy.begin()  + index);
+                        }
+                        else{
+                            std::unique_lock<std::mutex> lock(_mutex);
+                            _busy[index] = false;
+                        }
+                    }
+                    else{
+                        // this happens if we haven't find any handle that needs our work
+                        std::this_thread::sleep_for( std::chrono::milliseconds(1) );
+                    }
+                }
+            }
+            if( _worker_teardown_cb) _worker_teardown_cb();
+        }
+        );
+}
+
+inline void thread_pool::subscribe_handle(const shared_function_ptr &loop_handle)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _loop_handles.push_back( loop_handle );
+    _busy.push_back( false );
+    assert( _loop_handles.size() == 1);
+}
+
+
+// the destructor joins all threads
+inline thread_pool::~thread_pool()
+{
+    {
+        std::unique_lock<std::mutex> lock(_mutex);
+        _stop = true;
+    }
+    for(std::thread &worker: _workers)
+        worker.join();
+}
+
+}
+}
+#endif
+

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -90,7 +90,8 @@ inline thread_pool::thread_pool(size_t num_threads,
                         // if the weak pointer points to a delated handle, remove it
                         if(!handle ){
                             _loop_handles.erase(handle_it);
-                            _index  = (_index) % _loop_handles.size();
+                            if(  _loop_handles.empty() ==false)
+                                _index  = (_index) % _loop_handles.size();
                         }
                         else{
                             // mark as busy

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -60,7 +60,12 @@ void set_error_handler(log_err_handler);
 // worker_teardown_cb (optional):
 //     callback function that will be called in worker thread upon exit
 //
-void set_async_mode(size_t queue_size, const async_overflow_policy overflow_policy = async_overflow_policy::block_retry, const std::function<void()>& worker_warmup_cb = nullptr, const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(), const std::function<void()>& worker_teardown_cb = nullptr);
+void set_async_mode(size_t queue_size,
+                    const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
+                    const std::function<void()>& worker_warmup_cb = nullptr,
+                    const std::chrono::milliseconds& flush_interval_ms = std::chrono::milliseconds::zero(),
+                    const std::function<void()>& worker_teardown_cb = nullptr,
+                    size_t num_thread_in_pool = 1);
 
 // Turn off async mode
 void set_sync_mode();


### PR DESCRIPTION
Hi,

this is a PR related to https://github.com/gabime/spdlog/issues/275

The new implementation use a **thread pool** with 1 or more threads to serve ALL the `async_loggers` in the process.

There is still a single queue for each logger; error handling, flush and push should work as usual.
All the unit tests pass and the benchmark has the same throughput as before.

The way the thread_pool consumes the messages in the queue(s) is a bit counter-intuitive, but is necessary if we don't want to modify the semantic of `flush()` and queue_size.

1) Each `async_logger` passes function pointer (called further "handle") pointing to **`spdlog::details::async_log_helper::worker_loop()`** to the pool. By the way, that method is not a loop anymore. 
2) using **std::weak_ptr**, the pool is able to disconnect automatically the handle of any destroyed instance of `async_log_helper`.
3) The workers cycle through the available handles (one per async_logger) to find one that needs to be served.

It is quite a large change and I am not 100% sure that you want to accept this PR without any further modification. The user facing APi and the expected behaviour should be the same, though.
