### PR TITLE
Allow compilation on platforms with unwind (android)

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -42,7 +42,7 @@
 #define SPDLOG_DEPRECATED
 #endif
 
-#if defined(__linux__) && !defined(SPDLOG_NO_UNWIND)
+#if defined(__linux__) && !defined(__ANDROID__)
 #include <cxxabi.h>
 #define SPDLOG_CATCH_ALL catch (abi::__forced_unwind&) { _err_handler("Unknown exception"); throw; } catch (...)
 #else // __linux__

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -42,7 +42,7 @@
 #define SPDLOG_DEPRECATED
 #endif
 
-#ifdef __linux__
+#if defined(__linux__) && !defined(SPDLOG_NO_UNWIND)
 #include <cxxabi.h>
 #define SPDLOG_CATCH_ALL catch (abi::__forced_unwind&) { _err_handler("Unknown exception"); throw; } catch (...)
 #else // __linux__


### PR DESCRIPTION
I'm building envoy, which uses spdlog, using current android NDK and cmake - ran into this error.