### PR TITLE
Disambiguate fmt logging methods that are using variadic templates.

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -121,43 +121,41 @@ inline void spdlog::logger::log(level::level_enum lvl, const T& msg)
 }
 
 
-template <typename... Args>
-inline void spdlog::logger::trace(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::trace(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::trace, fmt, args...);
+    log(level::trace, fmt, arg1, args...);
 }
 
-template <typename... Args>
-inline void spdlog::logger::debug(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::debug(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::debug, fmt, args...);
+    log(level::debug, fmt, arg1, args...);
 }
 
-template <typename... Args>
-inline void spdlog::logger::info(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::info(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::info, fmt, args...);
+    log(level::info, fmt, arg1, args...);
 }
 
-
-template <typename... Args>
-inline void spdlog::logger::warn(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::warn(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::warn, fmt, args...);
+    log(level::warn, fmt, arg1, args...);
 }
 
-template <typename... Args>
-inline void spdlog::logger::error(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::error(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::err, fmt, args...);
+    log(level::err, fmt, arg1, args...);
 }
 
-template <typename... Args>
-inline void spdlog::logger::critical(const char* fmt, const Args&... args)
+template <typename Arg1, typename... Args>
+inline void spdlog::logger::critical(const char* fmt, const Arg1 &arg1, const Args&... args)
 {
-    log(level::critical, fmt, args...);
+    log(level::critical, fmt, arg1, args...);
 }
-
 
 template<typename T>
 inline void spdlog::logger::trace(const T& msg)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -37,12 +37,12 @@ public:
 
     template <typename... Args> void log(level::level_enum lvl, const char* fmt, const Args&... args);
     template <typename... Args> void log(level::level_enum lvl, const char* msg);
-    template <typename... Args> void trace(const char* fmt, const Args&... args);
-    template <typename... Args> void debug(const char* fmt, const Args&... args);
-    template <typename... Args> void info(const char* fmt, const Args&... args);
-    template <typename... Args> void warn(const char* fmt, const Args&... args);
-    template <typename... Args> void error(const char* fmt, const Args&... args);
-    template <typename... Args> void critical(const char* fmt, const Args&... args);
+    template <typename Arg1, typename... Args> void trace(const char* fmt, const Arg1&, const Args&... args);
+    template <typename Arg1, typename... Args> void debug(const char* fmt, const Arg1&, const Args&... args);
+    template <typename Arg1, typename... Args> void info(const char* fmt, const Arg1&, const Args&... args);
+    template <typename Arg1, typename... Args> void warn(const char* fmt, const Arg1&, const Args&... args);
+    template <typename Arg1, typename... Args> void error(const char* fmt, const Arg1&, const Args&... args);
+    template <typename Arg1, typename... Args> void critical(const char* fmt, const Arg1&, const Args&... args);
 
     template <typename T> void log(level::level_enum lvl, const T&);
     template <typename T> void trace(const T&);


### PR DESCRIPTION
Fix for #256 

As variadic template arguments can be zero length, we need to specify that at least one fmt argument is provided, to distinguish these methods from the existing trivial method that takes no fmt arguments.

Without this, static analysers such as ReSharper flag the logging calls as errors.