### PR TITLE
Add global flush_on function

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -64,6 +64,7 @@ public:
             new_logger->set_error_handler(_err_handler);
 
         new_logger->set_level(_level);
+        new_logger->flush_on(_flush_level);
 
 
         //Add to registry
@@ -85,6 +86,7 @@ public:
             new_logger->set_error_handler(_err_handler);
 
         new_logger->set_level(_level);
+        new_logger->flush_on(_flush_level);
 
         //Add to registry
         _loggers[logger_name] = new_logger;
@@ -153,6 +155,14 @@ public:
         _level = log_level;
     }
 
+    void flush_on(level::level_enum log_level)
+    {
+        std::lock_guard<Mutex> lock(_mutex);
+        for (auto& l : _loggers)
+            l.second->flush_on(log_level);
+        _flush_level = log_level;
+    }
+
     void set_error_handler(log_err_handler handler)
     {
         for (auto& l : _loggers)
@@ -197,6 +207,7 @@ private:
     std::unordered_map <std::string, std::shared_ptr<logger>> _loggers;
     formatter_ptr _formatter;
     level::level_enum _level = level::info;
+    level::level_enum _flush_level = level::off;
     log_err_handler _err_handler;
     bool _async_mode = false;
     size_t _async_q_size = 0;

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -236,6 +236,11 @@ inline void spdlog::set_level(level::level_enum log_level)
     return details::registry::instance().set_level(log_level);
 }
 
+inline void spdlog::flush_on(level::level_enum log_level)
+{
+    return details::registry::instance().flush_on(log_level);
+}
+
 inline void spdlog::set_error_handler(log_err_handler handler)
 {
     return details::registry::instance().set_error_handler(handler);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -36,9 +36,14 @@ void set_pattern(const std::string& format_string);
 void set_formatter(formatter_ptr f);
 
 //
-// Set global logging level for
+// Set global logging level
 //
 void set_level(level::level_enum log_level);
+
+//
+// Set global flush level
+//
+void flush_on(level::level_enum log_level);
 
 //
 // Set global error handler


### PR DESCRIPTION
This provides a way to set the flush level for all loggers. It replicates the interface and implementation of the `set_level` free function.

I set the default flush level to `off`, which is what `logger_impl` defaults to, so there should be no change of behavior.