### PR TITLE
Windows XP compatibility hack

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -30,6 +30,14 @@
 #include <share.h>
 #endif
 
+#define SPDLOG_SECURE_API
+
+#ifdef __MINGW32__
+#ifndef MINGW_HAS_SECURE_API
+#undef SPDLOG_SECURE_API
+#endif
+#endif
+
 #include <sys/types.h>
 
 #elif __linux__
@@ -333,10 +341,12 @@ inline std::string filename_to_str(const filename_t& filename)
 // Return errno string (thread safe)
 inline std::string errno_str(int err_num)
 {
+#ifdef SPDLOG_SECURE_API
     char buf[256];
     SPDLOG_CONSTEXPR auto buf_size = sizeof(buf);
 
 #ifdef _WIN32
+
     if(strerror_s(buf, buf_size, err_num) == 0)
         return std::string(buf);
     else
@@ -353,8 +363,10 @@ inline std::string errno_str(int err_num)
 #else  // gnu version (might not use the given buf, so its retval pointer must be used)
     return std::string(strerror_r(err_num, buf, buf_size));
 #endif
+#else
+    return std::to_string(err_num);
+#endif    
 }
-
 } //os
 } //details
 } //spdlog


### PR DESCRIPTION
This tries to fix a corner case, it avoids the dreadful `_ecvt_s could not be located` runtime error message when running on old xp machines.
Unfortunately many SMB still run on it.

Thanks
