### PR TITLE
UTC Time

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -71,7 +71,7 @@ public:
 protected:
     void _sink_it(details::log_msg& msg) override;
     void _set_formatter(spdlog::formatter_ptr msg_formatter) override;
-    void _set_pattern(const std::string& pattern, pattern_time ptime) override;
+    void _set_pattern(const std::string& pattern, pattern_time_type pattern_time) override;
 
 private:
     std::unique_ptr<details::async_log_helper> _async_log_helper;

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -71,7 +71,7 @@ public:
 protected:
     void _sink_it(details::log_msg& msg) override;
     void _set_formatter(spdlog::formatter_ptr msg_formatter) override;
-    void _set_pattern(const std::string& pattern) override;
+    void _set_pattern(const std::string& pattern, pattern_time ptime) override;
 
 private:
     std::unique_ptr<details::async_log_helper> _async_log_helper;

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -106,6 +106,15 @@ enum class async_overflow_policy
     discard_log_msg // Discard the message it enqueue fails
 };
 
+//
+// Pattern time - specific time getting to use for pattern_formatter.
+// local time by default
+//
+enum class pattern_time
+{
+	local, // use variant of time similar to std::localtime for std::tm
+	utc // use variant of time similar to std::gmtime for std::tm
+};
 
 //
 // Log exception

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -110,10 +110,10 @@ enum class async_overflow_policy
 // Pattern time - specific time getting to use for pattern_formatter.
 // local time by default
 //
-enum class pattern_time
+enum class pattern_time_type
 {
-	local, // use variant of time similar to std::localtime for std::tm
-	utc // use variant of time similar to std::gmtime for std::tm
+    local, // use variant of time similar to std::localtime for std::tm
+    utc // use variant of time similar to std::gmtime for std::tm
 };
 
 //

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -76,9 +76,9 @@ inline void spdlog::async_logger::_set_formatter(spdlog::formatter_ptr msg_forma
     _async_log_helper->set_formatter(_formatter);
 }
 
-inline void spdlog::async_logger::_set_pattern(const std::string& pattern)
+inline void spdlog::async_logger::_set_pattern(const std::string& pattern, pattern_time ptime)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern);
+    _formatter = std::make_shared<pattern_formatter>(pattern, ptime);
     _async_log_helper->set_formatter(_formatter);
 }
 

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -76,9 +76,9 @@ inline void spdlog::async_logger::_set_formatter(spdlog::formatter_ptr msg_forma
     _async_log_helper->set_formatter(_formatter);
 }
 
-inline void spdlog::async_logger::_set_pattern(const std::string& pattern, pattern_time ptime)
+inline void spdlog::async_logger::_set_pattern(const std::string& pattern, pattern_time_type pattern_time)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern, ptime);
+    _formatter = std::make_shared<pattern_formatter>(pattern, pattern_time);
     _async_log_helper->set_formatter(_formatter);
 }
 

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -53,9 +53,9 @@ inline void spdlog::logger::set_formatter(spdlog::formatter_ptr msg_formatter)
     _set_formatter(msg_formatter);
 }
 
-inline void spdlog::logger::set_pattern(const std::string& pattern, pattern_time ptime)
+inline void spdlog::logger::set_pattern(const std::string& pattern, pattern_time_type pattern_time)
 {
-    _set_pattern(pattern, ptime);
+    _set_pattern(pattern, pattern_time);
 }
 
 
@@ -316,9 +316,9 @@ inline void spdlog::logger::_sink_it(details::log_msg& msg)
         flush();
 }
 
-inline void spdlog::logger::_set_pattern(const std::string& pattern, pattern_time ptime)
+inline void spdlog::logger::_set_pattern(const std::string& pattern, pattern_time_type pattern_time)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern, ptime);
+    _formatter = std::make_shared<pattern_formatter>(pattern, pattern_time);
 }
 inline void spdlog::logger::_set_formatter(formatter_ptr msg_formatter)
 {

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -53,9 +53,9 @@ inline void spdlog::logger::set_formatter(spdlog::formatter_ptr msg_formatter)
     _set_formatter(msg_formatter);
 }
 
-inline void spdlog::logger::set_pattern(const std::string& pattern)
+inline void spdlog::logger::set_pattern(const std::string& pattern, pattern_time ptime)
 {
-    _set_pattern(pattern);
+    _set_pattern(pattern, ptime);
 }
 
 
