### PR TITLE
Silence warning "value stored to rv is never read"

### DIFF
--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -8,6 +8,7 @@ void prepare_logdir()
     system("del /F /Q logs\\*");
 #else
     auto rv = system("mkdir -p logs");
+    (void)rv;
     rv = system("rm -f logs/*");
     (void)rv;
 #endif


### PR DESCRIPTION
Otherwise clang's static analyzer gives me the following warning:

```
spdlog-0.16.3/tests/utils.cpp:11:10: warning: Value stored to 'rv' during its initialization is never read
    auto rv = system("mkdir -p logs");
         ^~   ~~~~~~~~~~~~~~~~~~~~~~~
```