### PR TITLE
update os.h to fix filesize() on older win32

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <sys/types.h>
+#include <io.h>
 
 #elif __linux__
 
@@ -204,9 +205,9 @@ inline size_t filesize(FILE *f)
         return st.st_size;
 
 #else //windows 32 bits
-    struct _stat st;
-    if (_fstat(fd, &st) == 0)
-        return st.st_size;
+    long ret = _filelength(fd);
+    if (ret >= 0)
+        return static_cast<size_t>(ret);
 #endif
 
 #else // unix


### PR DESCRIPTION
_fstat() always fails under older 32bit WinXP/Win2003 targets.

_filelength() just works for both WinXP SDK and later Win7+ 32bit targets.