### PR TITLE
Issue fix for spdlog #595. Conversion warning.

### DIFF
--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -82,7 +82,7 @@ private:
         GetConsoleScreenBufferInfo(out_handle_, &orig_buffer_info);
         WORD back_color = orig_buffer_info.wAttributes;
         // retrieve the current background color
-        back_color &= ~(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+        back_color &= static_cast<WORD>(~(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY));
         // keep the background color unchanged
         SetConsoleTextAttribute(out_handle_, attribs | back_color);
         return  orig_buffer_info.wAttributes; //return orig attribs


### PR DESCRIPTION
See: https://github.com/gabime/spdlog/issues/595

On line 85 in file sinks/wincolor_sink.h:
```
back_color &= ~(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE |
FOREGROUND_INTENSITY);
```

'back_color' is of type 'WORD' (unsigned short) whereas a bitwise
complement/NOT returns an int. This results in a conversion warning with
-Wconversion enabled.

```
85:20: warning: conversion to 'WORD {aka short unsigned int}' from 'int'
may alter its value [-Wconversion] back_color &= ~(FOREGROUND_RED |
FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY);
```

Possible solution:
We know that the result of ~(FOREGROUND_RED | FOREGROUND_GREEN |
FOREGROUND_BLUE | FOREGROUND_INTENSITY) is always within the limits of
an unsigned short so a simple cast should suffice (correct me if I'm
wrong):

```
back_color &= static_cast<WORD>(~(FOREGROUND_RED |
FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY));
```