### PR TITLE
cmake: misc improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 cmake_minimum_required(VERSION 3.1)
 project(spdlog VERSION 1.0.0)
+include(CTest)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -12,7 +13,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
-option(SPDLOG_BUILD_TESTS "Build tests" OFF)
 
 target_include_directories(
     spdlog
@@ -28,7 +28,7 @@ if(SPDLOG_BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()
 
-if(SPDLOG_BUILD_TESTS)
+if(BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,3 +78,6 @@ install(
     NAMESPACE "${namespace}"
     DESTINATION "${config_install_dir}"
 )
+
+file(GLOB_RECURSE spdlog_include_SRCS "${HEADER_BASE}/*.h")
+add_custom_target(spdlog_headers_for_ide SOURCES ${spdlog_include_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,10 @@ include(CTest)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
+endif()
+
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)


### PR DESCRIPTION
- show list of headers in IDEs
- use a standard option for controlling building of tests
- enable build warnings on GCC and Clang

Feel free to reject any of these and cherry-pick the individual commits if you disagree for some reason.