### PR TITLE
correct include path for sink/syslog_sink.h

### DIFF
--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "common.h"
+#include "../common.h"
 
 #ifdef SPDLOG_ENABLE_SYSLOG
 


### PR DESCRIPTION
Allow syslog to build by fixing include name.