### PR TITLE
Ensure marcos always expand to expressions

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -165,24 +165,23 @@ void drop_all();
 ///////////////////////////////////////////////////////////////////////////////
 
 #ifdef SPDLOG_TRACE_ON
-#define SPDLOG_STR_H(x) #x
-#define SPDLOG_STR_HELPER(x) SPDLOG_STR_H(x)
-#ifdef _MSC_VER
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
+#  define SPDLOG_STR_H(x) #x
+#  define SPDLOG_STR_HELPER(x) SPDLOG_STR_H(x)
+#  ifdef _MSC_VER
+#    define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ "(" SPDLOG_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
+#  else
+#    define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
+#  endif
 #else
-#define SPDLOG_TRACE(logger, ...) logger->trace("[ " __FILE__ ":" SPDLOG_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
-#endif
-#else
-#define SPDLOG_TRACE(logger, ...)
+#  define SPDLOG_TRACE(logger, ...) (void)0
 #endif
 
 #ifdef SPDLOG_DEBUG_ON
-#define SPDLOG_DEBUG(logger, ...) logger->debug(__VA_ARGS__)
+#  define SPDLOG_DEBUG(logger, ...) logger->debug(__VA_ARGS__)
 #else
-#define SPDLOG_DEBUG(logger, ...)
+#  define SPDLOG_DEBUG(logger, ...) (void)0
 #endif
 
 }
-
 
 #include "details/spdlog_impl.h"


### PR DESCRIPTION
Currently, the `SPDLOG_TRACE` and `SPDLOG_DEBUG` expand to nothing if they are disabled, but this can lead to problems. `assert` expands to `(void)0` when `NDEBUG` is defined, so I use the same here.

A couple of possible problems that could happen with the current definitions:

This is valid when `SPDLOG_DEBUG_ON` is defined, but expands to `,;` (which is an error) if not:
```
SPDLOG_DEBUG(logger, "x = {}", x), SDPLOG_DEBUG(logger, "y = {}", y);
```

If `SPDLOG_DEBUG_ON` is defined, this is a compilation error, but if not defined then then if statement actually catches the assignment to `b`:
```
bool b;
if (b)
    SPDLOG_DEBUG(logger, "b was true")
b = false;
````