### PR TITLE
rethrow unwind exception

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -42,6 +42,12 @@
 #define SPDLOG_DEPRECATED
 #endif
 
+#ifdef __linux__
+#include <cxxabi.h>
+#define SPDLOG_CATCH_ALL catch (abi::__forced_unwind&) { _err_handler("Unknown exception"); throw; } catch (...)
+#else // __linux__
+#define SPDLOG_CATCH_ALL catch (...)
+#endif // __linux__
 
 #include "spdlog/fmt/fmt.h"
 

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <string>
 
-
 // create logger with given name, sinks and the default pattern formatter
 // all other ctors will call this one
 template<class It>
@@ -78,7 +77,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char* fmt, const Ar
     {
         _err_handler(ex.what());
     }
-    catch (...)
+    SPDLOG_CATCH_ALL
     {
         _err_handler("Unknown exception");
     }
@@ -98,7 +97,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char* msg)
     {
         _err_handler(ex.what());
     }
-    catch (...)
+    SPDLOG_CATCH_ALL
     {
         _err_handler("Unknown exception");
     }
@@ -119,7 +118,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const T& msg)
     {
         _err_handler(ex.what());
     }
-    catch (...)
+    SPDLOG_CATCH_ALL
     {
         _err_handler("Unknown exception");
     }
@@ -566,3 +565,5 @@ inline const std::vector<spdlog::sink_ptr>& spdlog::logger::sinks() const
 {
     return _sinks;
 }
+
+#undef SPDLOG_CATCH_ALL


### PR DESCRIPTION
On Linux with pthread library spdlog causes an SIGABORT and crashes
the application in case it catches a thread specific cancellation
exception in a critical execution phase while in a try/catch block
in spdlog/detail/logger_impl.h
    
The exception is caught by some general catch(...) clause where
it is NOT rethrown.

However rethrowing these kind of exception is mandatory, otherwise
an abort will be caused by the glibc.