### PR TITLE
Adding a property-based format flag

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -57,6 +57,13 @@ int main(int, char*[])
         spd::set_pattern("*** [%H:%M:%S %z] [thread %t] %v ***");
         rotating_logger->info("This is another message with custom format");
 
+        // Using a per-logger dynamic property map
+        console->set_pattern("*** [%H:%M:%S %z] [thread %t] [%{property_name}] %v ***");
+        auto properties = console->properties();
+        (*properties)["property_name"] = "some property";
+        console->info("This message has a custom property");
+        (*properties)["property_name"] = "new property";
+        console->info("The property has changed");
 
         // Runtime log levels
         spd::set_level(spd::level::info); //Set global log level to info

--- a/example/example.vcxproj
+++ b/example/example.vcxproj
@@ -56,13 +56,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -65,7 +65,7 @@ inline void spdlog::async_logger::_set_formatter(spdlog::formatter_ptr msg_forma
 
 inline void spdlog::async_logger::_set_pattern(const std::string& pattern)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern);
+    _formatter = std::make_shared<pattern_formatter>(pattern, _properties);
     _async_log_helper->set_formatter(_formatter);
 }
 

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -18,7 +18,8 @@ template<class It>
 inline spdlog::logger::logger(const std::string& logger_name, const It& begin, const It& end):
     _name(logger_name),
     _sinks(begin, end),
-    _formatter(std::make_shared<pattern_formatter>("%+"))
+    _properties(std::make_shared<std::unordered_map<std::string, std::string>>()),
+    _formatter(std::make_shared<pattern_formatter>("%+", _properties))
 {
     _level = level::info;
     _flush_level = level::off;
@@ -55,6 +56,11 @@ inline void spdlog::logger::set_formatter(spdlog::formatter_ptr msg_formatter)
 inline void spdlog::logger::set_pattern(const std::string& pattern)
 {
     _set_pattern(pattern);
+}
+
+inline std::shared_ptr<std::unordered_map<std::string, std::string>> spdlog::logger::properties() const
+{
+    return _properties;
 }
 
 
@@ -259,7 +265,7 @@ inline void spdlog::logger::_sink_it(details::log_msg& msg)
 
 inline void spdlog::logger::_set_pattern(const std::string& pattern)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern);
+    _formatter = std::make_shared<pattern_formatter>(pattern, _properties);
 }
 inline void spdlog::logger::_set_formatter(formatter_ptr msg_formatter)
 {

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -111,9 +111,11 @@ public:
     void set_pattern(const std::string& pattern)
     {
         std::lock_guard<Mutex> lock(_mutex);
-        _formatter = std::make_shared<pattern_formatter>(pattern);
         for (auto& l : _loggers)
+        {
+            _formatter = std::make_shared<pattern_formatter>(pattern, l.second->properties());
             l.second->set_formatter(_formatter);
+        }
     }
 
     void set_level(level::level_enum log_level)

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -7,9 +7,9 @@
 
 #include <spdlog/details/log_msg.h>
 
-#include <vector>
-#include <string>
 #include <memory>
+#include <unordered_map>
+#include <vector>
 
 namespace spdlog
 {
@@ -29,14 +29,16 @@ class pattern_formatter : public formatter
 {
 
 public:
-    explicit pattern_formatter(const std::string& pattern);
+    explicit pattern_formatter(const std::string& pattern, std::shared_ptr<std::unordered_map<std::string, std::string>> properties);
     pattern_formatter(const pattern_formatter&) = delete;
     pattern_formatter& operator=(const pattern_formatter&) = delete;
     void format(details::log_msg& msg) override;
 private:
     const std::string _pattern;
     std::vector<std::unique_ptr<details::flag_formatter>> _formatters;
-    void handle_flag(char flag);
+    std::shared_ptr<std::unordered_map<std::string, std::string>> properties;
+
+    void handle_flag(char flag, const std::string& param="");
     void compile_pattern(const std::string& pattern);
 };
 }

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -15,9 +15,9 @@
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/common.h>
 
-#include <vector>
 #include <memory>
-#include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace spdlog
 {
@@ -59,6 +59,8 @@ public:
     void set_pattern(const std::string&);
     void set_formatter(formatter_ptr);
 
+    std::shared_ptr<std::unordered_map<std::string, std::string>> properties() const;
+
     // error handler
     void set_error_handler(log_err_handler);
     log_err_handler error_handler();
@@ -83,6 +85,7 @@ protected:
 
     const std::string _name;
     std::vector<sink_ptr> _sinks;
+    std::shared_ptr<std::unordered_map<std::string, std::string>> _properties;
     formatter_ptr _formatter;
     spdlog::level_t _level;
     spdlog::level_t _flush_level;


### PR DESCRIPTION
Working on a video processing project, I need to give context to log lines with the frame number that generated the messages. I could build my own `spdlog::formatter` but it would be mostly a copy of `spdlog::pattern_formatter`. Extending it is not possible because of private members.

Instead I went with mimicking something I have seem on log4net: the capacity to use dynamic, key-value-based properties inserted in the custom pattern string. The format is `%{property_name}.` Each logger holds a <string, string> map with O(1) access and insertion. Users can handle it freely through a shared_ptr.

I have also added a few lines to example.cpp and updated the Visual Studio solution to VS2015.

Hope you consider this contribution and I am open to discuss modifications.