### PR TITLE
modified path on quoted #includes

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -15,8 +15,8 @@
 //    3. will throw spdlog_ex upon log exceptions
 // Upon destruction, logs all remaining messages in the queue before destructing..
 
-#include "spdlog/common.h"
-#include "spdlog/logger.h"
+#include "common.h"
+#include "logger.h"
 
 #include <chrono>
 #include <functional>
@@ -79,4 +79,4 @@ private:
 }
 
 
-#include "spdlog/details/async_logger_impl.h"
+#include "details/async_logger_impl.h"

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -18,7 +18,7 @@
 #include <locale>
 #endif
 
-#include "spdlog/details/null_mutex.h"
+#include "details/null_mutex.h"
 
 //visual studio upto 2013 does not support noexcept nor constexpr
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
@@ -49,7 +49,7 @@
 #define SPDLOG_CATCH_ALL catch (...)
 #endif // __linux__
 
-#include "spdlog/fmt/fmt.h"
+#include "fmt/fmt.h"
 
 namespace spdlog
 {

--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -12,12 +12,12 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/sinks/sink.h"
-#include "spdlog/details/mpmc_bounded_q.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/os.h"
-#include "spdlog/formatter.h"
+#include "../common.h"
+#include "../sinks/sink.h"
+#include "../details/mpmc_bounded_q.h"
+#include "../details/log_msg.h"
+#include "../details/os.h"
+#include "../formatter.h"
 
 #include <chrono>
 #include <exception>

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -8,8 +8,8 @@
 // Async Logger implementation
 // Use an async_sink (queue per logger) to perform the logging in a worker thread
 
-#include "spdlog/details/async_log_helper.h"
-#include "spdlog/async_logger.h"
+#include "../details/async_log_helper.h"
+#include "../async_logger.h"
 
 #include <string>
 #include <functional>

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -9,8 +9,8 @@
 // When failing to open a file, retry several times(5) with small delay between the tries(10 ms)
 // Throw spdlog_ex exception on errors
 
-#include "spdlog/details/os.h"
-#include "spdlog/details/log_msg.h"
+#include "../details/os.h"
+#include "../details/log_msg.h"
 
 #include <chrono>
 #include <cstdio>

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/details/os.h"
+#include "../common.h"
+#include "../details/os.h"
 
 
 #include <string>

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog/logger.h"
-#include "spdlog/sinks/stdout_sinks.h"
+#include "../logger.h"
+#include "../sinks/stdout_sinks.h"
 
 #include <memory>
 #include <string>

--- a/include/spdlog/details/mpmc_bounded_q.h
+++ b/include/spdlog/details/mpmc_bounded_q.h
@@ -43,7 +43,7 @@ Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
 #pragma once
 
-#include "spdlog/common.h"
+#include "../common.h"
 
 #include <atomic>
 #include <utility>

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -4,7 +4,7 @@
 //
 #pragma once
 
-#include "spdlog/common.h"
+#include "../common.h"
 
 #include <cstdio>
 #include <ctime>

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include "spdlog/formatter.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/os.h"
-#include "spdlog/fmt/fmt.h"
+#include "../formatter.h"
+#include "../details/log_msg.h"
+#include "../details/os.h"
+#include "../fmt/fmt.h"
 
 #include <chrono>
 #include <ctime>

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -10,10 +10,10 @@
 // If user requests a non existing logger, nullptr will be returned
 // This class is thread safe
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/logger.h"
-#include "spdlog/async_logger.h"
-#include "spdlog/common.h"
+#include "../details/null_mutex.h"
+#include "../logger.h"
+#include "../async_logger.h"
+#include "../common.h"
 
 #include <chrono>
 #include <functional>

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -8,23 +8,23 @@
 //
 // Global registry functions
 //
-#include "spdlog/spdlog.h"
-#include "spdlog/details/registry.h"
-#include "spdlog/sinks/file_sinks.h"
-#include "spdlog/sinks/stdout_sinks.h"
+#include "../spdlog.h"
+#include "../details/registry.h"
+#include "../sinks/file_sinks.h"
+#include "../sinks/stdout_sinks.h"
 #ifdef SPDLOG_ENABLE_SYSLOG
-#include "spdlog/sinks/syslog_sink.h"
+#include "../sinks/syslog_sink.h"
 #endif
 
 #ifdef _WIN32
-#include "spdlog/sinks/wincolor_sink.h"
+#include "../sinks/wincolor_sink.h"
 #else
-#include "spdlog/sinks/ansicolor_sink.h"
+#include "../sinks/ansicolor_sink.h"
 #endif
 
 
 #ifdef __ANDROID__
-#include "spdlog/sinks/android_sink.h"
+#include "../sinks/android_sink.h"
 #endif
 
 #include <chrono>

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -18,9 +18,9 @@
 #ifndef FMT_USE_WINDOWS_H
 #define FMT_USE_WINDOWS_H 0
 #endif
-#include "../../fmt/format.h"
+#include "bundled/format.h"
 #if defined(SPDLOG_FMT_PRINTF)
-#include "../../fmt/printf.h"
+#include "bundled/fmt/printf.h"
 #endif
 
 #else //external fmtlib

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -20,7 +20,7 @@
 #endif
 #include "bundled/format.h"
 #if defined(SPDLOG_FMT_PRINTF)
-#include "bundled/fmt/printf.h"
+#include "bundled/printf.h"
 #endif
 
 #else //external fmtlib

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -18,9 +18,9 @@
 #ifndef FMT_USE_WINDOWS_H
 #define FMT_USE_WINDOWS_H 0
 #endif
-#include "spdlog/fmt/bundled/format.h"
+#include "../../fmt/format.h"
 #if defined(SPDLOG_FMT_PRINTF)
-#include "spdlog/fmt/bundled/printf.h"
+#include "../../fmt/printf.h"
 #endif
 
 #else //external fmtlib

--- a/include/spdlog/fmt/ostr.h
+++ b/include/spdlog/fmt/ostr.h
@@ -8,8 +8,8 @@
 // include external or bundled copy of fmtlib's ostream support
 //
 #if !defined(SPDLOG_FMT_EXTERNAL)
-#include "fmt/fmt.h"
-#include "fmt/bundled/ostream.h"
+#include "fmt.h"
+#include "bundled/ostream.h"
 #else
 #include <fmt/ostream.h>
 #endif

--- a/include/spdlog/fmt/ostr.h
+++ b/include/spdlog/fmt/ostr.h
@@ -8,8 +8,8 @@
 // include external or bundled copy of fmtlib's ostream support
 //
 #if !defined(SPDLOG_FMT_EXTERNAL)
-#include "spdlog/fmt/fmt.h"
-#include "spdlog/fmt/bundled/ostream.h"
+#include "fmt/fmt.h"
+#include "fmt/bundled/ostream.h"
 #else
 #include <fmt/ostream.h>
 #endif

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg.h"
+#include "details/log_msg.h"
 
 #include <vector>
 #include <string>
@@ -43,5 +43,5 @@ private:
 };
 }
 