@@ -316,9 +316,9 @@ inline void spdlog::logger::_sink_it(details::log_msg& msg)
         flush();
 }
 
-inline void spdlog::logger::_set_pattern(const std::string& pattern)
+inline void spdlog::logger::_set_pattern(const std::string& pattern, pattern_time ptime)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern);
+    _formatter = std::make_shared<pattern_formatter>(pattern, ptime);
 }
 inline void spdlog::logger::_set_formatter(formatter_ptr msg_formatter)
 {

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -311,15 +311,7 @@ class R_formatter SPDLOG_FINAL:public flag_formatter
 {
     void format(details::log_msg& msg, const std::tm& tm_time) override
     {
-		msg.formatted << (tm_time.tm_year + 1900);
-		msg.formatted << '-';
-		msg.formatted << tm_time.tm_mon;
-		msg.formatted << '-';
-		msg.formatted << tm_time.tm_mday;
-	
-		msg.formatted << ' ';
-		
-		pad_n_join(msg.formatted, tm_time.tm_hour, tm_time.tm_min, ':');
+        pad_n_join(msg.formatted, tm_time.tm_hour, tm_time.tm_min, ':');
     }
 };
 
@@ -502,13 +494,13 @@ class full_formatter SPDLOG_FINAL:public flag_formatter
 ///////////////////////////////////////////////////////////////////////////////
 // pattern_formatter inline impl
 ///////////////////////////////////////////////////////////////////////////////
-inline spdlog::pattern_formatter::pattern_formatter(const std::string& pattern, pattern_time ptime)
-: _time(ptime)
+inline spdlog::pattern_formatter::pattern_formatter(const std::string& pattern, pattern_time_type pattern_time)
+: _pattern_time(pattern_time)
 {
-    compile_pattern(pattern, _time);
+    compile_pattern(pattern);
 }
 
-inline void spdlog::pattern_formatter::compile_pattern(const std::string& pattern, pattern_time ptime)
+inline void spdlog::pattern_formatter::compile_pattern(const std::string& pattern)
 {
     auto end = pattern.end();
     std::unique_ptr<details::aggregate_formatter> user_chars;
@@ -673,26 +665,18 @@ inline void spdlog::pattern_formatter::handle_flag(char flag)
     }
 }
 
+inline std::tm spdlog::pattern_formatter::get_time(details::log_msg& msg) {
+    if (_pattern_time == pattern_time_type::local)
+        return details::os::localtime(log_clock::to_time_t(msg.time));
+    else
+        return details::os::gmtime(log_clock::to_time_t(msg.time));
+}
 
 inline void spdlog::pattern_formatter::format(details::log_msg& msg)
 {
 
 #ifndef SPDLOG_NO_DATETIME
-	auto tm_time = [this, &msg]()
-	{
-		switch (_time)
-		{
-		// it is always faster to put the most-common/default case first
-		case (pattern_time::local):
-			return details::os::localtime(log_clock::to_time_t(msg.time));
-
-		case (pattern_time::utc):
-			return details::os::gmtime(log_clock::to_time_t(msg.time));
-		
-		default:
-			return details::os::localtime(log_clock::to_time_t(msg.time));
-		}
-	}();
+    auto tm_time = get_time(msg);
 #else
     std::tm tm_time;
 #endif

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -503,9 +503,9 @@ class full_formatter SPDLOG_FINAL:public flag_formatter
 // pattern_formatter inline impl
 ///////////////////////////////////////////////////////////////////////////////
 inline spdlog::pattern_formatter::pattern_formatter(const std::string& pattern, pattern_time ptime)
-: _time(ptime), _pattern(pattern)
+: _time(ptime)
 {
-    compile_pattern(_pattern, _time);
+    compile_pattern(pattern, _time);
 }
 
 inline void spdlog::pattern_formatter::compile_pattern(const std::string& pattern, pattern_time ptime)

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -665,7 +665,8 @@ inline void spdlog::pattern_formatter::handle_flag(char flag)
     }
 }
 
