### PR TITLE
made the opened file handle not inherited by child process on windows

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -25,7 +25,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-
+#include <io.h>
 #ifdef __MINGW32__
 #include <share.h>
 #endif
@@ -147,6 +147,13 @@ inline int fopen_s(FILE** fp, const filename_t& filename, const filename_t& mode
 #else
     *fp = _fsopen((filename.c_str()), mode.c_str(), _SH_DENYWR);
 #endif
+    //don't let the handle be inherited by the child process
+    if (*fp != nullptr) {
+        HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(*fp));
+        if (hFile) {
+            SetHandleInformation(hFile, HANDLE_FLAG_INHERIT, 0);
+        }
+    }
     return *fp == nullptr;
 #else
     *fp = fopen((filename.c_str()), mode.c_str());


### PR DESCRIPTION
hi,
I faced a problem when using CreateProcess to create a child process in windows.  the child process was left untouched after was launched and will not exit.  when i restart my program i maybe not able to open app log because the file handle is held by the child process i create.    so maybe it's better to let the opened log file handle not be inherited by child process.
