### PR TITLE
Declare variables as size_t rather than unsigned.

### DIFF
--- a/include/spdlog/details/mpmc_bounded_q.h
+++ b/include/spdlog/details/mpmc_bounded_q.h
@@ -129,7 +129,7 @@ namespace spdlog
 
 			bool is_empty()
 			{				
-				unsigned front, front1, back;
+				size_t front, front1, back;
 				// try to take a consistent snapshot of front/tail.
 				do {					
 					front = enqueue_pos_.load(std::memory_order_acquire);


### PR DESCRIPTION
Modify `unsigned front, front1, back;` to `size_t front, front1, back;`