### PR TITLE
Dirty fix for Intel compiler compatibility.

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -359,8 +359,8 @@ inline size_t thread_id()
 #if defined(SPDLOG_DISABLE_TID_CACHING) || (defined(_MSC_VER) && (_MSC_VER < 1900)) || (defined(__clang__) && !__has_feature(cxx_thread_local))
     return _thread_id();
 #else // cache thread id in tls
-    static thread_local const size_t tid = _thread_id();
-    return tid;
+    static thread_local const size_t cached_tid = _thread_id();
+    return cached_tid;
 #endif
 
 

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -350,7 +350,11 @@ inline size_t _thread_id()
 }
 
 //Return current thread id as size_t (from thread local storage)
+#ifdef __INTEL_COMPILER
+size_t thread_id()
+#else
 inline size_t thread_id()
+#endif
 {
 #if defined(SPDLOG_DISABLE_TID_CACHING) || (defined(_MSC_VER) && (_MSC_VER < 1900)) || (defined(__clang__) && !__has_feature(cxx_thread_local))
     return _thread_id();


### PR DESCRIPTION
Intel compiler seems to have slightly different behavior when it comes to handling symbols that reference TLS members than what os.h expects. This is by no means a pretty fix, but more of a quick fix to fail compiling entirely when building against the Intel compiler on macOS.