### PR TITLE
Make set_color public in wincolor_sink to retain configurability

### DIFF
--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -50,6 +50,13 @@ public:
     wincolor_sink(const wincolor_sink& other) = delete;
     wincolor_sink& operator=(const wincolor_sink& other) = delete;
 
+    // change the  color for the given level
+    void set_color(level::level_enum level, WORD color)
+    {
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
+        colors_[level] = color;
+    }
+
 protected:
     virtual void _sink_it(const details::log_msg& msg) override
     {
@@ -62,13 +69,6 @@ protected:
     virtual void _flush() override
     {
         // windows console always flushed?
-    }
-
-    // change the  color for the given level
-    void set_color(level::level_enum level, WORD color)
-    {
-        std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
-        colors_[level] = color;
     }
 
 private:


### PR DESCRIPTION
For our application, we need to possibility to configure the defaul colors for the wincolor sink. Instead of forking the entire class, I think it makes more sense to keep this function public. 

The history seems to indicate that it was not made protected on purpose