### PR TITLE
Issue 497. Add multi-process-friendly rotating_file_sink_mp  

### DIFF
--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -55,6 +55,7 @@ int main(int argc, char* argv[])
 
         auto rotating_st = spdlog::rotating_logger_st("rotating_st", "logs/rotating_st", file_size, rotating_files);
         bench(howmany, rotating_st);
+        bench(howmany, spdlog::create<spdlog::sinks::rotating_file_sink_mp_st>("rotating_mp_st", "logs/rotating_mp_st", file_size, rotating_files));
         auto daily_st = spdlog::daily_logger_st("daily_st", "logs/daily_st");
         bench(howmany, daily_st);
         bench(howmany, spdlog::create<null_sink_st>("null_st"));
@@ -65,7 +66,7 @@ int main(int argc, char* argv[])
 
         auto rotating_mt = spdlog::rotating_logger_mt("rotating_mt", "logs/rotating_mt", file_size, rotating_files);
         bench_mt(howmany, rotating_mt, threads);
-
+        bench_mt(howmany, spdlog::create<spdlog::sinks::rotating_file_sink_mp_mt>("rotating_mp_mt", "logs/rotating_mp_mt", file_size, rotating_files), threads);
 
         auto daily_mt = spdlog::daily_logger_mt("daily_mt", "logs/daily_mt");
         bench_mt(howmany, daily_mt, threads);

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -17,7 +17,6 @@
 #include <string>
 #include <thread>
 #include <cerrno>
-#include <algorithm>
 
 namespace spdlog
 {

--- a/tests/file_log.cpp
+++ b/tests/file_log.cpp
@@ -20,7 +20,6 @@ TEST_CASE("simple_file_logger", "[simple_logger]]")
     REQUIRE(count_lines(filename) == 2);
 }
 
-
 TEST_CASE("flush_on", "[flush_on]]")
 {
     prepare_logdir();
@@ -54,7 +53,6 @@ TEST_CASE("rotating_file_logger1", "[rotating_logger]]")
     REQUIRE(count_lines(filename) == 10);
 }
 
-
 TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
 {
     prepare_logdir();
@@ -76,6 +74,40 @@ TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
 }
 
 
+TEST_CASE("rotating_file_logger_mp1", "[rotating_logger]]")
+{
+    prepare_logdir();
+    std::string basename = "logs/rotating_log";
+    auto logger = spdlog::create<spdlog::sinks::rotating_file_sink_mp_mt>("logger", basename, 1024, 0);
+
+    for (int i = 0; i < 10; ++i)
+        logger->info("Test message {}", i);
+
+    logger->flush();
+    auto filename = basename;
+    REQUIRE(count_lines(filename) == 10);
+}
+
+TEST_CASE("rotating_file_logger_mp2", "[rotating_logger]]")
+{
+    prepare_logdir();
+    std::string basename = "logs/rotating_log";
+    auto logger = spdlog::create<spdlog::sinks::rotating_file_sink_mp_mt>("logger", basename, 1024, 1);
+    for (int i = 0; i < 10; ++i)
+        logger->info("Test message {}", i);
+
+    logger->flush();
+    auto filename = basename;
+    REQUIRE(count_lines(filename) == 10);
+    for (int i = 0; i < 1000; i++)
+        logger->info("Test message {}", i);
+
+    logger->flush();
+    REQUIRE(get_filesize(filename) <= 1024);
+    auto filename1 = basename + ".1";
+    REQUIRE(get_filesize(filename1) <= 1024);
+}
+
 TEST_CASE("daily_logger", "[daily_logger]]")
 {
     prepare_logdir();
@@ -93,7 +125,6 @@ TEST_CASE("daily_logger", "[daily_logger]]")
     auto filename = w.str();
     REQUIRE(count_lines(filename) == 10);
 }
-
 
 TEST_CASE("daily_logger with dateonly calculator", "[daily_logger_dateonly]]")
 {
@@ -148,4 +179,3 @@ TEST_CASE("daily_logger with custom calculator", "[daily_logger_custom]]")
     auto filename = w.str();
     REQUIRE(count_lines(filename) == 10);
 }
-

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -11,6 +11,7 @@
 #include "utils.h"
 
 #include "../include/spdlog/spdlog.h"
+#include "../include/spdlog/sinks/file_sinks.h"
 #include "../include/spdlog/sinks/null_sink.h"
 #include "../include/spdlog/sinks/ostream_sink.h"
 


### PR DESCRIPTION
This PR contains code that provides multi-process safe way to write rotating file logs.

*Main idea*: each write to the log file must be atomic so we would not see any intersection of messages from different processes. 

To achieve this we should use low-level OS functions:
- Linux:
  - write (http://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html)
  - writev (http://pubs.opengroup.org/onlinepubs/9699919799/functions/writev.html)

- Windows:
  - _write (https://msdn.microsoft.com/en-us/en-en/library/1570wh78(v=vs.100).aspx)

Also log files rotation process have changed. At the start of rotation, rotating_file_sink_mp create special file - "rotating". This file is empty and have one purpose - it says to other processes that rotation is going on and you should wait some time. As soon as rotation would be performed, this flag-file will be removed and all processes would start to write messages in new log file.

*Pros*:
- every write operation is atomic
- messages in the log are sequential
- number of processes that write messages to log file is not limited
- the rotation of the log files takes approximately the same amount of time as the rotation in rotating_file_sink

*Cons*:
- length of the message is limited by OS
- we should constantly request size of the log file from OS - this is *very long* operation
- at rotation all processes should wait till will be ended

*New classes*:
- rotating_file_sink_mp  - based on rotating_file_sink with changes in file handling and rotation process
- file_helper_mp - based on file_helper

Tested on Linux and Windows.
The Windows implementation must be finalized.