### PR TITLE
rotating file logger callback

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -67,6 +67,9 @@ using level_t = std::atomic<int>;
 
 using log_err_handler = std::function<void(const std::string &err_msg)>;
 
+using rotating_logger_cb = std::function<void(std::vector<std::string>)>;
+using daily_logger_cb = std::function<void(std::string)>;
+
 //Log level enum
 namespace level
 {

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -59,25 +59,25 @@ inline std::shared_ptr<spdlog::logger> spdlog::basic_logger_st(const std::string
 }
 
 // Create multi/single threaded rotating file logger
-inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_mt(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files)
+inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_mt(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files, rotating_logger_cb cb /*= nullptr*/)
 {
-    return create<spdlog::sinks::rotating_file_sink_mt>(logger_name, filename, max_file_size, max_files);
+    return create<spdlog::sinks::rotating_file_sink_mt>(logger_name, filename, max_file_size, max_files, cb);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_st(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files)
+inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_st(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files, rotating_logger_cb cb /*= nullptr*/)
 {
-    return create<spdlog::sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files);
+    return create<spdlog::sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files, cb);
 }
 
 // Create file logger which creates new file at midnight):
-inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_mt(const std::string& logger_name, const filename_t& filename, int hour, int minute)
+inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_mt(const std::string& logger_name, const filename_t& filename, int hour, int minute, daily_logger_cb cb /*= nullptr*/)
 {
-    return create<spdlog::sinks::daily_file_sink_mt>(logger_name, filename, hour, minute);
+    return create<spdlog::sinks::daily_file_sink_mt>(logger_name, filename, hour, minute, cb);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_st(const std::string& logger_name, const filename_t& filename, int hour, int minute)
+inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_st(const std::string& logger_name, const filename_t& filename, int hour, int minute, daily_logger_cb cb /*= nullptr*/)
 {
-    return create<spdlog::sinks::daily_file_sink_st>(logger_name, filename, hour, minute);
+    return create<spdlog::sinks::daily_file_sink_st>(logger_name, filename, hour, minute, cb);
 }
 
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -77,14 +77,14 @@ std::shared_ptr<logger> basic_logger_st(const std::string& logger_name, const fi
 //
 // Create and register multi/single threaded rotating file logger
 //
-std::shared_ptr<logger> rotating_logger_mt(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files);
-std::shared_ptr<logger> rotating_logger_st(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files);
+std::shared_ptr<logger> rotating_logger_mt(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files, rotating_logger_cb cb = nullptr);
+std::shared_ptr<logger> rotating_logger_st(const std::string& logger_name, const filename_t& filename, size_t max_file_size, size_t max_files, rotating_logger_cb cb = nullptr);
 
 //
 // Create file logger which creates new file on the given time (default in  midnight):
 //
-std::shared_ptr<logger> daily_logger_mt(const std::string& logger_name, const filename_t& filename, int hour=0, int minute=0);
-std::shared_ptr<logger> daily_logger_st(const std::string& logger_name, const filename_t& filename, int hour=0, int minute=0);
+std::shared_ptr<logger> daily_logger_mt(const std::string& logger_name, const filename_t& filename, int hour=0, int minute=0, daily_logger_cb cb = nullptr);
+std::shared_ptr<logger> daily_logger_st(const std::string& logger_name, const filename_t& filename, int hour=0, int minute=0, daily_logger_cb cb = nullptr);
 
 //
 // Create and register stdout/stderr loggers


### PR DESCRIPTION
Hi

I have added callback for rotating file logger. https://github.com/gabime/spdlog/issues/155

Feature implemented

- callback for rotational logger: list of files are notified
- callback for daily file logger: recently closed file is notified

I didn't add open file descriptor because it will expose an open file to the client. It may affect future renaming for long running processes.

Please check this one and let me know if you need any changes.