### PR TITLE
WIP tracing symbols in pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ install_manifest.txt
 /tests/tests.VC.db
 /tests/tests
 /tests/logs/file_helper_test.txt
+*.kdev4
+build

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -80,6 +80,13 @@ typedef enum
     off = 6
 } level_enum;
 
+#define SPDLOG_LOGLEVEL_CRITICAL 5
+#define SPDLOG_LOGLEVEL_ERROR    4
+#define SPDLOG_LOGLEVEL_WARNING  3
+#define SPDLOG_LOGLEVEL_INFO     2
+#define SPDLOG_LOGLEVEL_DEBUG    1
+#define SPDLOG_LOGLEVEL_TRACE    0
+
 #if !defined(SPDLOG_LEVEL_NAMES)
 #define SPDLOG_LEVEL_NAMES { "trace", "debug", "info",  "warning", "error", "critical", "off" };
 #endif
@@ -155,5 +162,10 @@ using filename_t = std::wstring;
 using filename_t = std::string;
 #endif
 
-
+struct trace_info {
+    std::string func_raw;
+    std::string func_pretty;
+    std::string filename;
+    int lineno=-1;
+};
 } //spdlog

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -19,10 +19,11 @@ namespace details
 struct log_msg
 {
     log_msg() = default;
-    log_msg(const std::string *loggers_name, level::level_enum lvl) :
+    log_msg(const std::string *loggers_name, level::level_enum lvl, spdlog::trace_info tracer = {}) :
         logger_name(loggers_name),
         level(lvl),
-        msg_id(0)
+        msg_id(0),
+        tracer{std::move(tracer)}
     {
 #ifndef SPDLOG_NO_DATETIME
         time = os::now();
@@ -45,6 +46,7 @@ struct log_msg
     fmt::MemoryWriter raw;
     fmt::MemoryWriter formatted;
     size_t msg_id;
+    spdlog::trace_info tracer;
 };
 }
 }

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -64,7 +64,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char* fmt, const Ar
 
     try
     {
-        details::log_msg log_msg(&_name, lvl);
+        details::log_msg log_msg(&_name, lvl, tracer);
 
 #if defined(SPDLOG_FMT_PRINTF)
         fmt::printf(log_msg.raw, fmt, args...);
@@ -85,7 +85,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char* msg)
     if (!should_log(lvl)) return;
     try
     {
-        details::log_msg log_msg(&_name, lvl);
+        details::log_msg log_msg(&_name, lvl, tracer);
         log_msg.raw << msg;
         _sink_it(log_msg);
     }
@@ -101,7 +101,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const T& msg)
     if (!should_log(lvl)) return;
     try
     {
-        details::log_msg log_msg(&_name, lvl);
+        details::log_msg log_msg(&_name, lvl, tracer);
         log_msg.raw << msg;
         _sink_it(log_msg);
     }
@@ -556,5 +556,13 @@ inline void spdlog::logger::_incr_msg_counter(details::log_msg &msg)
 inline const std::vector<spdlog::sink_ptr>& spdlog::logger::sinks() const
 {
     return _sinks;
+}
+
+inline spdlog::logger& spdlog::logger::update_tracer(std::string file, int lineno, std::string func, std::string prettyfunc) {
+    tracer.filename = std::move(file);
+    tracer.lineno = lineno;
+    tracer.func_raw = std::move(func);
+    tracer.func_pretty = std::move(prettyfunc);
+    return *this;
 }
 

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -482,6 +482,56 @@ class full_formatter SPDLOG_FINAL:public flag_formatter
 
 
 
+// short file name
+class shortfilename_formatter SPDLOG_FINAL:public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        const auto &full = msg.tracer.filename;
+        auto it = full.find_last_of('/');
+        auto short_filename = it==std::string::npos ? full : full.substr(it + 1);
+        msg.formatted << short_filename;
+    }
+};
+
+// file name
+class filename_formatter SPDLOG_FINAL:public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        msg.formatted << msg.tracer.filename;
+    }
+};
+
+// line number
+class lineno_formatter SPDLOG_FINAL:public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        msg.formatted << msg.tracer.lineno;
+    }
+};
+
+// function name
+class function_formatter SPDLOG_FINAL:public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        msg.formatted << msg.tracer.func_raw;
+    }
+};
+
+// function pretty name
+class prettyfunction_formatter SPDLOG_FINAL:public flag_formatter
+{
+    void format(details::log_msg& msg, const std::tm&) override
+    {
+        msg.formatted << msg.tracer.func_pretty;
+    }
+};
+
+
+
 }
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -652,6 +702,26 @@ inline void spdlog::pattern_formatter::handle_flag(char flag)
 
     case ('i'):
         _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::i_formatter()));
