### PR TITLE
Fix indentation in tests/catch.hpp:2916

### DIFF
--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -2913,7 +2913,7 @@ namespace Catch {
                 for( std::vector<Ptr<Pattern> >::const_iterator it = m_patterns.begin(), itEnd = m_patterns.end(); it != itEnd; ++it )
                     if( !(*it)->matches( testCase ) )
                         return false;
-                    return true;
+                return true;
             }
         };
 


### PR DESCRIPTION
Compiling with -Wmisleading-indentation triggers warning:
/data/Git/spdlog/tests/catch.hpp: In member function ‘bool Catch::TestSpec::Filter::matches(const Catch::TestCaseInfo&) const’:
/data/Git/spdlog/tests/catch.hpp:2913:17: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
                 for( std::vector<Ptr<Pattern> >::const_iterator it = m_patterns.begin(), itEnd = m_patterns.end(); it != itEnd; ++it )
                 ^~~
/data/Git/spdlog/tests/catch.hpp:2916:21: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
                     return true;
                     ^~~~~~