### PR TITLE
Use double-braces in std::array initialization.

### DIFF
--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -82,7 +82,7 @@ static int to12h(const tm& t)
 using days_array = std::array<std::string, 7>;
 static const days_array& days()
 {
-    static const days_array arr{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+    static const days_array arr{ { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" } };
     return arr;
 }
 class a_formatter:public flag_formatter
@@ -96,7 +96,7 @@ class a_formatter:public flag_formatter
 //Full weekday name
 static const days_array& full_days()
 {
-    static const days_array arr{ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
+    static const days_array arr{ { "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" } };
     return arr;
 }
 class A_formatter:public flag_formatter
@@ -111,7 +111,7 @@ class A_formatter:public flag_formatter
 using months_array = std::array<std::string, 12>;
 static const months_array& months()
 {
-    static const months_array arr{ "Jan", "Feb", "Mar", "Apr", "May", "June", "July", "Aug", "Sept", "Oct", "Nov", "Dec" };
+    static const months_array arr{ { "Jan", "Feb", "Mar", "Apr", "May", "June", "July", "Aug", "Sept", "Oct", "Nov", "Dec" } };
     return arr;
 }
 class b_formatter:public flag_formatter
@@ -125,7 +125,7 @@ class b_formatter:public flag_formatter
 //Full month name
 static const months_array& full_months()
 {
-    static const months_array arr{ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
+    static const months_array arr{ { "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" } };
     return arr;
 }
 class B_formatter:public flag_formatter


### PR DESCRIPTION
There are some warnings in example codes.
Using double-braces solves them.

```
c++ example.cpp -o example -Wall -Wshadow -Wextra -pedantic -std=c++11 -pthread -I../include -O3 -march=native 
In file included from example.cpp:9:
In file included from ../include/spdlog/spdlog.h:14:
In file included from ../include/spdlog/logger.h:15:
In file included from ../include/spdlog/sinks/base_sink.h:14:
In file included from ../include/spdlog/formatter.h:44:
../include/spdlog/details/pattern_formatter_impl.h:85:34: warning: suggest
      braces around initialization of subobject [-Wmissing-braces]
  ...const days_array arr{ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                           {                                              }
../include/spdlog/details/pattern_formatter_impl.h:99:34: warning: suggest
      braces around initialization of subobject [-Wmissing-braces]
  ..."Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     {                                                                           }
../include/spdlog/details/pattern_formatter_impl.h:114:36: warning: suggest
      braces around initialization of subobject [-Wmissing-braces]
  ..."Jan", "Feb", "Mar", "Apr", "May", "June", "July", "Aug", "Sept", "Oct", "Nov", "Dec" };
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     {                                                                                    }
../include/spdlog/details/pattern_formatter_impl.h:128:36: warning: suggest
      braces around initialization of subobject [-Wmissing-braces]
  ..."January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     {                                                                                                                       }
```