### PR TITLE
Support for custom EOL per formatter

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -350,7 +350,7 @@ inline void spdlog::logger::_default_err_handler(const std::string &msg)
     char date_buf[100];
     std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", &tm_time);
     details::log_msg  err_msg;
-    err_msg.formatted.write("[*** LOG ERROR ***] [{}] [{}] [{}]{}", name(), msg, date_buf, details::os::eol);
+    err_msg.formatted.write("[*** LOG ERROR ***] [{}] [{}] [{}]{}", name(), msg, date_buf, details::os::default_eol);
     sinks::stderr_sink_mt::instance()->log(err_msg);
     _last_err_time = now;
 }

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -140,8 +140,7 @@ inline bool operator!=(const std::tm& tm1, const std::tm& tm2)
 #endif
 #endif
 
-SPDLOG_CONSTEXPR static const char* eol = SPDLOG_EOL;
-SPDLOG_CONSTEXPR static int eol_size = sizeof(SPDLOG_EOL) - 1;
+SPDLOG_CONSTEXPR static const char* default_eol = SPDLOG_EOL;
 
 
 

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -487,8 +487,8 @@ class full_formatter SPDLOG_FINAL:public flag_formatter
 ///////////////////////////////////////////////////////////////////////////////
 // pattern_formatter inline impl
 ///////////////////////////////////////////////////////////////////////////////
-inline spdlog::pattern_formatter::pattern_formatter(const std::string& pattern, pattern_time_type pattern_time)
-    : _pattern_time(pattern_time)
+inline spdlog::pattern_formatter::pattern_formatter(const std::string& pattern, pattern_time_type pattern_time, std::string eol)
+    : _eol(move(eol)), _pattern_time(pattern_time)
 {
     compile_pattern(pattern);
 }
@@ -682,5 +682,5 @@ inline void spdlog::pattern_formatter::format(details::log_msg& msg)
         f->format(msg, tm_time);
     }
     //write eol
-    msg.formatted.write(details::os::eol, details::os::eol_size);
+    msg.formatted.write(_eol.data(), _eol.size());
 }

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -29,11 +29,12 @@ class pattern_formatter SPDLOG_FINAL : public formatter
 {
 
 public:
-    explicit pattern_formatter(const std::string& pattern, pattern_time_type pattern_time = pattern_time_type::local);
+    explicit pattern_formatter(const std::string& pattern, pattern_time_type pattern_time = pattern_time_type::local, const std::string eol = spdlog::details::os::default_eol);
     pattern_formatter(const pattern_formatter&) = delete;
     pattern_formatter& operator=(const pattern_formatter&) = delete;
     void format(details::log_msg& msg) override;
 private:
+    const std::string _eol;
     const std::string _pattern;
     const pattern_time_type _pattern_time;
     std::vector<std::unique_ptr<details::flag_formatter>> _formatters;

--- a/tests/format.cpp
+++ b/tests/format.cpp
@@ -13,7 +13,7 @@ std::string log_info(const T& what, spdlog::level::level_enum logger_level = spd
     oss_logger.set_pattern("%v");
     oss_logger.info(what);
 
-    return oss.str().substr(0, oss.str().length() - spdlog::details::os::eol_size);
+    return oss.str().substr(0, oss.str().length() - strlen(spdlog::details::os::default_eol));
 }
 
 


### PR DESCRIPTION
Allow users to specify a custom EOL per pattern formatter. This will still use the system default if unspecified. Test cases pass.