### PR TITLE
Expose logger sinks.

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -291,3 +291,8 @@ inline bool spdlog::logger::_should_flush_on(const details::log_msg &msg)
     const auto flush_level = _flush_level.load(std::memory_order_relaxed);
     return (msg.level >= flush_level) && (msg.level != level::off);
 }
+
+inline std::vector<spdlog::sink_ptr> spdlog::logger::get_sinks() const
+{
+    return _sinks;
+}

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -68,6 +68,9 @@ public:
 
     virtual void flush();
 
+    // expose sinks
+    std::vector<sink_ptr> get_sinks() const;
+
 protected:
     virtual void _sink_it(details::log_msg&);
     virtual void _set_pattern(const std::string&);


### PR DESCRIPTION
A get method seems best for now as opposed to making the vector public.