### PR TITLE
New function to convert level_enum from string

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -51,6 +51,9 @@ namespace spdlog
 
 class formatter;
 
+template<class T, size_t N>
+constexpr size_t size(T(&)[N]) { return N; }
+
 namespace sinks
 {
 class sink;
@@ -98,6 +101,18 @@ inline const char* to_short_str(spdlog::level::level_enum l)
 {
     return short_level_names[l];
 }
+inline spdlog::level::level_enum to_level_enum(const char* name)
+{
+	for (size_t level = 0; level < size(level_names); level++)
+	{
+		if (!strcmp(level_names[level], name))
+		{
+			return (spdlog::level::level_enum) level;
+		}
+	}
+	return (spdlog::level::level_enum) 0;
+}
+
 } //level
 
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -56,9 +56,6 @@ namespace spdlog
 
 class formatter;
 
-template<class T, size_t N>
-constexpr size_t size(T(&)[N]) { return N; }
-
 namespace sinks
 {
 class sink;

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -87,16 +87,6 @@ enum level_enum
     off = 6
 };
 
-static std::unordered_map<std::string, level_enum> name_to_level = {
-                                                                        { "trace"   , level::trace },
-                                                                        { "debug"   , level::debug },
-                                                                        { "info"    , level::info },
-                                                                        { "warning" , level::warn },
-                                                                        { "error"   , level::err },
-                                                                        { "critical", level::critical },
-                                                                        { "off"     , level::off }
-                                                                   };
-
 
 #if !defined(SPDLOG_LEVEL_NAMES)
 #define SPDLOG_LEVEL_NAMES { "trace", "debug", "info", "warning", "error", "critical", "off" }
@@ -116,6 +106,15 @@ inline const char* to_short_str(spdlog::level::level_enum l)
 }
 inline spdlog::level::level_enum to_level_enum(const std::string& name)
 {
+    static std::unordered_map<std::string, level_enum> name_to_level = {
+                                                                            { level_names[0], level::trace },
+                                                                            { level_names[1], level::debug },
+                                                                            { level_names[2], level::info },
+                                                                            { level_names[3], level::warn },
+                                                                            { level_names[4], level::err },
+                                                                            { level_names[5], level::critical },
+                                                                            { level_names[6], level::off }
+                                                                       };
     auto ci = name_to_level.find(name);
     if (ci != name_to_level.end())
     {

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -15,7 +15,8 @@
 #include <memory>
 #include <atomic>
 #include <exception>
-#include<functional>
+#include <functional>
+#include <unordered_map>
 
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 #include <codecvt>
@@ -89,6 +90,17 @@ enum level_enum
     off = 6
 };
 
+static std::unordered_map<std::string, level_enum> name_to_level = {
+                                                                        { "trace"   , level::trace },
+                                                                        { "debug"   , level::debug },
+                                                                        { "info"    , level::info },
+                                                                        { "warning" , level::warn },
+                                                                        { "error"   , level::err },
+                                                                        { "critical", level::critical },
+                                                                        { "off"     , level::off }
+                                                                   };
+
+
 #if !defined(SPDLOG_LEVEL_NAMES)
 #define SPDLOG_LEVEL_NAMES { "trace", "debug", "info", "warning", "error", "critical", "off" }
 #endif
@@ -105,17 +117,19 @@ inline const char* to_short_str(spdlog::level::level_enum l)
 {
     return short_level_names[l];
 }
-inline spdlog::level::level_enum to_level_enum(const char* name)
+inline spdlog::level::level_enum to_level_enum(const std::string& name)
 {
-	for (size_t level = 0; level < size(level_names); level++)
-	{
-		if (!strcmp(level_names[level], name))
-		{
-			return (spdlog::level::level_enum) level;
-		}
-	}
-	return (spdlog::level::level_enum) 0;
+    auto ci = name_to_level.find(name);
+    if (ci != name_to_level.end())
+    {
+        return ci->second;
+    }
+    else
+    {
+        return level::off;
+    }
 }
+
 using level_hasher = std::hash<int>;
 } //level
 

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -42,6 +42,39 @@ TEST_CASE("log_levels", "[log_levels]")
     REQUIRE(log_info("Hello", spdlog::level::trace) == "Hello");
 }
 
+TEST_CASE("to_str", "[convert_to_str]")
+{
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::trace)) == "trace");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::debug)) == "debug");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::info)) == "info");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::warn)) == "warning");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::err)) == "error");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::critical)) == "critical");
+    REQUIRE(std::string(spdlog::level::to_str(spdlog::level::off)) == "off");
+}
+
+TEST_CASE("to_short_str", "[convert_to_short_str]")
+{
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::trace)) == "T");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::debug)) == "D");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::info)) == "I");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::warn)) == "W");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::err)) == "E");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::critical)) == "C");
+    REQUIRE(std::string(spdlog::level::to_short_str(spdlog::level::off)) == "O");
+}
+
+TEST_CASE("to_level_enum", "[convert_to_level_enum]")
+{
+    REQUIRE(spdlog::level::to_level_enum("trace") == spdlog::level::trace);
+    REQUIRE(spdlog::level::to_level_enum("debug") == spdlog::level::debug);
+    REQUIRE(spdlog::level::to_level_enum("info") == spdlog::level::info);
+    REQUIRE(spdlog::level::to_level_enum("warning") == spdlog::level::warn);
+    REQUIRE(spdlog::level::to_level_enum("error") == spdlog::level::err);
+    REQUIRE(spdlog::level::to_level_enum("critical") == spdlog::level::critical);
+    REQUIRE(spdlog::level::to_level_enum("off") == spdlog::level::off);
+    REQUIRE(spdlog::level::to_level_enum("null") == spdlog::level::off);
+}
 
 
 


### PR DESCRIPTION
## Requeriment
Configure log level using name. (trace, debug, info...)

## Solution
Creation a new function to convert level_enum from string  - **to_level_enum(const char*)** 

## Example
``` cpp
spdlog::level::level_enum lvl = spdlog::level::to_level_enum("debug");
```