### PR TITLE
Add allocator support

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -33,19 +33,19 @@ class async_logger SPDLOG_FINAL : public logger
 {
 public:
     template<class It>
-    async_logger(const std::string &logger_name, const It &begin, const It &end, size_t queue_size,
+    async_logger(const string &logger_name, const It &begin, const It &end, size_t queue_size,
         const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
         const std::function<void()> &worker_warmup_cb = nullptr,
         const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
         const std::function<void()> &worker_teardown_cb = nullptr);
 
-    async_logger(const std::string &logger_name, sinks_init_list sinks, size_t queue_size,
+    async_logger(const string &logger_name, sinks_init_list sinks, size_t queue_size,
         const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
         const std::function<void()> &worker_warmup_cb = nullptr,
         const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
         const std::function<void()> &worker_teardown_cb = nullptr);
 
-    async_logger(const std::string &logger_name, sink_ptr single_sink, size_t queue_size,
+    async_logger(const string &logger_name, sink_ptr single_sink, size_t queue_size,
         const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
         const std::function<void()> &worker_warmup_cb = nullptr,
         const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
@@ -62,10 +62,10 @@ public:
 protected:
     void _sink_it(details::log_msg &msg) override;
     void _set_formatter(spdlog::formatter_ptr msg_formatter) override;
-    void _set_pattern(const std::string &pattern, pattern_time_type pattern_time) override;
+    void _set_pattern(const string &pattern, pattern_time_type pattern_time) override;
 
 private:
-    std::unique_ptr<details::async_log_helper> _async_log_helper;
+    unique_ptr<details::async_log_helper> _async_log_helper;
 };
 } // namespace spdlog
 

--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -44,11 +44,11 @@ class async_log_helper
 
     struct async_msg
     {
-        std::string logger_name;
+        string logger_name;
         level::level_enum level;
         log_clock::time_point time;
         size_t thread_id;
-        std::string txt;
+        string txt;
         async_msg_type msg_type;
         size_t msg_id;
 
@@ -121,7 +121,7 @@ public:
 
     using clock = std::chrono::steady_clock;
 
-    async_log_helper(formatter_ptr formatter, std::vector<sink_ptr> sinks, size_t queue_size, const log_err_handler err_handler,
+    async_log_helper(formatter_ptr formatter, vector<sink_ptr> sinks, size_t queue_size, const log_err_handler err_handler,
         const async_overflow_policy overflow_policy = async_overflow_policy::block_retry, std::function<void()> worker_warmup_cb = nullptr,
         const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
         std::function<void()> worker_teardown_cb = nullptr);
@@ -142,7 +142,7 @@ public:
 
 private:
     formatter_ptr _formatter;
-    std::vector<std::shared_ptr<sinks::sink>> _sinks;
+    vector<shared_ptr<sinks::sink>> _sinks;
 
     // queue of messages to log
     q_type _q;
@@ -191,7 +191,7 @@ private:
 ///////////////////////////////////////////////////////////////////////////////
 // async_sink class implementation
 ///////////////////////////////////////////////////////////////////////////////
-inline spdlog::details::async_log_helper::async_log_helper(formatter_ptr formatter, std::vector<sink_ptr> sinks, size_t queue_size,
+inline spdlog::details::async_log_helper::async_log_helper(formatter_ptr formatter, vector<sink_ptr> sinks, size_t queue_size,
     log_err_handler err_handler, const async_overflow_policy overflow_policy, std::function<void()> worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, std::function<void()> worker_teardown_cb)
     : _formatter(std::move(formatter))

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -17,7 +17,7 @@
 #include <string>
 
 template<class It>
-inline spdlog::async_logger::async_logger(const std::string &logger_name, const It &begin, const It &end, size_t queue_size,
+inline spdlog::async_logger::async_logger(const string &logger_name, const It &begin, const It &end, size_t queue_size,
     const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
     : logger(logger_name, begin, end)
@@ -26,7 +26,7 @@ inline spdlog::async_logger::async_logger(const std::string &logger_name, const 
 {
 }
 
-inline spdlog::async_logger::async_logger(const std::string &logger_name, sinks_init_list sinks_list, size_t queue_size,
+inline spdlog::async_logger::async_logger(const string &logger_name, sinks_init_list sinks_list, size_t queue_size,
     const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
     : async_logger(logger_name, sinks_list.begin(), sinks_list.end(), queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms,
@@ -34,7 +34,7 @@ inline spdlog::async_logger::async_logger(const std::string &logger_name, sinks_
 {
 }
 
-inline spdlog::async_logger::async_logger(const std::string &logger_name, sink_ptr single_sink, size_t queue_size,
+inline spdlog::async_logger::async_logger(const string &logger_name, sink_ptr single_sink, size_t queue_size,
     const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
     : async_logger(
@@ -64,9 +64,9 @@ inline void spdlog::async_logger::_set_formatter(spdlog::formatter_ptr msg_forma
     _async_log_helper->set_formatter(_formatter);
 }
 
-inline void spdlog::async_logger::_set_pattern(const std::string &pattern, pattern_time_type pattern_time)
+inline void spdlog::async_logger::_set_pattern(const string &pattern, pattern_time_type pattern_time)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern, pattern_time);
+    _formatter = spdlog::make_shared<pattern_formatter>(pattern, pattern_time);
     _async_log_helper->set_formatter(_formatter);
 }
 

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -16,7 +16,7 @@ namespace details {
 struct log_msg
 {
     log_msg() = default;
-    log_msg(const std::string *loggers_name, level::level_enum lvl)
+    log_msg(const string *loggers_name, level::level_enum lvl)
         : logger_name(loggers_name)
         , level(lvl)
     {
@@ -33,12 +33,12 @@ struct log_msg
     log_msg &operator=(log_msg &&other) = delete;
     log_msg(log_msg &&other) = delete;
 
-    const std::string *logger_name{nullptr};
+    const string *logger_name{nullptr};
     level::level_enum level;
     log_clock::time_point time;
     size_t thread_id;
-    fmt::MemoryWriter raw;
-    fmt::MemoryWriter formatted;
+    fmt::BasicMemoryWriter<char, _allocator<char>> raw;
+    fmt::BasicMemoryWriter<char, _allocator<char>> formatted;
     size_t msg_id{0};
 };
 } // namespace details

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -14,26 +14,26 @@
 // create logger with given name, sinks and the default pattern formatter
 // all other ctors will call this one
 template<class It>
-inline spdlog::logger::logger(std::string logger_name, const It &begin, const It &end)
+inline spdlog::logger::logger(string logger_name, const It &begin, const It &end)
     : _name(std::move(logger_name))
     , _sinks(begin, end)
-    , _formatter(std::make_shared<pattern_formatter>("%+"))
+    , _formatter(make_shared<pattern_formatter>("%+"))
     , _level(level::info)
     , _flush_level(level::off)
     , _last_err_time(0)
     , _msg_counter(1) // message counter will start from 1. 0-message id will be reserved for controll messages
 {
-    _err_handler = [this](const std::string &msg) { this->_default_err_handler(msg); };
+    _err_handler = [this](const string &msg) { this->_default_err_handler(msg); };
 }
 
 // ctor with sinks as init list
-inline spdlog::logger::logger(const std::string &logger_name, sinks_init_list sinks_list)
+inline spdlog::logger::logger(const string &logger_name, sinks_init_list sinks_list)
     : logger(logger_name, sinks_list.begin(), sinks_list.end())
 {
 }
 
 // ctor with single sink
-inline spdlog::logger::logger(const std::string &logger_name, spdlog::sink_ptr single_sink)
+inline spdlog::logger::logger(const string &logger_name, spdlog::sink_ptr single_sink)
     : logger(logger_name, {std::move(single_sink)})
 {
 }
@@ -45,7 +45,7 @@ inline void spdlog::logger::set_formatter(spdlog::formatter_ptr msg_formatter)
     _set_formatter(std::move(msg_formatter));
 }
 
-inline void spdlog::logger::set_pattern(const std::string &pattern, pattern_time_type pattern_time)
+inline void spdlog::logger::set_pattern(const string &pattern, pattern_time_type pattern_time)
 {
     _set_pattern(pattern, pattern_time);
 }
@@ -262,7 +262,7 @@ inline void spdlog::logger::critical(const wchar_t *fmt, const Args &... args)
 //
 // name and level
 //
-inline const std::string &spdlog::logger::name() const
+inline const spdlog::string &spdlog::logger::name() const
 {
     return _name;
 }
@@ -320,9 +320,9 @@ inline void spdlog::logger::_sink_it(details::log_msg &msg)
     }
 }
 
-inline void spdlog::logger::_set_pattern(const std::string &pattern, pattern_time_type pattern_time)
+inline void spdlog::logger::_set_pattern(const string &pattern, pattern_time_type pattern_time)
 {
-    _formatter = std::make_shared<pattern_formatter>(pattern, pattern_time);
+    _formatter = spdlog::make_shared<pattern_formatter>(pattern, pattern_time);
 }
 
 inline void spdlog::logger::_set_formatter(formatter_ptr msg_formatter)
@@ -338,7 +338,7 @@ inline void spdlog::logger::flush()
     }
 }
 
-inline void spdlog::logger::_default_err_handler(const std::string &msg)
+inline void spdlog::logger::_default_err_handler(const string &msg)
 {
     auto now = time(nullptr);
     if (now - _last_err_time < 60)
@@ -365,7 +365,7 @@ inline void spdlog::logger::_incr_msg_counter(details::log_msg &msg)
     msg.msg_id = _msg_counter.fetch_add(1, std::memory_order_relaxed);
 }
 
-inline const std::vector<spdlog::sink_ptr> &spdlog::logger::sinks() const
+inline const spdlog::vector<spdlog::sink_ptr> &spdlog::logger::sinks() const
 {
     return _sinks;
 }

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -371,35 +371,35 @@ inline void sleep_for_millis(int milliseconds)
 // wchar support for windows file names (SPDLOG_WCHAR_FILENAMES must be defined)
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 #define SPDLOG_FILENAME_T(s) L##s
-inline std::string filename_to_str(const filename_t &filename)
+inline string filename_to_str(const filename_t &filename)
 {
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> c;
-    return c.to_bytes(filename);
+    return c.to_bytes(filename).c_str();
 }
 #else
 #define SPDLOG_FILENAME_T(s) s
-inline std::string filename_to_str(const filename_t &filename)
+inline string filename_to_str(const filename_t &filename)
 {
     return filename;
 }
 #endif
 
-inline std::string errno_to_string(char[256], char *res)
+inline string errno_to_string(char[256], char *res)
 {
-    return std::string(res);
+    return string(res);
 }
 
-inline std::string errno_to_string(char buf[256], int res)
+inline string errno_to_string(char buf[256], int res)
 {
     if (res == 0)
     {
-        return std::string(buf);
+        return string(buf);
     }
     return "Unknown error";
 }
 
 // Return errno string (thread safe)
-inline std::string errno_str(int err_num)
+inline string errno_str(int err_num)
 {
     char buf[256];
     SPDLOG_CONSTEXPR auto buf_size = sizeof(buf);
@@ -407,7 +407,7 @@ inline std::string errno_str(int err_num)
 #ifdef _WIN32
     if (strerror_s(buf, buf_size, err_num) == 0)
     {
-        return std::string(buf);
+        return string(buf);
     }
     else
     {
@@ -419,7 +419,7 @@ inline std::string errno_str(int err_num)
 
     if (strerror_r(err_num, buf, buf_size) == 0)
     {
-        return std::string(buf);
+        return string(buf);
     }
     else
     {

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -114,14 +114,16 @@ class B_formatter : public flag_formatter
 };
 
 // write 2 ints separated by sep with padding of 2
-static fmt::MemoryWriter &pad_n_join(fmt::MemoryWriter &w, int v1, int v2, char sep)
+template<class Allocator = std::allocator<char>>
+static fmt::BasicMemoryWriter<char, Allocator> &pad_n_join(fmt::BasicMemoryWriter<char, Allocator> &w, int v1, int v2, char sep)
 {
     w << fmt::pad(v1, 2, '0') << sep << fmt::pad(v2, 2, '0');
     return w;
 }
 
 // write 3 ints separated by sep with padding of 2
-static fmt::MemoryWriter &pad_n_join(fmt::MemoryWriter &w, int v1, int v2, int v3, char sep)
+template<class Allocator = std::allocator<char>>
+static fmt::BasicMemoryWriter<char, Allocator> &pad_n_join(fmt::BasicMemoryWriter<char, Allocator> &w, int v1, int v2, int v3, char sep)
 {
     w << fmt::pad(v1, 2, '0') << sep << fmt::pad(v2, 2, '0') << sep << fmt::pad(v3, 2, '0');
     return w;
@@ -418,7 +420,7 @@ public:
     }
 
 private:
-    std::string _str;
+    string _str;
 };
 
 // Full info formatter
@@ -472,17 +474,17 @@ class full_formatter SPDLOG_FINAL : public flag_formatter
 ///////////////////////////////////////////////////////////////////////////////
 // pattern_formatter inline impl
 ///////////////////////////////////////////////////////////////////////////////
-inline spdlog::pattern_formatter::pattern_formatter(const std::string &pattern, pattern_time_type pattern_time, std::string eol)
+inline spdlog::pattern_formatter::pattern_formatter(const string &pattern, pattern_time_type pattern_time, string eol)
     : _eol(std::move(eol))
     , _pattern_time(pattern_time)
 {
     compile_pattern(pattern);
 }
 
-inline void spdlog::pattern_formatter::compile_pattern(const std::string &pattern)
+inline void spdlog::pattern_formatter::compile_pattern(const string &pattern)
 {
     auto end = pattern.end();
-    std::unique_ptr<details::aggregate_formatter> user_chars;
+    unique_ptr<details::aggregate_formatter> user_chars;
     for (auto it = pattern.begin(); it != end; ++it)
     {
         if (*it == '%')
@@ -504,7 +506,7 @@ inline void spdlog::pattern_formatter::compile_pattern(const std::string &patter
         {
             if (!user_chars)
             {
-                user_chars = std::unique_ptr<details::aggregate_formatter>(new details::aggregate_formatter());
+                user_chars = unique_ptr<details::aggregate_formatter>(make_unique<details::aggregate_formatter>());
             }
             user_chars->add_ch(*it);
         }
@@ -520,134 +522,134 @@ inline void spdlog::pattern_formatter::handle_flag(char flag)
     {
     // logger name
     case 'n':
-        _formatters.emplace_back(new details::name_formatter());
+        _formatters.emplace_back(make_unique<details::name_formatter>());
         break;
 
     case 'l':
-        _formatters.emplace_back(new details::level_formatter());
+        _formatters.emplace_back(make_unique<details::level_formatter>());
         break;
 
     case 'L':
-        _formatters.emplace_back(new details::short_level_formatter());
+        _formatters.emplace_back(make_unique<details::short_level_formatter>());
         break;
 
     case ('t'):
-        _formatters.emplace_back(new details::t_formatter());
+        _formatters.emplace_back(make_unique<details::t_formatter>());
         break;
 
     case ('v'):
-        _formatters.emplace_back(new details::v_formatter());
+        _formatters.emplace_back(make_unique<details::v_formatter>());
         break;
 
     case ('a'):
-        _formatters.emplace_back(new details::a_formatter());
+        _formatters.emplace_back(make_unique<details::a_formatter>());
         break;
 
     case ('A'):
-        _formatters.emplace_back(new details::A_formatter());
+        _formatters.emplace_back(make_unique<details::A_formatter>());
         break;
 
     case ('b'):
     case ('h'):
-        _formatters.emplace_back(new details::b_formatter());
+        _formatters.emplace_back(make_unique<details::b_formatter>());
         break;
 
     case ('B'):
-        _formatters.emplace_back(new details::B_formatter());
+        _formatters.emplace_back(make_unique<details::B_formatter>());
         break;
     case ('c'):
-        _formatters.emplace_back(new details::c_formatter());
+        _formatters.emplace_back(make_unique<details::c_formatter>());
         break;
 
     case ('C'):
-        _formatters.emplace_back(new details::C_formatter());
+        _formatters.emplace_back(make_unique<details::C_formatter>());
         break;
 
     case ('Y'):
-        _formatters.emplace_back(new details::Y_formatter());
+        _formatters.emplace_back(make_unique<details::Y_formatter>());
         break;
 
     case ('D'):
     case ('x'):
 
-        _formatters.emplace_back(new details::D_formatter());
+        _formatters.emplace_back(make_unique<details::D_formatter>());
         break;
 
     case ('m'):
-        _formatters.emplace_back(new details::m_formatter());
+        _formatters.emplace_back(make_unique<details::m_formatter>());
         break;
 
     case ('d'):
-        _formatters.emplace_back(new details::d_formatter());
+        _formatters.emplace_back(make_unique<details::d_formatter>());
         break;
 
     case ('H'):
-        _formatters.emplace_back(new details::H_formatter());
+        _formatters.emplace_back(make_unique<details::H_formatter>());
         break;
 
     case ('I'):
-        _formatters.emplace_back(new details::I_formatter());
+        _formatters.emplace_back(make_unique<details::I_formatter>());
         break;
 
     case ('M'):
-        _formatters.emplace_back(new details::M_formatter());
+        _formatters.emplace_back(make_unique<details::M_formatter>());
         break;
 
     case ('S'):
-        _formatters.emplace_back(new details::S_formatter());
+        _formatters.emplace_back(make_unique<details::S_formatter>());
         break;
 
     case ('e'):
-        _formatters.emplace_back(new details::e_formatter());
+        _formatters.emplace_back(make_unique<details::e_formatter>());
         break;
 
     case ('f'):
-        _formatters.emplace_back(new details::f_formatter());
+        _formatters.emplace_back(make_unique<details::f_formatter>());
         break;
     case ('F'):
-        _formatters.emplace_back(new details::F_formatter());
+        _formatters.emplace_back(make_unique<details::F_formatter>());
         break;
 
     case ('E'):
-        _formatters.emplace_back(new details::E_formatter());
+        _formatters.emplace_back(make_unique<details::E_formatter>());
         break;
 
     case ('p'):
-        _formatters.emplace_back(new details::p_formatter());
+        _formatters.emplace_back(make_unique<details::p_formatter>());
         break;
 
     case ('r'):
-        _formatters.emplace_back(new details::r_formatter());
+        _formatters.emplace_back(make_unique<details::r_formatter>());
         break;
 
     case ('R'):
-        _formatters.emplace_back(new details::R_formatter());
+        _formatters.emplace_back(make_unique<details::R_formatter>());
         break;
 
     case ('T'):
     case ('X'):
-        _formatters.emplace_back(new details::T_formatter());
+        _formatters.emplace_back(make_unique<details::T_formatter>());
         break;
 
     case ('z'):
-        _formatters.emplace_back(new details::z_formatter());
+        _formatters.emplace_back(make_unique<details::z_formatter>());
         break;
 
     case ('+'):
-        _formatters.emplace_back(new details::full_formatter());
+        _formatters.emplace_back(make_unique<details::full_formatter>());
         break;
 
     case ('P'):
-        _formatters.emplace_back(new details::pid_formatter());
+        _formatters.emplace_back(make_unique<details::pid_formatter>());
         break;
 
     case ('i'):
-        _formatters.emplace_back(new details::i_formatter());
+        _formatters.emplace_back(make_unique<details::i_formatter>());
         break;
 
     default: // Unknown flag appears as is
-        _formatters.emplace_back(new details::ch_formatter('%'));
-        _formatters.emplace_back(new details::ch_formatter(flag));
+        _formatters.emplace_back(make_unique<details::ch_formatter>('%'));
+        _formatters.emplace_back(make_unique<details::ch_formatter>(flag));
         break;
     }
 }

--- a/include/spdlog/details/pattern_formatter_impl.h
+++ b/include/spdlog/details/pattern_formatter_impl.h
@@ -73,7 +73,7 @@ static int to12h(const tm &t)
 }
 
 // Abbreviated weekday name
-static const std::string days[]{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+static const char* days[]{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 class a_formatter : public flag_formatter
 {
     void format(details::log_msg &msg, const std::tm &tm_time) override
@@ -83,7 +83,7 @@ class a_formatter : public flag_formatter
 };
 
 // Full weekday name
-static const std::string full_days[]{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+static const char* full_days[]{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 class A_formatter : public flag_formatter
 {
     void format(details::log_msg &msg, const std::tm &tm_time) override
@@ -93,7 +93,7 @@ class A_formatter : public flag_formatter
 };
 
 // Abbreviated month
-static const std::string months[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"};
+static const char* months[]{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"};
 class b_formatter : public flag_formatter
 {
     void format(details::log_msg &msg, const std::tm &tm_time) override
@@ -103,7 +103,7 @@ class b_formatter : public flag_formatter
 };
 
 // Full month name
-static const std::string full_months[]{
+static const char* full_months[]{
     "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
 class B_formatter : public flag_formatter
 {

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -31,7 +31,7 @@ public:
     registry_t<Mutex>(const registry_t<Mutex> &) = delete;
     registry_t<Mutex> &operator=(const registry_t<Mutex> &) = delete;
 
-    void register_logger(std::shared_ptr<logger> logger)
+    void register_logger(shared_ptr<logger> logger)
     {
         std::lock_guard<Mutex> lock(_mutex);
         auto logger_name = logger->name();
@@ -39,7 +39,7 @@ public:
         _loggers[logger_name] = logger;
     }
 
-    std::shared_ptr<logger> get(const std::string &logger_name)
+    shared_ptr<logger> get(const string &logger_name)
     {
         std::lock_guard<Mutex> lock(_mutex);
         auto found = _loggers.find(logger_name);
@@ -47,19 +47,19 @@ public:
     }
 
     template<class It>
-    std::shared_ptr<logger> create(const std::string &logger_name, const It &sinks_begin, const It &sinks_end)
+    shared_ptr<logger> create(const string &logger_name, const It &sinks_begin, const It &sinks_end)
     {
         std::lock_guard<Mutex> lock(_mutex);
         throw_if_exists(logger_name);
-        std::shared_ptr<logger> new_logger;
+        shared_ptr<logger> new_logger;
         if (_async_mode)
         {
-            new_logger = std::make_shared<async_logger>(logger_name, sinks_begin, sinks_end, _async_q_size, _overflow_policy,
+            new_logger = spdlog::make_shared<async_logger>(logger_name, sinks_begin, sinks_end, _async_q_size, _overflow_policy,
                 _worker_warmup_cb, _flush_interval_ms, _worker_teardown_cb);
         }
         else
         {
-            new_logger = std::make_shared<logger>(logger_name, sinks_begin, sinks_end);
+            new_logger = spdlog::make_shared<logger>(logger_name, sinks_begin, sinks_end);
         }
 
         if (_formatter)
@@ -81,14 +81,14 @@ public:
     }
 
     template<class It>
-    std::shared_ptr<async_logger> create_async(const std::string &logger_name, size_t queue_size,
+    shared_ptr<async_logger> create_async(const string &logger_name, size_t queue_size,
         const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
         const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb, const It &sinks_begin,
         const It &sinks_end)
     {
         std::lock_guard<Mutex> lock(_mutex);
         throw_if_exists(logger_name);
-        auto new_logger = std::make_shared<async_logger>(
+        auto new_logger = spdlog::make_shared<async_logger>(
             logger_name, sinks_begin, sinks_end, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb);
 
         if (_formatter)
@@ -109,7 +109,7 @@ public:
         return new_logger;
     }
 
-    void apply_all(std::function<void(std::shared_ptr<logger>)> fun)
+    void apply_all(std::function<void(shared_ptr<logger>)> fun)
     {
         std::lock_guard<Mutex> lock(_mutex);
         for (auto &l : _loggers)
@@ -118,7 +118,7 @@ public:
         }
     }
 
-    void drop(const std::string &logger_name)
+    void drop(const string &logger_name)
     {
         std::lock_guard<Mutex> lock(_mutex);
         _loggers.erase(logger_name);
@@ -130,17 +130,17 @@ public:
         _loggers.clear();
     }
 
-    std::shared_ptr<logger> create(const std::string &logger_name, sinks_init_list sinks)
+    shared_ptr<logger> create(const string &logger_name, sinks_init_list sinks)
     {
         return create(logger_name, sinks.begin(), sinks.end());
     }
 
-    std::shared_ptr<logger> create(const std::string &logger_name, sink_ptr sink)
+    shared_ptr<logger> create(const string &logger_name, sink_ptr sink)
     {
         return create(logger_name, {sink});
     }
 
-    std::shared_ptr<async_logger> create_async(const std::string &logger_name, size_t queue_size,
+    shared_ptr<async_logger> create_async(const string &logger_name, size_t queue_size,
         const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
         const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb, sinks_init_list sinks)
     {
@@ -148,7 +148,7 @@ public:
             logger_name, queue_size, overflow_policy, worker_warmup_cb, flush_interval_ms, worker_teardown_cb, sinks.begin(), sinks.end());
     }
 
-    std::shared_ptr<async_logger> create_async(const std::string &logger_name, size_t queue_size,
+    shared_ptr<async_logger> create_async(const string &logger_name, size_t queue_size,
         const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
         const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb, sink_ptr sink)
     {
@@ -165,10 +165,10 @@ public:
         }
     }
 
-    void set_pattern(const std::string &pattern)
+    void set_pattern(const string &pattern)
     {
         std::lock_guard<Mutex> lock(_mutex);
-        _formatter = std::make_shared<pattern_formatter>(pattern);
+        _formatter = spdlog::make_shared<pattern_formatter>(pattern);
         for (auto &l : _loggers)
         {
             l.second->set_formatter(_formatter);
@@ -231,7 +231,7 @@ public:
 private:
     registry_t<Mutex>() = default;
 
-    void throw_if_exists(const std::string &logger_name)
+    void throw_if_exists(const string &logger_name)
     {
         if (_loggers.find(logger_name) != _loggers.end())
         {
@@ -240,7 +240,7 @@ private:
     }
 
     Mutex _mutex;
-    std::unordered_map<std::string, std::shared_ptr<logger>> _loggers;
+    unordered_map<string, shared_ptr<logger>> _loggers;
     formatter_ptr _formatter;
     level::level_enum _level = level::info;
     level::level_enum _flush_level = level::off;

--- a/include/spdlog/details/spdlog_impl.h
+++ b/include/spdlog/details/spdlog_impl.h
@@ -31,54 +31,54 @@
 #include <memory>
 #include <string>
 
-inline void spdlog::register_logger(std::shared_ptr<logger> logger)
+inline void spdlog::register_logger(shared_ptr<logger> logger)
 {
     return details::registry::instance().register_logger(std::move(logger));
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::get(const std::string &name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::get(const string &name)
 {
     return details::registry::instance().get(name);
 }
 
-inline void spdlog::drop(const std::string &name)
+inline void spdlog::drop(const string &name)
 {
     details::registry::instance().drop(name);
 }
 
 // Create multi/single threaded simple file logger
-inline std::shared_ptr<spdlog::logger> spdlog::basic_logger_mt(const std::string &logger_name, const filename_t &filename, bool truncate)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::basic_logger_mt(const string &logger_name, const filename_t &filename, bool truncate)
 {
     return create<spdlog::sinks::simple_file_sink_mt>(logger_name, filename, truncate);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::basic_logger_st(const std::string &logger_name, const filename_t &filename, bool truncate)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::basic_logger_st(const string &logger_name, const filename_t &filename, bool truncate)
 {
     return create<spdlog::sinks::simple_file_sink_st>(logger_name, filename, truncate);
 }
 
 // Create multi/single threaded rotating file logger
-inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_mt(
-    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::rotating_logger_mt(
+    const string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files)
 {
     return create<spdlog::sinks::rotating_file_sink_mt>(logger_name, filename, max_file_size, max_files);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::rotating_logger_st(
-    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::rotating_logger_st(
+    const string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files)
 {
     return create<spdlog::sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files);
 }
 
 // Create file logger which creates new file at midnight):
-inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_mt(
-    const std::string &logger_name, const filename_t &filename, int hour, int minute)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::daily_logger_mt(
+    const string &logger_name, const filename_t &filename, int hour, int minute)
 {
     return create<spdlog::sinks::daily_file_sink_mt>(logger_name, filename, hour, minute);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_st(
-    const std::string &logger_name, const filename_t &filename, int hour, int minute)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::daily_logger_st(
+    const string &logger_name, const filename_t &filename, int hour, int minute)
 {
     return create<spdlog::sinks::daily_file_sink_st>(logger_name, filename, hour, minute);
 }
@@ -86,22 +86,22 @@ inline std::shared_ptr<spdlog::logger> spdlog::daily_logger_st(
 //
 // stdout/stderr loggers
 //
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt(const string &logger_name)
 {
     return spdlog::details::registry::instance().create(logger_name, spdlog::sinks::stdout_sink_mt::instance());
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_logger_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_logger_st(const string &logger_name)
 {
     return spdlog::details::registry::instance().create(logger_name, spdlog::sinks::stdout_sink_st::instance());
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt(const string &logger_name)
 {
     return spdlog::details::registry::instance().create(logger_name, spdlog::sinks::stderr_sink_mt::instance());
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const string &logger_name)
 {
     return spdlog::details::registry::instance().create(logger_name, spdlog::sinks::stderr_sink_st::instance());
 }
@@ -111,100 +111,100 @@ inline std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st(const std::strin
 //
 #if defined _WIN32 && !defined(__cplusplus_winrt)
 
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_color_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_color_mt(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>();
+    auto sink = spdlog::make_shared<spdlog::sinks::wincolor_stdout_sink_mt>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_color_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_color_st(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::wincolor_stdout_sink_st>();
+    auto sink = spdlog::make_shared<spdlog::sinks::wincolor_stdout_sink_st>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_color_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_color_mt(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
+    auto sink = spdlog::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_color_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_color_st(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_st>();
+    auto sink = spdlog::make_shared<spdlog::sinks::wincolor_stderr_sink_st>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
 #else // ansi terminal colors
 
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_color_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_color_mt(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
+    auto sink = spdlog::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stdout_color_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stdout_color_st(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_st>();
+    auto sink = spdlog::make_shared<spdlog::sinks::ansicolor_stdout_sink_st>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_color_mt(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_color_mt(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
+    auto sink = spdlog::make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 
-inline std::shared_ptr<spdlog::logger> spdlog::stderr_color_st(const std::string &logger_name)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::stderr_color_st(const string &logger_name)
 {
-    auto sink = std::make_shared<spdlog::sinks::ansicolor_stderr_sink_st>();
+    auto sink = spdlog::make_shared<spdlog::sinks::ansicolor_stderr_sink_st>();
     return spdlog::details::registry::instance().create(logger_name, sink);
 }
 #endif
 
 #ifdef SPDLOG_ENABLE_SYSLOG
 // Create syslog logger
-inline std::shared_ptr<spdlog::logger> spdlog::syslog_logger(
-    const std::string &logger_name, const std::string &syslog_ident, int syslog_option, int syslog_facility)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::syslog_logger(
+    const string &logger_name, const string &syslog_ident, int syslog_option, int syslog_facility)
 {
     return create<spdlog::sinks::syslog_sink>(logger_name, syslog_ident, syslog_option, syslog_facility);
 }
 #endif
 
 #ifdef __ANDROID__
-inline std::shared_ptr<spdlog::logger> spdlog::android_logger(const std::string &logger_name, const std::string &tag)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::android_logger(const string &logger_name, const string &tag)
 {
     return create<spdlog::sinks::android_sink>(logger_name, tag);
 }
 #endif
 
 // Create and register a logger a single sink
-inline std::shared_ptr<spdlog::logger> spdlog::create(const std::string &logger_name, const spdlog::sink_ptr &sink)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create(const string &logger_name, const spdlog::sink_ptr &sink)
 {
     return details::registry::instance().create(logger_name, sink);
 }
 
 // Create logger with multiple sinks
-inline std::shared_ptr<spdlog::logger> spdlog::create(const std::string &logger_name, spdlog::sinks_init_list sinks)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create(const string &logger_name, spdlog::sinks_init_list sinks)
 {
     return details::registry::instance().create(logger_name, sinks);
 }
 
 template<typename Sink, typename... Args>
-inline std::shared_ptr<spdlog::logger> spdlog::create(const std::string &logger_name, Args... args)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create(const string &logger_name, Args... args)
 {
-    sink_ptr sink = std::make_shared<Sink>(args...);
+    sink_ptr sink = spdlog::make_shared<Sink>(args...);
     return details::registry::instance().create(logger_name, {sink});
 }
 
 template<class It>
-inline std::shared_ptr<spdlog::logger> spdlog::create(const std::string &logger_name, const It &sinks_begin, const It &sinks_end)
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create(const string &logger_name, const It &sinks_begin, const It &sinks_end)
 {
     return details::registry::instance().create(logger_name, sinks_begin, sinks_end);
 }
 
 // Create and register an async logger with a single sink
-inline std::shared_ptr<spdlog::logger> spdlog::create_async(const std::string &logger_name, const sink_ptr &sink, size_t queue_size,
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create_async(const string &logger_name, const sink_ptr &sink, size_t queue_size,
     const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
 {
@@ -213,7 +213,7 @@ inline std::shared_ptr<spdlog::logger> spdlog::create_async(const std::string &l
 }
 
 // Create and register an async logger with multiple sinks
-inline std::shared_ptr<spdlog::logger> spdlog::create_async(const std::string &logger_name, sinks_init_list sinks, size_t queue_size,
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create_async(const string &logger_name, sinks_init_list sinks, size_t queue_size,
     const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
 {
@@ -222,7 +222,7 @@ inline std::shared_ptr<spdlog::logger> spdlog::create_async(const std::string &l
 }
 
 template<class It>
-inline std::shared_ptr<spdlog::logger> spdlog::create_async(const std::string &logger_name, const It &sinks_begin, const It &sinks_end,
+inline spdlog::shared_ptr<spdlog::logger> spdlog::create_async(const string &logger_name, const It &sinks_begin, const It &sinks_end,
     size_t queue_size, const async_overflow_policy overflow_policy, const std::function<void()> &worker_warmup_cb,
     const std::chrono::milliseconds &flush_interval_ms, const std::function<void()> &worker_teardown_cb)
 {
@@ -235,7 +235,7 @@ inline void spdlog::set_formatter(spdlog::formatter_ptr f)
     details::registry::instance().formatter(std::move(f));
 }
 
-inline void spdlog::set_pattern(const std::string &format_string)
+inline void spdlog::set_pattern(const string &format_string)
 {
     return details::registry::instance().set_pattern(format_string);
 }
@@ -267,7 +267,7 @@ inline void spdlog::set_sync_mode()
     details::registry::instance().set_sync_mode();
 }
 
-inline void spdlog::apply_all(std::function<void(std::shared_ptr<logger>)> fun)
+inline void spdlog::apply_all(std::function<void(shared_ptr<logger>)> fun)
 {
     details::registry::instance().apply_all(std::move(fun));
 }

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -26,20 +26,20 @@ public:
 class pattern_formatter SPDLOG_FINAL : public formatter
 {
 public:
-    explicit pattern_formatter(const std::string &pattern, pattern_time_type pattern_time = pattern_time_type::local,
-        std::string eol = spdlog::details::os::default_eol);
+    explicit pattern_formatter(const string &pattern, pattern_time_type pattern_time = pattern_time_type::local,
+        string eol = spdlog::details::os::default_eol);
     pattern_formatter(const pattern_formatter &) = delete;
     pattern_formatter &operator=(const pattern_formatter &) = delete;
     void format(details::log_msg &msg) override;
 
 private:
-    const std::string _eol;
-    const std::string _pattern;
+    const string _eol;
+    const string _pattern;
     const pattern_time_type _pattern_time;
-    std::vector<std::unique_ptr<details::flag_formatter>> _formatters;
+    vector<unique_ptr<details::flag_formatter>> _formatters;
     std::tm get_time(details::log_msg &msg);
     void handle_flag(char flag);
-    void compile_pattern(const std::string &pattern);
+    void compile_pattern(const string &pattern);
 };
 } // namespace spdlog
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -6,7 +6,7 @@
 #pragma once
 
 // Thread safe logger (except for set_pattern(..), set_formatter(..) and set_error_handler())
-// Has name, log level, vector of std::shared sink pointers and formatter
+// Has name, log level, vector of shared sink pointers and formatter
 // Upon each log write the logger:
 // 1. Checks if its log level is enough to log the message
 // 2. Format the message using the formatter function
@@ -24,11 +24,11 @@ namespace spdlog {
 class logger
 {
 public:
-    logger(const std::string &name, sink_ptr single_sink);
-    logger(const std::string &name, sinks_init_list sinks);
+    logger(const string &name, sink_ptr single_sink);
+    logger(const string &name, sinks_init_list sinks);
 
     template<class It>
-    logger(std::string name, const It &begin, const It &end);
+    logger(string name, const It &begin, const It &end);
 
     virtual ~logger();
 
@@ -109,8 +109,8 @@ public:
     bool should_log(level::level_enum msg_level) const;
     void set_level(level::level_enum log_level);
     level::level_enum level() const;
-    const std::string &name() const;
-    void set_pattern(const std::string &pattern, pattern_time_type pattern_time = pattern_time_type::local);
+    const string &name() const;
+    void set_pattern(const string &pattern, pattern_time_type pattern_time = pattern_time_type::local);
     void set_formatter(formatter_ptr msg_formatter);
 
     // automatically call flush() if message level >= log_level
@@ -118,7 +118,7 @@ public:
 
     virtual void flush();
 
-    const std::vector<sink_ptr> &sinks() const;
+    const vector<sink_ptr> &sinks() const;
 
     // error handler
     virtual void set_error_handler(log_err_handler err_handler);
@@ -126,11 +126,11 @@ public:
 
 protected:
     virtual void _sink_it(details::log_msg &msg);
-    virtual void _set_pattern(const std::string &pattern, pattern_time_type pattern_time);
+    virtual void _set_pattern(const string &pattern, pattern_time_type pattern_time);
     virtual void _set_formatter(formatter_ptr msg_formatter);
 
     // default error handler: print the error to stderr with the max rate of 1 message/minute
-    virtual void _default_err_handler(const std::string &msg);
+    virtual void _default_err_handler(const string &msg);
 
     // return true if the given message level should trigger a flush
     bool _should_flush_on(const details::log_msg &msg);
@@ -138,8 +138,8 @@ protected:
     // increment the message count (only if defined(SPDLOG_ENABLE_MESSAGE_COUNTER))
     void _incr_msg_counter(details::log_msg &msg);
 
-    const std::string _name;
-    std::vector<sink_ptr> _sinks;
+    const string _name;
+    vector<sink_ptr> _sinks;
     formatter_ptr _formatter;
     spdlog::level_t _level;
     spdlog::level_t _flush_level;

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -30,7 +30,7 @@ namespace sinks {
 class android_sink : public sink
 {
 public:
-    explicit android_sink(const std::string &tag = "spdlog", bool use_raw_msg = false)
+    explicit android_sink(const string &tag = "spdlog", bool use_raw_msg = false)
         : _tag(tag)
         , _use_raw_msg(use_raw_msg)
     {
@@ -81,7 +81,7 @@ private:
         }
     }
 
-    std::string _tag;
+    string _tag;
     bool _use_raw_msg;
 };
 

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -31,9 +31,9 @@ public:
         colors_[level::trace] = cyan;
         colors_[level::debug] = cyan;
         colors_[level::info] = reset;
-        colors_[level::warn] = yellow + bold;
-        colors_[level::err] = red + bold;
-        colors_[level::critical] = bold + on_red;
+        colors_[level::warn] = string(yellow) + bold;
+        colors_[level::err] = string(red) + bold;
+        colors_[level::critical] = string(bold) + on_red;
         colors_[level::off] = reset;
     }
 
@@ -42,41 +42,41 @@ public:
         _flush();
     }
 
-    void set_color(level::level_enum color_level, const std::string &color)
+    void set_color(level::level_enum color_level, const string &color)
     {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
         colors_[color_level] = color;
     }
 
     /// Formatting codes
-    const std::string reset = "\033[m";
-    const std::string bold = "\033[1m";
-    const std::string dark = "\033[2m";
-    const std::string underline = "\033[4m";
-    const std::string blink = "\033[5m";
-    const std::string reverse = "\033[7m";
-    const std::string concealed = "\033[8m";
-    const std::string clear_line = "\033[K";
+    const char* reset = "\033[m";
+    const char* bold = "\033[1m";
+    const char* dark = "\033[2m";
+    const char* underline = "\033[4m";
+    const char* blink = "\033[5m";
+    const char* reverse = "\033[7m";
+    const char* concealed = "\033[8m";
+    const char* clear_line = "\033[K";
 
     // Foreground colors
-    const std::string black = "\033[30m";
-    const std::string red = "\033[31m";
-    const std::string green = "\033[32m";
-    const std::string yellow = "\033[33m";
-    const std::string blue = "\033[34m";
-    const std::string magenta = "\033[35m";
-    const std::string cyan = "\033[36m";
-    const std::string white = "\033[37m";
+    const char* black = "\033[30m";
+    const char* red = "\033[31m";
+    const char* green = "\033[32m";
+    const char* yellow = "\033[33m";
+    const char* blue = "\033[34m";
+    const char* magenta = "\033[35m";
+    const char* cyan = "\033[36m";
+    const char* white = "\033[37m";
 
     /// Background colors
-    const std::string on_black = "\033[40m";
-    const std::string on_red = "\033[41m";
-    const std::string on_green = "\033[42m";
-    const std::string on_yellow = "\033[43m";
-    const std::string on_blue = "\033[44m";
-    const std::string on_magenta = "\033[45m";
-    const std::string on_cyan = "\033[46m";
-    const std::string on_white = "\033[47m";
+    const char* on_black = "\033[40m";
+    const char* on_red = "\033[41m";
+    const char* on_green = "\033[42m";
+    const char* on_yellow = "\033[43m";
+    const char* on_blue = "\033[44m";
+    const char* on_magenta = "\033[45m";
+    const char* on_cyan = "\033[46m";
+    const char* on_white = "\033[47m";
 
 protected:
     void _sink_it(const details::log_msg &msg) override
@@ -85,7 +85,7 @@ protected:
         // If color is not supported in the terminal, log as is instead.
         if (should_do_colors_)
         {
-            const std::string &prefix = colors_[msg.level];
+            const string& prefix = colors_[msg.level];
             fwrite(prefix.data(), sizeof(char), prefix.size(), target_file_);
             fwrite(msg.formatted.data(), sizeof(char), msg.formatted.size(), target_file_);
             fwrite(reset.data(), sizeof(char), reset.size(), target_file_);
@@ -105,7 +105,7 @@ protected:
 
     FILE *target_file_;
     bool should_do_colors_;
-    std::unordered_map<level::level_enum, std::string, level::level_hasher> colors_;
+    unordered_map<level::level_enum, string, level::level_hasher> colors_;
 };
 
 template<class Mutex>

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -88,8 +88,8 @@ protected:
             const string& prefix = colors_[msg.level];
             fwrite(prefix.data(), sizeof(char), prefix.size(), target_file_);
             fwrite(msg.formatted.data(), sizeof(char), msg.formatted.size(), target_file_);
-            fwrite(reset.data(), sizeof(char), reset.size(), target_file_);
-            fwrite(clear_line.data(), sizeof(char), clear_line.size(), target_file_);
+            fwrite(reset, sizeof(char), sizeof(reset) / sizeof(*reset), target_file_);
+            fwrite(clear_line, sizeof(char), sizeof(clear_line) / sizeof(*clear_line), target_file_);
         }
         else
         {

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -31,7 +31,7 @@ public:
     dist_sink &operator=(const dist_sink &) = delete;
 
 protected:
-    std::vector<std::shared_ptr<sink>> _sinks;
+    vector<shared_ptr<sink>> _sinks;
 
     void _sink_it(const details::log_msg &msg) override
     {
@@ -51,13 +51,13 @@ protected:
     }
 
 public:
-    void add_sink(std::shared_ptr<sink> sink)
+    void add_sink(shared_ptr<sink> sink)
     {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
         _sinks.push_back(sink);
     }
 
-    void remove_sink(std::shared_ptr<sink> sink)
+    void remove_sink(shared_ptr<sink> sink)
     {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
         _sinks.erase(std::remove(_sinks.begin(), _sinks.end(), sink), _sinks.end());

--- a/include/spdlog/sinks/file_sinks.h
+++ b/include/spdlog/sinks/file_sinks.h
@@ -81,7 +81,7 @@ public:
     // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
     static filename_t calc_filename(const filename_t &filename, std::size_t index)
     {
-        typename std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
+        typename std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::BasicMemoryWriter<char, _allocator<char>>, fmt::BasicMemoryWriter<wchar_t, _allocator<wchar_t>>>::type w;
         if (index != 0u)
         {
             filename_t basename, ext;
@@ -92,7 +92,7 @@ public:
         {
             w.write(SPDLOG_FILENAME_T("{}"), filename);
         }
-        return w.str();
+        return w.c_str();
     }
 
 protected:
@@ -163,10 +163,10 @@ struct default_daily_file_name_calculator
         std::tm tm = spdlog::details::os::localtime();
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extenstion(filename);
-        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
+        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::BasicMemoryWriter<char, spdlog::_allocator<char>>, fmt::BasicMemoryWriter<wchar_t, spdlog::_allocator<wchar_t>>>::type w;
         w.write(SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}_{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
             tm.tm_hour, tm.tm_min, ext);
-        return w.str();
+        return w.c_str();
     }
 };
 
@@ -181,9 +181,9 @@ struct dateonly_daily_file_name_calculator
         std::tm tm = spdlog::details::os::localtime();
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extenstion(filename);
-        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
+        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::BasicMemoryWriter<char, spdlog::_allocator<char>>, fmt::BasicMemoryWriter<wchar_t, spdlog::_allocator<wchar_t>>>::type w;
         w.write(SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, ext);
-        return w.str();
+        return w.c_str();
     }
 };
 

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -23,9 +23,9 @@ class stdout_sink SPDLOG_FINAL : public base_sink<Mutex>
 public:
     explicit stdout_sink() = default;
 
-    static std::shared_ptr<MyType> instance()
+    static shared_ptr<MyType> instance()
     {
-        static std::shared_ptr<MyType> instance = std::make_shared<MyType>();
+        static shared_ptr<MyType> instance = make_shared<MyType>();
         return instance;
     }
 
@@ -53,9 +53,9 @@ class stderr_sink SPDLOG_FINAL : public base_sink<Mutex>
 public:
     explicit stderr_sink() = default;
 
-    static std::shared_ptr<MyType> instance()
+    static shared_ptr<MyType> instance()
     {
-        static std::shared_ptr<MyType> instance = std::make_shared<MyType>();
+        static shared_ptr<MyType> instance = make_shared<MyType>();
         return instance;
     }
 

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -27,7 +27,7 @@ class syslog_sink : public sink
 {
 public:
     //
-    syslog_sink(const std::string &ident = "", int syslog_option = 0, int syslog_facility = LOG_USER)
+    syslog_sink(const string &ident = "", int syslog_option = 0, int syslog_facility = LOG_USER)
         : _ident(ident)
     {
         _priorities[static_cast<size_t>(level::trace)] = LOG_DEBUG;
@@ -60,7 +60,7 @@ public:
 private:
     std::array<int, 7> _priorities;
     // must store the ident because the man says openlog might use the pointer as is and not a string copy
-    const std::string _ident;
+    const string _ident;
 
     //
     // Simply maps spdlog's log level to syslog priority level.

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -72,7 +72,7 @@ protected:
 
 private:
     HANDLE out_handle_;
-    std::unordered_map<level::level_enum, WORD, level::level_hasher> colors_;
+    unordered_map<level::level_enum, WORD, level::level_hasher> colors_;
 
     // set color and return the orig console attributes (for resetting later)
     WORD set_console_attribs(WORD attribs)

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -21,13 +21,13 @@ namespace spdlog {
 // Return an existing logger or nullptr if a logger with such name doesn't exist.
 // example: spdlog::get("my_logger")->info("hello {}", "world");
 //
-std::shared_ptr<logger> get(const std::string &name);
+shared_ptr<logger> get(const string &name);
 
 //
 // Set global formatting
 // example: spdlog::set_pattern("%Y-%m-%d %H:%M:%S.%e %l : %v");
 //
-void set_pattern(const std::string &format_string);
+void set_pattern(const string &format_string);
 void set_formatter(formatter_ptr f);
 
 //
@@ -73,97 +73,97 @@ void set_sync_mode();
 // Create and register multi/single threaded basic file logger.
 // Basic logger simply writes to given file without any limitations or rotations.
 //
-std::shared_ptr<logger> basic_logger_mt(const std::string &logger_name, const filename_t &filename, bool truncate = false);
-std::shared_ptr<logger> basic_logger_st(const std::string &logger_name, const filename_t &filename, bool truncate = false);
+shared_ptr<logger> basic_logger_mt(const string &logger_name, const filename_t &filename, bool truncate = false);
+shared_ptr<logger> basic_logger_st(const string &logger_name, const filename_t &filename, bool truncate = false);
 
 //
 // Create and register multi/single threaded rotating file logger
 //
-std::shared_ptr<logger> rotating_logger_mt(
-    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files);
+shared_ptr<logger> rotating_logger_mt(
+    const string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files);
 
-std::shared_ptr<logger> rotating_logger_st(
-    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files);
+shared_ptr<logger> rotating_logger_st(
+    const string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files);
 
 //
 // Create file logger which creates new file on the given time (default in midnight):
 //
-std::shared_ptr<logger> daily_logger_mt(const std::string &logger_name, const filename_t &filename, int hour = 0, int minute = 0);
-std::shared_ptr<logger> daily_logger_st(const std::string &logger_name, const filename_t &filename, int hour = 0, int minute = 0);
+shared_ptr<logger> daily_logger_mt(const string &logger_name, const filename_t &filename, int hour = 0, int minute = 0);
+shared_ptr<logger> daily_logger_st(const string &logger_name, const filename_t &filename, int hour = 0, int minute = 0);
 
 //
 // Create and register stdout/stderr loggers
 //
-std::shared_ptr<logger> stdout_logger_mt(const std::string &logger_name);
-std::shared_ptr<logger> stdout_logger_st(const std::string &logger_name);
-std::shared_ptr<logger> stderr_logger_mt(const std::string &logger_name);
-std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name);
+shared_ptr<logger> stdout_logger_mt(const string &logger_name);
+shared_ptr<logger> stdout_logger_st(const string &logger_name);
+shared_ptr<logger> stderr_logger_mt(const string &logger_name);
+shared_ptr<logger> stderr_logger_st(const string &logger_name);
 //
 // Create and register colored stdout/stderr loggers
 //
-std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name);
-std::shared_ptr<logger> stdout_color_st(const std::string &logger_name);
-std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name);
-std::shared_ptr<logger> stderr_color_st(const std::string &logger_name);
+shared_ptr<logger> stdout_color_mt(const string &logger_name);
+shared_ptr<logger> stdout_color_st(const string &logger_name);
+shared_ptr<logger> stderr_color_mt(const string &logger_name);
+shared_ptr<logger> stderr_color_st(const string &logger_name);
 
 //
 // Create and register a syslog logger
 //
 #ifdef SPDLOG_ENABLE_SYSLOG
-std::shared_ptr<logger> syslog_logger(
-    const std::string &logger_name, const std::string &ident = "", int syslog_option = 0, int syslog_facilty = (1 << 3));
+shared_ptr<logger> syslog_logger(
+    const string &logger_name, const string &ident = "", int syslog_option = 0, int syslog_facilty = (1 << 3));
 #endif
 
 #if defined(__ANDROID__)
-std::shared_ptr<logger> android_logger(const std::string &logger_name, const std::string &tag = "spdlog");
+shared_ptr<logger> android_logger(const string &logger_name, const string &tag = "spdlog");
 #endif
 
 // Create and register a logger with a single sink
-std::shared_ptr<logger> create(const std::string &logger_name, const sink_ptr &sink);
+shared_ptr<logger> create(const string &logger_name, const sink_ptr &sink);
 
 // Create and register a logger with multiple sinks
-std::shared_ptr<logger> create(const std::string &logger_name, sinks_init_list sinks);
+shared_ptr<logger> create(const string &logger_name, sinks_init_list sinks);
 
 template<class It>
-std::shared_ptr<logger> create(const std::string &logger_name, const It &sinks_begin, const It &sinks_end);
+shared_ptr<logger> create(const string &logger_name, const It &sinks_begin, const It &sinks_end);
 
 // Create and register a logger with templated sink type
 // Example:
 // spdlog::create<daily_file_sink_st>("mylog", "dailylog_filename");
 template<typename Sink, typename... Args>
-std::shared_ptr<spdlog::logger> create(const std::string &logger_name, Args... args);
+shared_ptr<spdlog::logger> create(const string &logger_name, Args... args);
 
 // Create and register an async logger with a single sink
-std::shared_ptr<logger> create_async(const std::string &logger_name, const sink_ptr &sink, size_t queue_size,
+shared_ptr<logger> create_async(const string &logger_name, const sink_ptr &sink, size_t queue_size,
     const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
     const std::function<void()> &worker_warmup_cb = nullptr,
     const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
     const std::function<void()> &worker_teardown_cb = nullptr);
 
 // Create and register an async logger with multiple sinks
-std::shared_ptr<logger> create_async(const std::string &logger_name, sinks_init_list sinks, size_t queue_size,
+shared_ptr<logger> create_async(const string &logger_name, sinks_init_list sinks, size_t queue_size,
     const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
     const std::function<void()> &worker_warmup_cb = nullptr,
     const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
     const std::function<void()> &worker_teardown_cb = nullptr);
 
 template<class It>
-std::shared_ptr<logger> create_async(const std::string &logger_name, const It &sinks_begin, const It &sinks_end, size_t queue_size,
+shared_ptr<logger> create_async(const string &logger_name, const It &sinks_begin, const It &sinks_end, size_t queue_size,
     const async_overflow_policy overflow_policy = async_overflow_policy::block_retry,
     const std::function<void()> &worker_warmup_cb = nullptr,
     const std::chrono::milliseconds &flush_interval_ms = std::chrono::milliseconds::zero(),
     const std::function<void()> &worker_teardown_cb = nullptr);
 
 // Register the given logger with the given name
-void register_logger(std::shared_ptr<logger> logger);
+void register_logger(shared_ptr<logger> logger);
 
 // Apply a user defined function on all registered loggers
 // Example:
-// spdlog::apply_all([&](std::shared_ptr<spdlog::logger> l) {l->flush();});
-void apply_all(std::function<void(std::shared_ptr<logger>)> fun);
+// spdlog::apply_all([&](shared_ptr<spdlog::logger> l) {l->flush();});
+void apply_all(std::function<void(shared_ptr<logger>)> fun);
 
 // Drop the reference to the given logger
-void drop(const std::string &name);
+void drop(const string &name);
 
 // Drop all references from the registry
 void drop_all();


### PR DESCRIPTION
Hi,

I was trying to use spdlog, but evolving in a tight memory industry, I had to add allocator support first.
That being done, here is my modest contribution back to you. I could try only on PC though.

- Allocators default to std::malloc & std::free so if you don't care or are already using spdlog, it makes no difference to you
- To override allocators, use 
> spdlog::allocator().allocate = xx; // or lambda [](size_t size) { return MyOwnMalloc(size); };
> spdlog::allocator().deallocate = yy; // or lambda [](void* ptr) { MyOwnFree(ptr); };

Cheers,
Cyrille // Bousk