### PR TITLE
fixed compilation error in clang before version 8

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -315,7 +315,7 @@ inline size_t _thread_id()
 //Return current thread id as size_t (from thread local storage)
 inline size_t thread_id()
 {
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#if defined(_MSC_VER) && (_MSC_VER < 1900) || defined(__clang_major__) && (__clang_major__ < 8)
     return _thread_id();
 #else
     static thread_local const size_t tid = _thread_id();


### PR DESCRIPTION
fixed compilation error in clang before version 8 (does not support thread_local keyword)

`thread_local` keyword just be supported in the Xcode 8 Beta and GM releases. (clang 8)

References:
https://stackoverflow.com/questions/23791060/c-thread-local-storage-clang-503-0-40-mac-osx/37817455#37817455
https://developer.apple.com/videos/play/wwdc2016/405/
http://devstreaming.apple.com/videos/wwdc/2016/405i2ilotov3bazyei1/405/405_whats_new_in_llvm.pdf