### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Very fast, header only, C++ logging library. [![Build Status](https://travis-ci.
 * FreeBSD:  `cd /usr/ports/devel/spdlog/ && make install clean`
 * Fedora: `yum install spdlog`
 * Gentoo: `emerge dev-libs/spdlog`
-* Arch Linux: `pacman -S spdlog-git`
+* Arch Linux: `yaourt -S spdlog-git`
 * vcpkg: `vcpkg install spdlog`
  
 


### PR DESCRIPTION
Updated install section for Arch Linux.
I changed
`pacman -S spdlog-git ` to `yaourt -S spdlog-git` in the readme.

[spdlog-git is in AUR](https://aur.archlinux.org/packages/spdlog-git/), not in the official repositories. Therefore it should be installed with an AUR Helper like yaourt or packer, but not with pacman. I suggest yaourt since it seems to be the most commonly used AUR Helper.

Pacman cant find the package with `pacman -S spdlog-git `. I tested in my own Arch Linux machine.