### PR TITLE
add hunter to package managers in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Very fast, header only, C++ logging library. [![Build Status](https://travis-ci.
 * Fedora: `yum install spdlog`
 * Arch Linux: `pacman -S spdlog-git`
 * vcpkg: `vcpkg install spdlog`
- 
+* [hunter](https://github.com/ruslo/hunter): https://github.com/ruslo/hunter/wiki/pkg.spdlog
 
 ## Platforms
  * Linux, FreeBSD, Solaris


### PR DESCRIPTION
spdlog is also available in the [hunter](https://github.com/ruslo/hunter) CMake package manager.

https://github.com/ruslo/hunter/wiki/pkg.spdlog

```
hunter_add_package(spdlog)
find_package(spdlog CONFIG REQUIRED)
target_link_libraries(... spdlog::spdlog)
```

https://github.com/gabime/spdlog#or-use-your-favourite-package-manager

Thanks for spdlog!