### PR TITLE
Fix get size of mpmc queue issue

### DIFF
--- a/include/spdlog/details/mpmc_bounded_q.h
+++ b/include/spdlog/details/mpmc_bounded_q.h
@@ -137,8 +137,6 @@ public:
     {
         size_t first_pos = dequeue_pos_.load(std::memory_order_relaxed);
         size_t last_pos = enqueue_pos_.load(std::memory_order_relaxed);
-        if (last_pos <= first_pos)
-            return 0;
         auto size = last_pos - first_pos;
         return size < max_size_ ? size : max_size_;
     }


### PR DESCRIPTION
Because the `first_pos` may overflow the size_t and come to zero again. So in that critical condition, `last_pos` is less than `first_pos` and the size is not zero. Simply don't check this comes to the right result.