### PR TITLE
Fix for MinGW error: 'There are no arguments that depend on a template parameter'

### DIFF
--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~wincolor_sink()
     {
-        flush();
+        this->flush();
     }
 
     wincolor_sink(const wincolor_sink& other) = delete;


### PR DESCRIPTION
Fix for MinGW 5.3.0 compilation error:

[ 12%] Building CXX object tests/CMakeFiles/catch_tests.dir/errors.cpp.obj
In file included from C:/projects/spdlog/include/spdlog/details/spdlog_impl.h:20:0,
                 from C:/projects/spdlog/include/spdlog/spdlog.h:178,
                 from C:\projects\spdlog\tests\includes.h:13,
                 from C:\projects\spdlog\tests\errors.cpp:4:
C:/projects/spdlog/include/spdlog/sinks/wincolor_sink.h: In destructor 'virtual spdlog::sinks::wincolor_sink<Mutex>::~wincolor_sink()':
C:/projects/spdlog/include/spdlog/sinks/wincolor_sink.h:47:15: error: there are no arguments to 'flush' that depend on a template parameter, so a declaration of 'flush' must be available [-fpermissive]
         flush();
               ^
C:/projects/spdlog/include/spdlog/sinks/wincolor_sink.h:47:15: note: (if you use '-fpermissive', G++ will accept your code, but allowing the use of an undeclared name is deprecated)
tests\CMakeFiles\catch_tests.dir\build.make:62: recipe for target 'tests/CMakeFiles/catch_tests.dir/errors.cpp.obj' failed

Signed-off-by: Remigiusz Kołłątaj <remigiusz.kollataj@gmail.com>