+        break;
+
+    case ('J'):
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::filename_formatter()));
+        break;
+
+    case ('j'):
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::shortfilename_formatter()));
+        break;
+
+    case ('#'):
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::lineno_formatter()));
+        break;
+
+    case ('u'):
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::function_formatter()));
+        break;
+
+    case ('U'):
+        _formatters.push_back(std::unique_ptr<details::flag_formatter>(new details::prettyfunction_formatter()));
         break;
 
     default: //Unknown flag appears as is

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -107,6 +107,9 @@ public:
     virtual void set_error_handler(log_err_handler);
     virtual log_err_handler error_handler();
 
+    // this method should be called only by preprocessor macros
+    logger& update_tracer(std::string filename, int lineno, std::string function, std::string function_pretty);
+
 protected:
     virtual void _sink_it(details::log_msg&);
     virtual void _set_pattern(const std::string&, pattern_time_type);
@@ -129,6 +132,7 @@ protected:
     log_err_handler _err_handler;
     std::atomic<time_t> _last_err_time;
     std::atomic<size_t> _msg_counter;
+    spdlog::trace_info tracer;
 };
 }
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -155,7 +155,6 @@ void drop_all();
 //
 // Trace & Debug can be switched on/off at compile time for zero cost debug statements.
 // Uncomment SPDLOG_DEBUG_ON/SPDLOG_TRACE_ON in tweakme.h to enable.
-// SPDLOG_TRACE(..) will also print current file and line.
 //
 // Example:
 // spdlog::set_level(spdlog::level::trace);
@@ -165,27 +164,60 @@ void drop_all();
 // SPDLOG_DEBUG_IF(my_logger, true, "some debug message {} {}", 3, 4);
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef SPDLOG_TRACE_ON
-#define SPDLOG_STR_H(x) #x
-#define SPDLOG_STR_HELPER(x) SPDLOG_STR_H(x)
+
 #ifdef _MSC_VER
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
-#define SPDLOG_TRACE_IF(logger, flag, ...) logger->trace_if(flag, "[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
+#define __SPD_PRETTY_FUNCTION__ __FUNCSIG__
 #else
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
-#define SPDLOG_TRACE_IF(logger, flag, ...) logger->trace_if(flag, "[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
+#define __SPD_PRETTY_FUNCTION__ __PRETTY_FUNCTION__
 #endif
+
+
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_TRACE or defined(SPDLOG_TRACE_ON)
+#define SPDLOG_TRACE(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).trace(__VA_ARGS__)
+#define SPDLOG_TRACE_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).trace_if(flag, __VA_ARGS__)
 #else
 #define SPDLOG_TRACE(logger, ...)
 #define SPDLOG_TRACE_IF(logger, flag, ...)
 #endif
 
-#ifdef SPDLOG_DEBUG_ON
-#define SPDLOG_DEBUG(logger, ...) logger->debug(__VA_ARGS__)
-#define SPDLOG_DEBUG_IF(logger, flag, ...) logger->debug_if(flag, __VA_ARGS__)
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_DEBUG or defined(SPDLOG_DEBUG_ON)
+#define SPDLOG_DEBUG(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).debug(__VA_ARGS__)
+#define SPDLOG_DEBUG_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).debug_if(flag, __VA_ARGS__)
 #else
 #define SPDLOG_DEBUG(logger, ...)
 #define SPDLOG_DEBUG_IF(logger, flag, ...)
