### PR TITLE
New log function to enable wrappers with local filters

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -344,7 +344,7 @@ inline std::string errno_str(int err_num)
         return "Unkown error";
 
 #elif defined(__FreeBSD__) || defined(__APPLE__) || defined(ANDROID) || \
-      ((_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE) // posix version
+      ((_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE) || !defined(__GLIBC__) // posix version
 
     if (strerror_r(err_num, buf, buf_size) == 0)
         return std::string(buf);

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -37,6 +37,8 @@ public:
 
     template <typename... Args> void log(level::level_enum lvl, const char* fmt, const Args&... args);
     template <typename... Args> void log(level::level_enum lvl, const char* msg);
+    template <typename... Args> void log_nofilter(level::level_enum lvl, const char* fmt, const Args&... args);
+    template <typename... Args> void log_nofilter(level::level_enum lvl, const char* msg);
     template <typename... Args> void trace(const char* fmt, const Args&... args);
     template <typename... Args> void debug(const char* fmt, const Args&... args);
     template <typename... Args> void info(const char* fmt, const Args&... args);
@@ -45,6 +47,7 @@ public:
     template <typename... Args> void critical(const char* fmt, const Args&... args);
 
     template <typename T> void log(level::level_enum lvl, const T&);
+    template <typename T> void log_nofilter(level::level_enum lvl, const T&);
     template <typename T> void trace(const T&);
     template <typename T> void debug(const T&);
     template <typename T> void info(const T&);


### PR DESCRIPTION
This update is to enable users to write wrappers to spdlog to enable for instance differnt threads to override the default log level, thus enabling a single thread to run with "info" while all other threads use "error".
