### PR TITLE
Use the feature checking macros to detect thread_local support in clang.

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -48,6 +48,10 @@
 
 #endif
 
+#ifndef __has_feature       // Clang - feature checking macros.
+#define __has_feature(x) 0  // Compatibility with non-clang compilers.
+#endif
+
 namespace spdlog
 {
 namespace details
@@ -315,7 +319,7 @@ inline size_t _thread_id()
 //Return current thread id as size_t (from thread local storage)
 inline size_t thread_id()
 {
-#if defined(_MSC_VER) && (_MSC_VER < 1900) || defined(__clang_major__) && (__clang_major__ < 8)
+#if defined(_MSC_VER) && (_MSC_VER < 1900) || defined(__clang__) && !__has_feature(cxx_thread_local)
     return _thread_id();
 #else
     static thread_local const size_t tid = _thread_id();


### PR DESCRIPTION
I have re-examined the clang's official documents.

[http://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros](http://clang.llvm.org/docs/LanguageExtensions.html#builtin-macros)
It told me that, the marketing version numbers should not be used to check for language features, as different vendors use different numbering schemes. Instead, use the [Feature Checking Macros](http://clang.llvm.org/docs/LanguageExtensions.html#langext-feature-check).

[http://clang.llvm.org/docs/LanguageExtensions.html#c-11-thread-local](http://clang.llvm.org/docs/LanguageExtensions.html#c-11-thread-local)
There is a official example to determine if support for thread_local variables.

[http://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension]
(http://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension)
And there is a example to compatibility with non-clang compilers.


Ps: Why the marketing version numbers should not be used to check for language features?
I found a special thing. The llvm-clang official version just updated to 4.0, but the build-in version of Xcode is consistent with Xcode version.