### PR TITLE
Compatibility with Oracle Developer Studio 12.5 on  Solaris

### DIFF
--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -359,7 +359,7 @@ inline void spdlog::details::async_log_helper::sleep_or_yield(const spdlog::log_
 
     // yield upto 150 micros
     if (time_since_op <= microseconds(100))
-        return yield();
+        return std::this_thread::yield();
 
 
     // sleep for 20 ms upto 200 ms

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -343,7 +343,7 @@ inline std::string errno_str(int err_num)
     else
         return "Unkown error";
 
-#elif defined(__FreeBSD__) || defined(__APPLE__) || defined(ANDROID) || \
+#elif defined(__FreeBSD__) || defined(__APPLE__) || defined(ANDROID) || defined(__SUNPRO_CC) || \
       ((_POSIX_C_SOURCE >= 200112L) && ! _GNU_SOURCE) // posix version
 
     if (strerror_r(err_num, buf, buf_size) == 0)


### PR DESCRIPTION
Oracle Developer Studio 12.5 is fully C++11 capable, and these two changes enabled me to compile and use spdlog in my application. 