### PR TITLE
Don't allow log file handle child process inheritance in Windows

### DIFF
--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -48,7 +48,7 @@ public:
     {
 
         close();
-        auto *mode = truncate ? SPDLOG_FILENAME_T("wb") : SPDLOG_FILENAME_T("ab");
+        auto *mode = truncate ? SPDLOG_TRUNCATE_MODE : SPDLOG_APPEND_MODE;
         _filename = fname;
         for (int tries = 0; tries < open_tries; ++tries)
         {

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -366,6 +366,8 @@ inline size_t thread_id()
 // wchar support for windows file names (SPDLOG_WCHAR_FILENAMES must be defined)
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 #define SPDLOG_FILENAME_T(s) L ## s
+#define SPDLOG_TRUNCATE_MODE SPDLOG_FILENAME_T("wbN")
+#define SPDLOG_APPEND_MODE SPDLOG_FILENAME_T("abN")
 inline std::string filename_to_str(const filename_t& filename)
 {
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> c;
@@ -373,6 +375,8 @@ inline std::string filename_to_str(const filename_t& filename)
 }
 #else
 #define SPDLOG_FILENAME_T(s) s
+#define SPDLOG_TRUNCATE_MODE SPDLOG_FILENAME_T("wb")
+#define SPDLOG_APPEND_MODE SPDLOG_FILENAME_T("ab")
 inline std::string filename_to_str(const filename_t& filename)
 {
     return filename;


### PR DESCRIPTION
Hi!

We started using spdlog in VS Code for a fast logging experience. It has been working great so far.

We did find an issue on Windows in which log file handles were being inherited by child processes https://github.com/Microsoft/vscode/issues/39659. This is problematic if we assume the file handle is released once we drop the logger, since the child processes will still have open handles to the log files. Once we attempt to instantiate a new logger on that same file path, we would get an exception after the 5 `f_fopen_s` attempts.

Our fix for this is to use the `N` mode character on Windows when opening the file. [This prevents file handle inheritance by child processes](https://msdn.microsoft.com/en-us/library/z5hh6ee9.aspx#Unicode%20support):

> N
> Specifies that the file is not inherited by child processes.

We assume that this is the desired behavior anyway in Windows.

cc @sandy081