### PR TITLE
CMake explicit language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 cmake_minimum_required(VERSION 3.1)
-project(spdlog VERSION 0.16.3)
+project(spdlog VERSION 0.16.3 LANGUAGES CXX)
 include(CTest)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
@@ -73,7 +73,6 @@ configure_file("cmake/spdlog.pc.in" "${pkg_config}" @ONLY)
 install(
     TARGETS spdlog
     EXPORT "${targets_export_name}"
-    INCLUDES DESTINATION "${include_install_dir}"
 )
 
 # install headers

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,7 @@
 # *************************************************************************/
 
 cmake_minimum_required(VERSION 3.0)
-project(SpdlogExamples)
+project(SpdlogExamples CXX)
 
 if(TARGET spdlog)
   # Part of the main project

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -21,7 +21,7 @@
 # * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 # *************************************************************************/
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(SpdlogExamples CXX)
 
 if(TARGET spdlog)
@@ -32,16 +32,16 @@ else()
   find_package(spdlog CONFIG REQUIRED)
 endif()
 
-find_package(Threads)
+find_package(Threads REQUIRED)
 
 add_executable(example example.cpp)
-target_link_libraries(example spdlog::spdlog ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(example spdlog::spdlog Threads::Threads)
 
 add_executable(benchmark bench.cpp)
-target_link_libraries(benchmark spdlog::spdlog ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(benchmark spdlog::spdlog Threads::Threads)
 
 add_executable(multisink multisink.cpp)
-target_link_libraries(multisink spdlog::spdlog ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(multisink spdlog::spdlog Threads::Threads)
 
 enable_testing()
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(spdlog-utests)
+project(spdlog-utests CXX)
 
 enable_testing()
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Hey, a few changes to cmake files.

Marking project as CXX will disable detecting C compiler and other C related checks.

'INCLUDES DESTINATION' adds paths to 'INTERFACE_INCLUDE_DIRECTORIES' which is where include paths already are in spdlog target.

Bumped example's cmake version to 3.1.

Both test and example CMakeLists were using CRLF, changed to LF to match other source files.