### PR TITLE
Fix compilation error with GCC 8

### DIFF
--- a/include/spdlog/sinks/file_sinks.h
+++ b/include/spdlog/sinks/file_sinks.h
@@ -81,7 +81,7 @@ public:
     // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
     static filename_t calc_filename(const filename_t& filename, std::size_t index)
     {
-        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
+        typename std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
         if (index)
         {
             filename_t basename, ext;


### PR DESCRIPTION
Fix compilation error with GCC 8.0.1 

```
error: need 'typename' before 'std::conditional<std::is_same<char, char>::value, fmt::BasicMemoryWriter<char>, fmt::BasicMemoryWriter<wchar_t> >::type' because 'std::conditional<std::is_same<char, char>::value, fmt::BasicMemoryWriter<char>, fmt::BasicMemoryWriter<wchar_t> >' is a dependent scope
         std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
```