-inline std::tm spdlog::pattern_formatter::get_time(details::log_msg& msg) {
+inline std::tm spdlog::pattern_formatter::get_time(details::log_msg& msg) 
+{
     if (_pattern_time == pattern_time_type::local)
         return details::os::localtime(log_clock::to_time_t(msg.time));
     else

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -29,15 +29,16 @@ class pattern_formatter SPDLOG_FINAL : public formatter
 {
 
 public:
-    explicit pattern_formatter(const std::string& pattern);
+    explicit pattern_formatter(const std::string& pattern, pattern_time ptime = pattern_time::local);
     pattern_formatter(const pattern_formatter&) = delete;
     pattern_formatter& operator=(const pattern_formatter&) = delete;
     void format(details::log_msg& msg) override;
 private:
     const std::string _pattern;
+	const pattern_time _time;
     std::vector<std::unique_ptr<details::flag_formatter>> _formatters;
     void handle_flag(char flag);
-    void compile_pattern(const std::string& pattern);
+    void compile_pattern(const std::string& pattern, pattern_time ptime);
 };
 }
 

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -29,16 +29,17 @@ class pattern_formatter SPDLOG_FINAL : public formatter
 {
 
 public:
-    explicit pattern_formatter(const std::string& pattern, pattern_time ptime = pattern_time::local);
+    explicit pattern_formatter(const std::string& pattern, pattern_time_type pattern_time = pattern_time_type::local);
     pattern_formatter(const pattern_formatter&) = delete;
     pattern_formatter& operator=(const pattern_formatter&) = delete;
     void format(details::log_msg& msg) override;
 private:
     const std::string _pattern;
-	const pattern_time _time;
+    const pattern_time_type _pattern_time;
     std::vector<std::unique_ptr<details::flag_formatter>> _formatters;
+    std::tm get_time(details::log_msg& msg);
     void handle_flag(char flag);
-    void compile_pattern(const std::string& pattern, pattern_time ptime);
+    void compile_pattern(const std::string& pattern);
 };
 }
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -66,7 +66,7 @@ public:
     void set_level(level::level_enum);
     level::level_enum level() const;
     const std::string& name() const;
-    void set_pattern(const std::string&, pattern_time = pattern_time::local);
+    void set_pattern(const std::string&, pattern_time_type = pattern_time_type::local);
     void set_formatter(formatter_ptr);
 
     // automatically call flush() if message level >= log_level
@@ -82,7 +82,7 @@ public:
 
 protected:
     virtual void _sink_it(details::log_msg&);
-    virtual void _set_pattern(const std::string&, pattern_time);
+    virtual void _set_pattern(const std::string&, pattern_time_type);
     virtual void _set_formatter(formatter_ptr);
 
     // default error handler: print the error to stderr with the max rate of 1 message/minute

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -66,7 +66,7 @@ public:
     void set_level(level::level_enum);
     level::level_enum level() const;
     const std::string& name() const;
-    void set_pattern(const std::string&);
+    void set_pattern(const std::string&, pattern_time = pattern_time::local);
     void set_formatter(formatter_ptr);
 
     // automatically call flush() if message level >= log_level
@@ -82,7 +82,7 @@ public:
 
 protected:
     virtual void _sink_it(details::log_msg&);
-    virtual void _set_pattern(const std::string&);
+    virtual void _set_pattern(const std::string&, pattern_time);
     virtual void _set_formatter(formatter_ptr);
 
     // default error handler: print the error to stderr with the max rate of 1 message/minute


### PR DESCRIPTION
This issue addresses #215 in the way @gabime stated he'd like it to be handled: with a simple flag that can be passed to `pattern_formatter`'s constructor. It's a smaller, simpler solution that propagates its changes to the virtual functions `_set_pattern` and `set_pattern` in `spdlog::logger` and `spdlog::async_logger`.

The implementation is made as an enumeration simply because there may be more efficient time abstractions that spdlog takes advantage of in the future: the enumeration allows for seamless transition to these while maintaining backwards compatibility by ensuring that all defaulted loggers and pattern formatters use `spdlog::pattern_time::local` by default.

Anyone who has derived from `logger` and `async_logger` will have to change their code to handle the new parameter for the virtual `set_pattern` call, but I believe this is a negligible burden in 100% of the cases where people have actually customized `spdlog` to this degree.

I have not measured the impact of a switch statement, but have done my best to use my general knowledge to ensure it will remain more or less swift, especially in the default case.

Small question: did you mean to never initialize the member variable `_pattern` in `spdlog::pattern_formatter` ? It never gets initialized (and you never use it anywhere?). I would imagine it's accidentally an artifact of slowly changing the pattern formatter to work in a compiled form and actually no longer needing it, so I don't set it in my code, but I do set the `_time` member variable. Shouldn't it be removed, if that's the case? If so, I will be happy to remove it in this branch.

Let me know if you need anything else.