### PR TITLE
SPDLOG_BUILD_TESTING now depends on BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(spdlog VERSION 1.0.0)
 include(CTest)
+include(CMakeDependentOption)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -17,7 +18,10 @@ endif()
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
-option(SPDLOG_BUILD_TESTING "Build spdlog tests" ON)
+cmake_dependent_option(SPDLOG_BUILD_TESTING 
+    "Build spdlog tests" ON
+    "BUILD_TESTING" OFF
+)
 
 target_include_directories(
     spdlog


### PR DESCRIPTION
I encountered an issue when using spdlog through add_subdirectory.
Since SPDLOG_BUILD_TESTING is ON by default, it now adds tests to my project, even if BUILD_TESTING (the official CTest variable) is set to OFF.
cmake_dependent_option makes it so that if someone enables BUILD_TESTING then SPDLOG_BUILD_TESTING will be set to ON by default.
This way one can disable all external tests by setting only BUILD_TESTING before using add_subdirectory and then setting it back to its original value.
The only change for those using the library directly is that they now use BUILD_TESTING instead of SPDLOG_BUILD_TESTING when configuring.