### PR TITLE
A few small ANSI color improvements

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -49,7 +49,7 @@ public:
     }
 
     /// Formatting codes
-    const std::string reset = "\033[00m";
+    const std::string reset = "\033[m";
     const std::string bold = "\033[1m";
     const std::string dark = "\033[2m";
     const std::string underline = "\033[4m";

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -56,6 +56,7 @@ public:
     const std::string blink = "\033[5m";
     const std::string reverse = "\033[7m";
     const std::string concealed = "\033[8m";
+    const std::string clear_line = "\033[K";
 
     // Foreground colors
     const std::string black = "\033[30m";
@@ -88,6 +89,7 @@ protected:
             fwrite(prefix.data(), sizeof(char), prefix.size(), target_file_);
             fwrite(msg.formatted.data(), sizeof(char), msg.formatted.size(), target_file_);
             fwrite(reset.data(), sizeof(char), reset.size(), target_file_);
+            fwrite(clear_line.data(), sizeof(char), clear_line.size(), target_file_);
         }
         else
         {

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -58,7 +58,7 @@ public:
     const std::string concealed = "\033[8m";
 
     // Foreground colors
-    const std::string grey = "\033[30m";
+    const std::string black = "\033[30m";
     const std::string red = "\033[31m";
     const std::string green = "\033[32m";
     const std::string yellow = "\033[33m";
@@ -68,7 +68,7 @@ public:
     const std::string white = "\033[37m";
 
     /// Background colors
-    const std::string on_grey = "\033[40m";
+    const std::string on_black = "\033[40m";
     const std::string on_red = "\033[41m";
     const std::string on_green = "\033[42m";
     const std::string on_yellow = "\033[43m";


### PR DESCRIPTION
Hey there 👋 

This PR does the following:

- Renames `gray` to `black` as it is more accurate (`30m` is officially specified as "black")
- Removes needless zeros from the `reset` code
- Clears the line after writing a log message, which fixes `->critical()` log messages bleeding their background color onto the new line. This is because the log messages have the newline _before_ the reset code, thus forcing most xterm-compliant emulators to paint the entire next line red before writing the next log message.

Before:
<img alt="image" src="https://user-images.githubusercontent.com/885648/35101886-6b9ad60e-fc61-11e7-9de8-c88ca45a1cf4.png">

After:
<img alt="image" src="https://user-images.githubusercontent.com/885648/35101908-86737382-fc61-11e7-9819-6dcfec978c70.png">


