### PR TITLE
Added file header support for step_logger

### DIFF
--- a/include/spdlog/contrib/sinks/step_file_sink.h
+++ b/include/spdlog/contrib/sinks/step_file_sink.h
@@ -58,9 +58,22 @@ struct default_step_file_name_calculator
 };
 
 /*
+ * The default action when recording starts
+ */
+struct default_action_when_recording_starts
+{
+    // Write the start message to the beginning of the file and return its size
+    static size_t beginning_of_file()
+    {
+        return 0;
+    }
+};
+
+/*
  * Rotating file sink based on size and a specified time step
  */
-template<class Mutex, class FileNameCalc = default_step_file_name_calculator>
+template<class Mutex, class FileNameCalc = default_step_file_name_calculator, 
+            class RecordingStartActions = default_action_when_recording_starts>
 class step_file_sink SPDLOG_FINAL : public base_sink<Mutex>
 {
 public:
@@ -113,7 +126,7 @@ protected:
             std::tie(_current_filename, std::ignore) = FileNameCalc::calc_filename(_base_filename, _tmp_ext);
             _file_helper.open(_current_filename);
             _tp = _next_tp();
-            _current_size = msg.formatted.size();
+            _current_size = msg.formatted.size() + RecordingStartActions::beginning_of_file();
         }
         _file_helper.write(msg);
     }


### PR DESCRIPTION
Hey. 
I started testing step_logger on the production server. I noticed that there is not enough possibility to write a header for the creation of the CSV files, and since the files are written with a limitation in volume and time, it is not the best option to add it from outside. :) 
Therefore, himself a logger.