+#endif
+
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_INFO
+#define SPDLOG_INFO(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).info(__VA_ARGS__)
+#define SPDLOG_INFO_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).info_if(flag, __VA_ARGS__)
+#else
+#define SPDLOG_INFO(logger, ...)
+#define SPDLOG_INFO_IF(logger, flag, ...)
+#endif
+
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_WARNING
+#define SPDLOG_WARN(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).warn(__VA_ARGS__)
+#define SPDLOG_WARN_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).warn_if(flag, __VA_ARGS__)
+#else
+#define SPDLOG_WARN(logger, ...)
+#define SPDLOG_WARN_IF(logger, flag, ...)
+#endif
+
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_ERROR
+#define SPDLOG_ERROR(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).error(__VA_ARGS__)
+#define SPDLOG_ERROR_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).error_if(flag, __VA_ARGS__)
+#else
+#define SPDLOG_ERROR(logger, ...)
+#define SPDLOG_ERROR_IF(logger, flag, ...)
+#endif
+
+#if SPDLOG_MIN_LEVEL <= SPDLOG_LOGLEVEL_CRITICAL
+#define SPDLOG_CRITICAL(logger, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).critical(__VA_ARGS__)
+#define SPDLOG_CRITICAL_IF(logger, flag, ...) logger->update_tracer(__FILE__, __LINE__, __FUNCTION__, __SPD_PRETTY_FUNCTION__).critical_if(flag, __VA_ARGS__)
+#else
+#define SPDLOG_CRITICAL(logger, ...)
+#define SPDLOG_CRITICAL_IF(logger, flag, ...)
 #endif
 
 }

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -54,6 +54,7 @@
 //
 // #define SPDLOG_DEBUG_ON
 // #define SPDLOG_TRACE_ON
+#define SPDLOG_MIN_LEVEL 1 // 1==SPDLOG_LOGLEVEL_DEBUG
 ///////////////////////////////////////////////////////////////////////////////
 
 

--- a/tests/trace.cpp
+++ b/tests/trace.cpp
@@ -1,0 +1,28 @@
+
+#include "includes.h"
+#include <iostream>
+
+template<class T>
+std::string log_deb(const T& what, spdlog::level::level_enum logger_level = spdlog::level::info)
+{
+    std::ostringstream oss;
+    auto oss_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+
+    spdlog::logger oss_logger("oss", oss_sink);
+    oss_logger.set_level(logger_level);
+    oss_logger.set_pattern("%j:%#> %u");
+    SPDLOG_DEBUG((&oss_logger), what);
+
+    return oss.str().substr(0, oss.str().length() - spdlog::details::os::eol_size);
+}
+
+
+TEST_CASE("tracing", "[log_levels2]")
+{
+    REQUIRE(log_deb("Hello", spdlog::level::err) == "");
+    REQUIRE(log_deb("Hello", spdlog::level::critical) == "");
+    REQUIRE(log_deb("Hello", spdlog::level::info) == "");
+    REQUIRE(log_deb("Hello", spdlog::level::debug) == "trace.cpp:14> log_deb");
+    REQUIRE(log_deb("Hello", spdlog::level::trace) == "trace.cpp:14> log_deb");
+}
+


### PR DESCRIPTION
This pull request is proof of concept, not finished work. I want to know if you are interested in changes like this - I may then finish it. It possibly solves #340 and #476 

This commit adds additional symbols to pattern that allow logging:
- file name (as in __LINE__ or just last part of path)
- line number
- function name (as either __FUNCTION__ or __PRETTY_FUNCTION__

To use it, user must 
1. set pattern, eg. "%u @ %j:%#> %v" is equivalent to message "__FUNCTION__ @ __FILE__:__LINE__> %v"
2. for given logger use exclusively macro invocations (SPDLOG_DEBUG)
(see example in tests/trace.cpp)

Implementation:
spdlog::trace_info struct keeps data when given log line was created. It is updated in spdlog::logger by macros. Logger copies this data to log_msg. 
I don't like the way I keep this data in logger, but I don't see way around it without duplicating whole api (suggestions?)

Downsides:
- if user uses non-macro invocation (logger->debug(...)) AND has one of new symbols in pattern, then logged message will be wrong (either empty or pointing to location where last macro was used)
- every log_msg object is a little bigger (sizeof(int) + 3 std::strings), even if pattern doesn't use this data

Further work needed:
- currently this is implemented for SPDLOG_DEBUG and _TRACE. Macros for all log levels are necessary. Is there good reason why those 2 macros are optional and disabled by default in tweakme?
- perhaps it wolud be good to make this whole feature optional in tweakme.

So, would you like me to continue work on this? Any suggestions are welcome.