### PR TITLE
Symbol visiblity

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -25,7 +25,7 @@
 namespace spdlog {
 namespace details {
 template<class Mutex>
-class registry_t
+class SPDLOG_API registry_t
 {
 public:
     registry_t<Mutex>(const registry_t<Mutex> &) = delete;

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -141,3 +141,28 @@
 //
 // #define SPDLOG_LEVEL_NAMES { "MY TRACE", "MY DEBUG", "MY INFO", "MY WARNING", "MY ERROR", "MY CRITICAL", "OFF" }
 ///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Uncomment to enable dll symbols export/import.
+// You also need to define SPDLOG_EXPORTS when compiling shared library.
+// 
+// #define SPDLOG_ENABLE_DLL_IMPORT_EXPORT
+///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// This defines the SPDLOG_API macro that allows a class marked with it to be
+// exported by a dll.
+// Users should define SPDLOG_EXPORTS=1 when compiling a shared library that
+// uses spdlog.
+#ifdef SPDLOG_ENABLE_DLL_IMPORT_EXPORT
+#ifdef  SPDLOG_EXPORTS
+/*Enabled as "export" while compiling the dll project*/
+#define SPDLOG_API __declspec(dllexport)
+#else
+/*Enabled as "import" in the Client side for using already created dll file*/
+#define SPDLOG_API __declspec(dllimport)
+#endif
+#else
+#define SPDLOG_API
+#endif
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
See #693

I tested this on a simple project with a shared library and a main program and the simple case
worked. I believe this will help with using spdlog from shared libraries.

I don't know if this is enough to fix the whole issue.
Users need to enable SPDLOG_ENABLE_DLL_IMPORT_EXPORT in tweakme.h and define SPDLOG_EXPORTS when building shared library.