### PR TITLE
Fixed bug in SPDLOG_TRACE macro when passing a variable for fmt

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -172,15 +172,15 @@ do { res = (char*) malloc((strlen(str1)+strlen(str2)+1)*sizeof(char)); strcpy(re
 #ifdef _MSC_VER
 #define SPDLOG_TRACE(logger, fmt, ...) \
 do { \
-    char* c; SPDLOG_CONCAT_STR("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] ", fmt, c); \
-    logger->trace(c, ##__VA_ARGS__); \
+    char* s; SPDLOG_CONCAT_STR("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] ", fmt, s); \
+    logger->trace(s, ##__VA_ARGS__); \
 } \
 while(0)
 #else
 #define SPDLOG_TRACE(logger, fmt, ...) \
 do { \
-    char* c; SPDLOG_CONCAT_STR("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] ", fmt, c); \
-    logger->trace(c, ##__VA_ARGS__); \
+    char* s; SPDLOG_CONCAT_STR("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] ", fmt, s); \
+    logger->trace(s, ##__VA_ARGS__); \
 } \
 while(0)
 #endif

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -167,10 +167,22 @@ void drop_all();
 #ifdef SPDLOG_TRACE_ON
 #define SPDLOG_STR_H(x) #x
 #define SPDLOG_STR_HELPER(x) SPDLOG_STR_H(x)
+#define SPDLOG_CONCAT_STR(str1, str2, res) \
+do { res = (char*) malloc((strlen(str1)+strlen(str2)+1)*sizeof(char)); strcpy(res, str1); strcat(res, str2);} while(0)
 #ifdef _MSC_VER
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
+#define SPDLOG_TRACE(logger, fmt, ...) \
+do { \
+    char* c; SPDLOG_CONCAT_STR("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] ", fmt, c); \
+    logger->trace(c, ##__VA_ARGS__); \
+} \
+while(0)
 #else
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
+#define SPDLOG_TRACE(logger, fmt, ...) \
+do { \
+    char* c; SPDLOG_CONCAT_STR("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] ", fmt, c); \
+    logger->trace(c, ##__VA_ARGS__); \
+} \
+while(0)
 #endif
 #else
 #define SPDLOG_TRACE(logger, ...)


### PR DESCRIPTION
Fixes #529

Proposed solution: concatenate file/line information and fmt before logging