-#include "spdlog/details/pattern_formatter_impl.h"
+#include "details/pattern_formatter_impl.h"
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -12,8 +12,8 @@
 // 2. Format the message using the formatter function
 // 3. Pass the formatted message to its sinks to performa the actual logging
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/common.h"
+#include "sinks/base_sink.h"
+#include "common.h"
 
 #include <vector>
 #include <memory>
@@ -132,4 +132,4 @@ protected:
 };
 }
 
-#include "spdlog/details/logger_impl.h"
+#include "details/logger_impl.h"

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -7,7 +7,7 @@
 
 #if defined(__ANDROID__)
 
-#include "spdlog/sinks/sink.h"
+#include "sink.h"
 
 #include <mutex>
 #include <string>

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/common.h"
-#include "spdlog/details/os.h"
+#include "base_sink.h"
+#include "../common.h"
+#include "../details/os.h"
 
 #include <string>
 #include <map>

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -10,10 +10,10 @@
 // all locking is taken care of here so no locking needed by the implementers..
 //
 
-#include "spdlog/sinks/sink.h"
-#include "spdlog/formatter.h"
-#include "spdlog/common.h"
-#include "spdlog/details/log_msg.h"
+#include "sink.h"
+#include "../formatter.h"
+#include "../common.h"
+#include "../details/log_msg.h"
 
 #include <mutex>
 

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/sinks/sink.h"
+#include "../details/log_msg.h"
+#include "../details/null_mutex.h"
+#include "base_sink.h"
+#include "sink.h"
 
 #include <algorithm>
 #include <mutex>

--- a/include/spdlog/sinks/file_sinks.h
+++ b/include/spdlog/sinks/file_sinks.h
@@ -5,10 +5,10 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/file_helper.h"
-#include "spdlog/fmt/fmt.h"
+#include "base_sink.h"
+#include "../details/null_mutex.h"
+#include "../details/file_helper.h"
+#include "../fmt/fmt.h"
 
 #include <algorithm>
 #include <chrono>

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -7,8 +7,8 @@
 
 #if defined(_MSC_VER)
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
+#include "base_sink.h"
+#include "../details/null_mutex.h"
 
 #include <WinBase.h>
 

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
+#include "base_sink.h"
+#include "../details/null_mutex.h"
 
 #include <mutex>
 

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
+#include "../details/null_mutex.h"
+#include "base_sink.h"
 
 #include <ostream>
 #include <mutex>

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg.h"
+#include "../details/log_msg.h"
 
 namespace spdlog
 {

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -5,8 +5,8 @@
 
 #pragma once
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
+#include "../details/null_mutex.h"
+#include "base_sink.h"
 
 #include <cstdio>
 #include <memory>

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -5,12 +5,12 @@
 
 #pragma once
 
-#include "spdlog/common.h"
+#include "common.h"
 
 #ifdef SPDLOG_ENABLE_SYSLOG
 
-#include "spdlog/sinks/sink.h"
-#include "spdlog/details/log_msg.h"
+#include "sink.h"
+#include "../details/log_msg.h"
 
 #include <array>
 #include <string>

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -7,7 +7,7 @@
 
 #include "base_sink.h"
 #include "../details/null_mutex.h"
-#include "common.h"
+#include "../common.h"
 
 #include <mutex>
 #include <string>

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/common.h"
+#include "base_sink.h"
+#include "../details/null_mutex.h"
+#include "common.h"
 
 #include <mutex>
 #include <string>

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -9,9 +9,9 @@
 
 #define SPDLOG_VERSION "0.14.0"
 
-#include "spdlog/tweakme.h"
-#include "spdlog/common.h"
-#include "spdlog/logger.h"
+#include "tweakme.h"
+#include "common.h"
+#include "logger.h"
 
 #include <memory>
 #include <functional>
@@ -191,4 +191,4 @@ void drop_all();
 }
 
 
-#include "spdlog/details/spdlog_impl.h"
+#include "details/spdlog_impl.h"


### PR DESCRIPTION
Paths pointing to the root of the library where replaced for ones relatives to each file.

For example, inside `/include/spdlog/details/file_helper.h:`
`#include "spdlog/details/os.h"`
This will look for `os.h` in `/include/spdlog/details/spdlog/details/` which doesn't exists.
replaced with:
`#include "../details/os.h"`
and similar for all the files