### PR TITLE
Don't use fstat64 when _LARGEFILE_SOURCE is defined

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -248,7 +248,7 @@ inline size_t filesize(FILE *f)
 #else // unix
     int fd = fileno(f);
     //64 bits(but not in osx or cygwin, where fstat64 is deprecated)
-#if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
+#if !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(_LARGEFILE_SOURCE) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
     struct stat64 st ;
     if (fstat64(fd, &st) == 0)
         return static_cast<size_t>(st.st_size);


### PR DESCRIPTION
Using fstat64 on ancient distributions like RHEL5 causes errors because
fstat64 is declared inline, but there's no definition. Modern compilers
don't like that without the -fgnu89-inline flag.

> gcc-4.9.4/lib/gcc/x86_64-unknown-linux-gnu/4.9.4/include-fixed/sys/stat.h:255:16: error: inline function 'int fstat64(int, stat64*)' used but never defined
> __inline__ int fstat64 (int __fd, struct stat64 *__buf) __THROW __nonnull ((2)); 