### PR TITLE
Add prefix for BUILD_TESTING cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,12 @@ target_include_directories(
 
 set(HEADER_BASE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
-include(CTest)
 if(SPDLOG_BUILD_EXAMPLES)
     add_subdirectory(example)
 endif()
 
-if(BUILD_TESTING)
+if(SPDLOG_BUILD_TESTING)
+    include(CTest)
     add_subdirectory(tests)
 endif()
 


### PR DESCRIPTION
This is helpful when using spdlog as a dependency (git submodule) when a
master project is not interested in spdlog tests. Using
"BUILD_TESTING" name may create a confusion.
Extra: BUILD_EXAMPLE variable already have a prefix.