### PR TITLE
feature/version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ example/*
 
 # generated files
 generated
+include/spdlog/version.h
 
 # Cmake
 CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,12 @@ endif()
 #---------------------------------------------------------------------------------------
 # spdlog target
 #---------------------------------------------------------------------------------------
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/spdlog/version.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/spdlog/version.h
+    @ONLY
+)
+
 add_library(spdlog INTERFACE)
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ install(
 install(
     DIRECTORY "${HEADER_BASE}/${PROJECT_NAME}"
     DESTINATION "${include_install_dir}"
+    FILES_MATCHING PATTERN "*.h"
 )
 
 # install project version file

--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -12,6 +12,9 @@
 #include <memory>
 #include <string>
 #include <thread>
+
+#define SPDLOG_BENCH_ON
+
 #include "spdlog/spdlog.h"
 #include "spdlog/async_logger.h"
 #include "spdlog/sinks/file_sinks.h"

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#if !defined(SPDLOG_DEBUG_ON) and !defined(SPDLOG_BENCH_ON)
 #include "version.h"
+#endif
 
 #include "tweakme.h"
 #include "common.h"

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#define SPDLOG_VERSION "0.16.1"
+#include "version.h"
 
 #include "tweakme.h"
 #include "common.h"

--- a/include/spdlog/version.h.in
+++ b/include/spdlog/version.h.in
@@ -1,0 +1,9 @@
+/*
+ * Auto-generated source code file for 'spdlog'.
+ * See main CMake project file variables if you need to modify the original.
+ */
+
+#pragma once
+
+#define SPDLOG_VERSION "@PROJECT_VERSION@"
+


### PR DESCRIPTION
We can generate version file from CMake project file. This reduce version string location to one place i.e. main CMake file.

In future, we can improve it so it will handle git hash etc. for non-tagged build etc.