### PR TITLE
Improve async flush

### DIFF
--- a/include/spdlog/details/mpmc_bounded_q.h
+++ b/include/spdlog/details/mpmc_bounded_q.h
@@ -144,6 +144,13 @@ public:
         return true;
     }
 
+#if __cplusplus >= 201402L
+    [[deprecated("introduces data race")]]
+#elif defined(__clang__) || defined(__GNUC__)
+    __attribute__((deprecated("introduces data race")))
+#elif defined(_MSC_VER)
+    __declspec(deprecated("introduces data race"))
+#endif
     bool is_empty()
     {
         size_t front, front1, back;
@@ -155,6 +162,16 @@ public:
             front1 = enqueue_pos_.load(std::memory_order_relaxed);
         } while (front != front1);
         return back == front;
+    }
+
+    auto enqueue_pos(std::memory_order memory_order = std::memory_order_seq_cst) const -> size_t
+    {
+        return enqueue_pos_.load(memory_order);
+    }
+
+    auto dequeue_pos(std::memory_order memory_order = std::memory_order_seq_cst) const -> size_t
+    {
+        return dequeue_pos_.load(memory_order);
     }
 
 private:


### PR DESCRIPTION
Using flush with an async logger is problematic, because the call can hang forever. This is due to the fact that flush waits for the queue to be empty, instead of waiting for just the messages in the queue at the time of the call to flush to be removed. If there is a logger on another thread writing to the queue faster than messages are being pulled off, the call to flush will never return.

This is particularly problematic because most code cannot know if a reference to a `spdlog::logger` is an async logger or not (it depends if `set_async_mode` was called). If a call to flush can cause deadlock if the logger is async and if there is no way to know (short of a `dynamic_cast`), then it is never safe to call flush on a logger reference.

The expectation for a call to flush is not "block until no messages are waiting to be written"; it's "block until all the messages currently on the queue are written". This change does that: instead of blocking until the queue is empty, it blocks until the dequeue position catches up to what the enqueue position was when flush was called.

As long as messages are being pulled off the queue, this guarantees that flush will eventually exit.

A few notes about the implementation:

- The waiting logic checks if `write_pos > read_pos` before setting `last_op`, which can save a call to `now` if no waiting is necessary. This should be slightly more efficient when the queue is already empty.

- This adds two accessors to the queue class, which is not ideal but better than making async_log_helper a friend class.

- Since `wait_empty_q` was private and only used in the flush method, I removed it.

- The queue function `is_empty` introduces a race condition and shouldn't be used, so I marked it as deprecated. It's not used anywhere in the spdlog project, but it's public, so it didn't seem wise to just delete it, as another project might be using it. The race condition in `is_empty` could lead to `is_empty` never returning true, even though the queue is empty at points in time.

For example:
thread 1 calls `is_empty` and reads `front = front1 = 1` and `back = 0`. `is_empty` returns false;
thread 2 pulls off a message, so now `dequeue_pos_` (aka `back`) is `1`. The queue is empty
thread 3 pushes a new message on to the queue, so now `enqueue_pos_` (aka `front`) is 2
thread 1 calls `is_empty` again and reads `front = front2 = 2` and `back = 1`. `is_empty` returns false

So a thread waiting on `is_empty` might do so forever, even though the queue is empty at several points in time. Even if it doesn't wait forever, it will end up waiting significantly longer than it likely wants to.