### PR TITLE
Feature/improve cmake lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+### Install ###
+# Note: use 'targets_export_name'
 #
 # Copyright(c) 2015 Ruslan Baratov.
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
@@ -7,6 +9,7 @@ cmake_minimum_required(VERSION 3.1)
 project(spdlog VERSION 1.0.0)
 include(CTest)
 include(CMakeDependentOption)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,7 +21,7 @@ endif()
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
-cmake_dependent_option(SPDLOG_BUILD_TESTING 
+cmake_dependent_option(SPDLOG_BUILD_TESTING
     "Build spdlog tests" ON
     "BUILD_TESTING" OFF
 )
@@ -27,7 +30,7 @@ target_include_directories(
     spdlog
     INTERFACE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 set(HEADER_BASE "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -40,17 +43,12 @@ if(SPDLOG_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-### Install ###
-# * https://github.com/forexample/package-example
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-set(config_install_dir "lib/cmake/${PROJECT_NAME}")
-set(include_install_dir "include")
-set(pkgconfig_install_dir "lib/pkgconfig")
-
-set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-set(pkg_config "${generated_dir}/${PROJECT_NAME}.pc")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
+set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+set(version_config "${CMAKE_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${PROJECT_NAME}Config.cmake")
+set(pkg_config "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
@@ -59,8 +57,6 @@ write_basic_package_version_file(
     "${version_config}" COMPATIBILITY SameMajorVersion
 )
 
-# Note: use 'targets_export_name'
-configure_file("cmake/Config.cmake.in" "${project_config}" @ONLY)
 configure_file("cmake/spdlog.pc.in" "${pkg_config}" @ONLY)
 
 install(
@@ -69,10 +65,13 @@ install(
     INCLUDES DESTINATION "${include_install_dir}"
 )
 
-install(DIRECTORY "include/spdlog" DESTINATION "${include_install_dir}")
+install(
+    DIRECTORY "${HEADER_BASE}/${PROJECT_NAME}"
+    DESTINATION "${include_install_dir}"
+)
 
 install(
-    FILES "${project_config}" "${version_config}"
+    FILES "${version_config}"
     DESTINATION "${config_install_dir}"
 )
 
@@ -85,7 +84,16 @@ install(
     EXPORT "${targets_export_name}"
     NAMESPACE "${namespace}"
     DESTINATION "${config_install_dir}"
+    FILE ${project_config}
 )
+
+export(
+    EXPORT ${targets_export_name}
+    NAMESPACE "${namespace}"
+    FILE ${project_config}
+)
+
+export(PACKAGE ${PROJECT_NAME})
 
 file(GLOB_RECURSE spdlog_include_SRCS "${HEADER_BASE}/*.h")
 add_custom_target(spdlog_headers_for_ide SOURCES ${spdlog_include_SRCS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ include(CTest)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 
+#---------------------------------------------------------------------------------------
+# compiler config
+#---------------------------------------------------------------------------------------
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -18,6 +21,9 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
     set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 endif()
 
+#---------------------------------------------------------------------------------------
+# spdlog target
+#---------------------------------------------------------------------------------------
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)
@@ -43,6 +49,9 @@ if(SPDLOG_BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
+#---------------------------------------------------------------------------------------
+# Install/export targets and files
+#---------------------------------------------------------------------------------------
 set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
 set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 cmake_minimum_required(VERSION 3.1)
-project(spdlog VERSION 1.0.0)
+project(spdlog VERSION 0.14.0)
 include(CTest)
 include(CMakeDependentOption)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,3 @@
-### Install ###
-# Note: use 'targets_export_name'
 #
 # Copyright(c) 2015 Ruslan Baratov.
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
@@ -52,6 +50,7 @@ endif()
 #---------------------------------------------------------------------------------------
 # Install/export targets and files
 #---------------------------------------------------------------------------------------
+# set files and directories
 set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 set(include_install_dir "${CMAKE_INSTALL_INCLUDEDIR}")
 set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
@@ -61,34 +60,41 @@ set(pkg_config "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
+# generate package version file
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${version_config}" COMPATIBILITY SameMajorVersion
 )
 
+# configure pkg config file
 configure_file("cmake/spdlog.pc.in" "${pkg_config}" @ONLY)
 
+# install targets
 install(
     TARGETS spdlog
     EXPORT "${targets_export_name}"
     INCLUDES DESTINATION "${include_install_dir}"
 )
 
+# install headers
 install(
     DIRECTORY "${HEADER_BASE}/${PROJECT_NAME}"
     DESTINATION "${include_install_dir}"
 )
 
+# install project version file
 install(
     FILES "${version_config}"
     DESTINATION "${config_install_dir}"
 )
 
+# install pkg config file
 install(
     FILES "${pkg_config}"
     DESTINATION "${pkgconfig_install_dir}"
 )
 
+# install project config file
 install(
     EXPORT "${targets_export_name}"
     NAMESPACE "${namespace}"
@@ -96,12 +102,14 @@ install(
     FILE ${project_config}
 )
 
+# export build directory config file
 export(
     EXPORT ${targets_export_name}
     NAMESPACE "${namespace}"
     FILE ${project_config}
 )
 
+# register project in CMake user registry
 export(PACKAGE ${PROJECT_NAME})
 
 file(GLOB_RECURSE spdlog_include_SRCS "${HEADER_BASE}/*.h")


### PR DESCRIPTION
Add some improvements to the CMakeLists.txt file:
* Register build tree into CMake user package registry -> no need to install to use the project via find_package()
* Use spdlog namespace in both build and install interfaces
* Use the GNUInstallDirs module for install directories
* Set current project version
* Divide the file in clear sections
* More detailed comments in the install/export section

Importing the project via find_package() has been tested for both cases: installed and via CMake user registry.