### PR TITLE
Update fmt to v5.0.0

### DIFF
--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -88,8 +88,8 @@ class async_log_helper
             msg.level = level;
             msg.time = time;
             msg.thread_id = thread_id;
-            msg.raw.clear();
-            msg.raw << txt;
+            msg.raw = fmt::memory_buffer();
+            fmt::format_to(msg.raw, txt);
             msg.msg_id = msg_id;
         }
     };

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -37,12 +37,13 @@ struct log_msg
     level::level_enum level;
     log_clock::time_point time;
     size_t thread_id;
-    fmt::MemoryWriter raw;
-    fmt::MemoryWriter formatted;
+    fmt::memory_buffer raw;
+    fmt::memory_buffer formatted;
     size_t msg_id{0};
     // wrap this range with color codes
     size_t color_range_start{0};
     size_t color_range_end{0};
+
 };
 } // namespace details
 } // namespace spdlog

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -64,7 +64,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char *fmt, const Ar
 #if defined(SPDLOG_FMT_PRINTF)
         fmt::printf(log_msg.raw, fmt, args...);
 #else
-        log_msg.raw.write(fmt, args...);
+        fmt::format_to(log_msg.raw, fmt, args...);
 #endif
         _sink_it(log_msg);
     }
@@ -89,7 +89,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char *msg)
     try
     {
         details::log_msg log_msg(&_name, lvl);
-        log_msg.raw << msg;
+        fmt::format_to(log_msg.raw, msg);
         _sink_it(log_msg);
     }
     catch (const std::exception &ex)
@@ -113,7 +113,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
     try
     {
         details::log_msg log_msg(&_name, lvl);
-        log_msg.raw << msg;
+        fmt::format_to(log_msg.raw, "{}", msg);
         _sink_it(log_msg);
     }
     catch (const std::exception &ex)

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -1,0 +1,1301 @@
+// Formatting library for C++ - the core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_CORE_H_
+#define FMT_CORE_H_
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <iterator>
+#include <string>
+#include <type_traits>
+
+// The fmt library version in the form major * 10000 + minor * 100 + patch.
+#define FMT_VERSION 50000
+
+#ifdef __has_feature
+# define FMT_HAS_FEATURE(x) __has_feature(x)
+#else
+# define FMT_HAS_FEATURE(x) 0
+#endif
+
+#ifdef __has_include
+# define FMT_HAS_INCLUDE(x) __has_include(x)
+#else
+# define FMT_HAS_INCLUDE(x) 0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+# define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+#else
+# define FMT_GCC_VERSION 0
+#endif
+
+#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
+# define FMT_HAS_GXX_CXX11 FMT_GCC_VERSION
+#else
+# define FMT_HAS_GXX_CXX11 0
+#endif
+
+#ifdef _MSC_VER
+# define FMT_MSC_VER _MSC_VER
+#else
+# define FMT_MSC_VER 0
+#endif
+
+// Check if relaxed c++14 constexpr is supported.
+// GCC doesn't allow throw in constexpr until version 6 (bug 67371).
+#ifndef FMT_USE_CONSTEXPR
+# define FMT_USE_CONSTEXPR \
+  (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VER >= 1910 || \
+   (FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L))
+#endif
+#if FMT_USE_CONSTEXPR
+# define FMT_CONSTEXPR constexpr
+# define FMT_CONSTEXPR_DECL constexpr
+#else
+# define FMT_CONSTEXPR inline
+# define FMT_CONSTEXPR_DECL
+#endif
+
+#ifndef FMT_OVERRIDE
+# if FMT_HAS_FEATURE(cxx_override) || \
+     (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+     FMT_MSC_VER >= 1900
+#  define FMT_OVERRIDE override
+# else
+#  define FMT_OVERRIDE
+# endif
+#endif
+
+#if FMT_HAS_FEATURE(cxx_explicit_conversions) || \
+    FMT_MSC_VER >= 1800
+# define FMT_EXPLICIT explicit
+#else
+# define FMT_EXPLICIT
+#endif
+
+#ifndef FMT_NULL
+# if FMT_HAS_FEATURE(cxx_nullptr) || \
+   (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+   FMT_MSC_VER >= 1600
+#  define FMT_NULL nullptr
+#  define FMT_USE_NULLPTR 1
+# else
+#  define FMT_NULL NULL
+# endif
+#endif
+
+#ifndef FMT_USE_NULLPTR
+# define FMT_USE_NULLPTR 0
+#endif
+
+// Check if exceptions are disabled.
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
+# define FMT_EXCEPTIONS 0
+#elif FMT_MSC_VER && !_HAS_EXCEPTIONS
+# define FMT_EXCEPTIONS 0
+#endif
+#ifndef FMT_EXCEPTIONS
+# define FMT_EXCEPTIONS 1
+#endif
+
+// Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).
+#ifndef FMT_USE_NOEXCEPT
+# define FMT_USE_NOEXCEPT 0
+#endif
+
+#if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || \
+    (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || \
+    FMT_MSC_VER >= 1900
+# define FMT_DETECTED_NOEXCEPT noexcept
+#else
+# define FMT_DETECTED_NOEXCEPT throw()
+#endif
+
+#ifndef FMT_NOEXCEPT
+# if FMT_EXCEPTIONS
+#  define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
+# else
+#  define FMT_NOEXCEPT
+# endif
+#endif
+
+// This is needed because GCC still uses throw() in its headers when exceptions
+// are disabled.
+#if FMT_GCC_VERSION
+# define FMT_DTOR_NOEXCEPT FMT_DETECTED_NOEXCEPT
+#else
+# define FMT_DTOR_NOEXCEPT FMT_NOEXCEPT
+#endif
+
+#ifndef FMT_BEGIN_NAMESPACE
+# if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
+     FMT_MSC_VER >= 1900
+#  define FMT_INLINE_NAMESPACE inline namespace
+#  define FMT_END_NAMESPACE }}
+# else
+#  define FMT_INLINE_NAMESPACE namespace
+#  define FMT_END_NAMESPACE } using namespace v5; }
+# endif
+# define FMT_BEGIN_NAMESPACE namespace fmt { FMT_INLINE_NAMESPACE v5 {
+#endif
+
+#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
+# ifdef FMT_EXPORT
+#  define FMT_API __declspec(dllexport)
+# elif defined(FMT_SHARED)
+#  define FMT_API __declspec(dllimport)
+# endif
+#endif
+#ifndef FMT_API
+# define FMT_API
+#endif
+
+#ifndef FMT_ASSERT
+# define FMT_ASSERT(condition, message) assert((condition) && message)
+#endif
+
+#define FMT_DELETED = delete
+
+// A macro to disallow the copy construction and assignment.
+#define FMT_DISALLOW_COPY_AND_ASSIGN(Type) \
+    Type(const Type &) FMT_DELETED; \
+    void operator=(const Type &) FMT_DELETED
+
+// libc++ supports string_view in pre-c++17.
+#if (FMT_HAS_INCLUDE(<string_view>) && \
+      (__cplusplus > 201402L || defined(_LIBCPP_VERSION))) || \
+    (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
+# include <string_view>
+# define FMT_USE_STD_STRING_VIEW
+#elif (FMT_HAS_INCLUDE(<experimental/string_view>) && \
+       __cplusplus >= 201402L)
+# include <experimental/string_view>
+# define FMT_USE_EXPERIMENTAL_STRING_VIEW
+#endif
+
+// std::result_of is defined in <functional> in gcc 4.4.
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
+# include <functional>
+#endif
+
+FMT_BEGIN_NAMESPACE
+
+// An implementation of declval for pre-C++11 compilers such as gcc 4.
+namespace internal {
+template <typename T>
+typename std::add_rvalue_reference<T>::type declval() FMT_NOEXCEPT;
+}
+
+/**
+  An implementation of ``std::basic_string_view`` for pre-C++17. It provides a
+  subset of the API. ``fmt::basic_string_view`` is used for format strings even
+  if ``std::string_view`` is available to prevent issues when a library is
+  compiled with a different ``-std`` option than the client code (which is not
+  recommended).
+ */
+template <typename Char>
+class basic_string_view {
+ private:
+  const Char *data_;
+  size_t size_;
+
+ public:
+  typedef Char char_type;
+  typedef const Char *iterator;
+
+  // Standard basic_string_view type.
+#if defined(FMT_USE_STD_STRING_VIEW)
+  typedef std::basic_string_view<Char> type;
+#elif defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
+  typedef std::experimental::basic_string_view<Char> type;
+#else
+  struct type {
+    const char *data() const { return FMT_NULL; }
+    size_t size() const { return 0; };
+  };
+#endif
+
+  FMT_CONSTEXPR basic_string_view() FMT_NOEXCEPT : data_(FMT_NULL), size_(0) {}
+
+  /** Constructs a string reference object from a C string and a size. */
+  FMT_CONSTEXPR basic_string_view(const Char *s, size_t size) FMT_NOEXCEPT
+    : data_(s), size_(size) {}
+
+  /**
+    \rst
+    Constructs a string reference object from a C string computing
+    the size with ``std::char_traits<Char>::length``.
+    \endrst
+   */
+  basic_string_view(const Char *s)
+    : data_(s), size_(std::char_traits<Char>::length(s)) {}
+
+  /** Constructs a string reference from a ``std::basic_string`` object. */
+  template <typename Alloc>
+  FMT_CONSTEXPR basic_string_view(
+      const std::basic_string<Char, Alloc> &s) FMT_NOEXCEPT
+  : data_(s.c_str()), size_(s.size()) {}
+
+  FMT_CONSTEXPR basic_string_view(type s) FMT_NOEXCEPT
+  : data_(s.data()), size_(s.size()) {}
+
+  /** Returns a pointer to the string data. */
+  const Char *data() const { return data_; }
+
+  /** Returns the string size. */
+  FMT_CONSTEXPR size_t size() const { return size_; }
+
+  FMT_CONSTEXPR iterator begin() const { return data_; }
+  FMT_CONSTEXPR iterator end() const { return data_ + size_; }
+
+  FMT_CONSTEXPR void remove_prefix(size_t n) {
+    data_ += n;
+    size_ -= n;
+  }
+
+  // Lexicographically compare this string reference to other.
+  int compare(basic_string_view other) const {
+    size_t size = size_ < other.size_ ? size_ : other.size_;
+    int result = std::char_traits<Char>::compare(data_, other.data_, size);
+    if (result == 0)
+      result = size_ == other.size_ ? 0 : (size_ < other.size_ ? -1 : 1);
+    return result;
+  }
+
+  friend bool operator==(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) == 0;
+  }
+  friend bool operator!=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) != 0;
+  }
+  friend bool operator<(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) < 0;
+  }
+  friend bool operator<=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) <= 0;
+  }
+  friend bool operator>(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) > 0;
+  }
+  friend bool operator>=(basic_string_view lhs, basic_string_view rhs) {
+    return lhs.compare(rhs) >= 0;
+  }
+};
+
+typedef basic_string_view<char> string_view;
+typedef basic_string_view<wchar_t> wstring_view;
+
+template <typename Context>
+class basic_format_arg;
+
+template <typename Context>
+class basic_format_args;
+
+// A formatter for objects of type T.
+template <typename T, typename Char = char, typename Enable = void>
+struct formatter;
+
+namespace internal {
+
+/** A contiguous memory buffer with an optional growing ability. */
+template <typename T>
+class basic_buffer {
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_buffer);
+
+  T *ptr_;
+  std::size_t size_;
+  std::size_t capacity_;
+
+ protected:
+  basic_buffer(T *p = FMT_NULL, std::size_t size = 0, std::size_t capacity = 0)
+    FMT_NOEXCEPT: ptr_(p), size_(size), capacity_(capacity) {}
+
+  /** Sets the buffer data and capacity. */
+  void set(T *data, std::size_t capacity) FMT_NOEXCEPT {
+    ptr_ = data;
+    capacity_ = capacity;
+  }
+
+  /** Increases the buffer capacity to hold at least *capacity* elements. */
+  virtual void grow(std::size_t capacity) = 0;
+
+ public:
+  typedef T value_type;
+  typedef const T &const_reference;
+
+  virtual ~basic_buffer() {}
+
+  T *begin() FMT_NOEXCEPT { return ptr_; }
+  T *end() FMT_NOEXCEPT { return ptr_ + size_; }
+
+  /** Returns the size of this buffer. */
+  std::size_t size() const FMT_NOEXCEPT { return size_; }
+
+  /** Returns the capacity of this buffer. */
+  std::size_t capacity() const FMT_NOEXCEPT { return capacity_; }
+
+  /** Returns a pointer to the buffer data. */
+  T *data() FMT_NOEXCEPT { return ptr_; }
+
+  /** Returns a pointer to the buffer data. */
+  const T *data() const FMT_NOEXCEPT { return ptr_; }
+
+  /**
+    Resizes the buffer. If T is a POD type new elements may not be initialized.
+   */
+  void resize(std::size_t new_size) {
+    reserve(new_size);
+    size_ = new_size;
+  }
+
+  /** Reserves space to store at least *capacity* elements. */
+  void reserve(std::size_t capacity) {
+    if (capacity > capacity_)
+      grow(capacity);
+  }
+
+  void push_back(const T &value) {
+    reserve(size_ + 1);
+    ptr_[size_++] = value;
+  }
+
+  /** Appends data to the end of the buffer. */
+  template <typename U>
+  void append(const U *begin, const U *end);
+
+  T &operator[](std::size_t index) { return ptr_[index]; }
+  const T &operator[](std::size_t index) const { return ptr_[index]; }
+};
+
+typedef basic_buffer<char> buffer;
+typedef basic_buffer<wchar_t> wbuffer;
+
+// A container-backed buffer.
+template <typename Container>
+class container_buffer : public basic_buffer<typename Container::value_type> {
+ private:
+  Container &container_;
+
+ protected:
+  void grow(std::size_t capacity) FMT_OVERRIDE {
+    container_.resize(capacity);
+    this->set(&container_[0], capacity);
+  }
+
+ public:
+  explicit container_buffer(Container &c)
+    : basic_buffer<typename Container::value_type>(&c[0], c.size(), c.size()),
+      container_(c) {}
+};
+
+struct error_handler {
+  FMT_CONSTEXPR error_handler() {}
+  FMT_CONSTEXPR error_handler(const error_handler &) {}
+
+  // This function is intentionally not constexpr to give a compile-time error.
+  FMT_API void on_error(const char *message);
+};
+
+// Formatting of wide characters and strings into a narrow output is disallowed:
+//   fmt::format("{}", L"test"); // error
+// To fix this, use a wide format string:
+//   fmt::format(L"{}", L"test");
+template <typename Char>
+inline void require_wchar() {
+  static_assert(
+      std::is_same<wchar_t, Char>::value,
+      "formatting of wide characters into a narrow output is disallowed");
+}
+
+template <typename Char>
+struct named_arg_base;
+
+template <typename T, typename Char>
+struct named_arg;
+
+template <typename T>
+struct is_named_arg : std::false_type {};
+
+template <typename T, typename Char>
+struct is_named_arg<named_arg<T, Char>> : std::true_type {};
+
+enum type {
+  none_type, name_arg_type,
+  // Integer types should go first,
+  int_type, uint_type, long_long_type, ulong_long_type, bool_type, char_type,
+  last_integer_type = char_type,
+  // followed by floating-point types.
+  double_type, long_double_type, last_numeric_type = long_double_type,
+  cstring_type, string_type, pointer_type, custom_type
+};
+
+FMT_CONSTEXPR bool is_integral(type t) {
+  FMT_ASSERT(t != internal::name_arg_type, "invalid argument type");
+  return t > internal::none_type && t <= internal::last_integer_type;
+}
+
+FMT_CONSTEXPR bool is_arithmetic(type t) {
+  FMT_ASSERT(t != internal::name_arg_type, "invalid argument type");
+  return t > internal::none_type && t <= internal::last_numeric_type;
+}
+
+template <typename T, typename Char, bool ENABLE = true>
+struct convert_to_int {
+  enum {
+    value = !std::is_arithmetic<T>::value && std::is_convertible<T, int>::value
+  };
+};
+
+template <typename Char>
+struct string_value {
+  const Char *value;
+  std::size_t size;
+};
+
+template <typename Context>
+struct custom_value {
+  const void *value;
+  void (*format)(const void *arg, Context &ctx);
+};
+
+// A formatting argument value.
+template <typename Context>
+class value {
+ public:
+  typedef typename Context::char_type char_type;
+
+  union {
+    int int_value;
+    unsigned uint_value;
+    long long long_long_value;
+    unsigned long long ulong_long_value;
+    double double_value;
+    long double long_double_value;
+    const void *pointer;
+    string_value<char_type> string;
+    string_value<signed char> sstring;
+    string_value<unsigned char> ustring;
+    custom_value<Context> custom;
+  };
+
+  FMT_CONSTEXPR value(int val = 0) : int_value(val) {}
+  value(unsigned val) { uint_value = val; }
+  value(long long val) { long_long_value = val; }
+  value(unsigned long long val) { ulong_long_value = val; }
+  value(double val) { double_value = val; }
+  value(long double val) { long_double_value = val; }
+  value(const char_type *val) { string.value = val; }
+  value(const signed char *val) {
+    static_assert(std::is_same<char, char_type>::value,
+                  "incompatible string types");
+    sstring.value = val;
+  }
+  value(const unsigned char *val) {
+    static_assert(std::is_same<char, char_type>::value,
+                  "incompatible string types");
+    ustring.value = val;
+  }
+  value(basic_string_view<char_type> val) {
+    string.value = val.data();
+    string.size = val.size();
+  }
+  value(const void *val) { pointer = val; }
+
+  template <typename T>
+  explicit value(const T &val) {
+    custom.value = &val;
+    custom.format = &format_custom_arg<T>;
+  }
+
+  const named_arg_base<char_type> &as_named_arg() {
+    return *static_cast<const named_arg_base<char_type>*>(pointer);
+  }
+
+ private:
+  // Formats an argument of a custom type, such as a user-defined class.
+  template <typename T>
+  static void format_custom_arg(const void *arg, Context &ctx) {
+    // Get the formatter type through the context to allow different contexts
+    // have different extension points, e.g. `formatter<T>` for `format` and
+    // `printf_formatter<T>` for `printf`.
+    typename Context::template formatter_type<T>::type f;
+    auto &&parse_ctx = ctx.parse_context();
+    parse_ctx.advance_to(f.parse(parse_ctx));
+    ctx.advance_to(f.format(*static_cast<const T*>(arg), ctx));
+  }
+};
+
+template <typename Context, type TYPE>
+struct typed_value : value<Context> {
+  static const type type_tag = TYPE;
+
+  template <typename T>
+  FMT_CONSTEXPR typed_value(const T &val) : value<Context>(val) {}
+};
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value);
+
+#define FMT_MAKE_VALUE(TAG, ArgType, ValueType) \
+  template <typename C> \
+  FMT_CONSTEXPR typed_value<C, TAG> make_value(ArgType val) { \
+    return static_cast<ValueType>(val); \
+  }
+
+FMT_MAKE_VALUE(bool_type, bool, int)
+FMT_MAKE_VALUE(int_type, short, int)
+FMT_MAKE_VALUE(uint_type, unsigned short, unsigned)
+FMT_MAKE_VALUE(int_type, int, int)
+FMT_MAKE_VALUE(uint_type, unsigned, unsigned)
+
+// To minimize the number of types we need to deal with, long is translated
+// either to int or to long long depending on its size.
+typedef std::conditional<sizeof(long) == sizeof(int), int, long long>::type
+        long_type;
+FMT_MAKE_VALUE(
+    (sizeof(long) == sizeof(int) ? int_type : long_long_type), long, long_type)
+typedef std::conditional<sizeof(unsigned long) == sizeof(unsigned),
+                         unsigned, unsigned long long>::type ulong_type;
+FMT_MAKE_VALUE(
+    (sizeof(unsigned long) == sizeof(unsigned) ? uint_type : ulong_long_type),
+    unsigned long, ulong_type)
+
+FMT_MAKE_VALUE(long_long_type, long long, long long)
+FMT_MAKE_VALUE(ulong_long_type, unsigned long long, unsigned long long)
+FMT_MAKE_VALUE(int_type, signed char, int)
+FMT_MAKE_VALUE(uint_type, unsigned char, unsigned)
+FMT_MAKE_VALUE(char_type, char, int)
+
+#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
+template <typename C>
+inline typed_value<C, char_type> make_value(wchar_t val) {
+  require_wchar<typename C::char_type>();
+  return static_cast<int>(val);
+}
+#endif
+
+FMT_MAKE_VALUE(double_type, float, double)
+FMT_MAKE_VALUE(double_type, double, double)
+FMT_MAKE_VALUE(long_double_type, long double, long double)
+
+// Formatting of wide strings into a narrow buffer and multibyte strings
+// into a wide buffer is disallowed (https://github.com/fmtlib/fmt/pull/606).
+FMT_MAKE_VALUE(cstring_type, typename C::char_type*,
+               const typename C::char_type*)
+FMT_MAKE_VALUE(cstring_type, const typename C::char_type*,
+               const typename C::char_type*)
+
+FMT_MAKE_VALUE(cstring_type, signed char*, const signed char*)
+FMT_MAKE_VALUE(cstring_type, const signed char*, const signed char*)
+FMT_MAKE_VALUE(cstring_type, unsigned char*, const unsigned char*)
+FMT_MAKE_VALUE(cstring_type, const unsigned char*, const unsigned char*)
+FMT_MAKE_VALUE(string_type, basic_string_view<typename C::char_type>,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(string_type,
+               typename basic_string_view<typename C::char_type>::type,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(string_type, const std::basic_string<typename C::char_type>&,
+               basic_string_view<typename C::char_type>)
+FMT_MAKE_VALUE(pointer_type, void*, const void*)
+FMT_MAKE_VALUE(pointer_type, const void*, const void*)
+
+#if FMT_USE_NULLPTR
+FMT_MAKE_VALUE(pointer_type, std::nullptr_t, const void*)
+#endif
+
+// Formatting of arbitrary pointers is disallowed. If you want to output a
+// pointer cast it to "void *" or "const void *". In particular, this forbids
+// formatting of "[const] volatile char *" which is printed as bool by
+// iostreams.
+template <typename C, typename T>
+typename std::enable_if<!std::is_same<T, typename C::char_type>::value>::type
+    make_value(const T *) {
+  static_assert(!sizeof(T), "formatting of non-void pointers is disallowed");
+}
+
+template <typename C, typename T>
+inline typename std::enable_if<
+    std::is_enum<T>::value && convert_to_int<T, typename C::char_type>::value,
+    typed_value<C, int_type>>::type
+  make_value(const T &val) { return static_cast<int>(val); }
+
+template <typename C, typename T, typename Char = typename C::char_type>
+inline typename std::enable_if<
+    !convert_to_int<T, Char>::value &&
+    !std::is_convertible<T, basic_string_view<Char>>::value,
+    // Implicit conversion to std::string is not handled here because it's
+    // unsafe: https://github.com/fmtlib/fmt/issues/729
+    typed_value<C, custom_type>>::type
+  make_value(const T &val) { return val; }
+
+template <typename C, typename T>
+typed_value<C, name_arg_type>
+    make_value(const named_arg<T, typename C::char_type> &val) {
+  basic_format_arg<C> arg = make_arg<C>(val.value);
+  std::memcpy(val.data, &arg, sizeof(arg));
+  return static_cast<const void*>(&val);
+}
+
+// Maximum number of arguments with packed types.
+enum { max_packed_args = 15 };
+
+template <typename Context>
+class arg_map;
+
+template <typename>
+struct result_of;
+
+template <typename F, typename... Args>
+struct result_of<F(Args...)> {
+  // A workaround for gcc 4.4 that doesn't allow F to be a reference.
+  typedef typename std::result_of<
+    typename std::remove_reference<F>::type(Args...)>::type type;
+};
+}
+
+// A formatting argument. It is a trivially copyable/constructible type to
+// allow storage in basic_memory_buffer.
+template <typename Context>
+class basic_format_arg {
+ private:
+  internal::value<Context> value_;
+  internal::type type_;
+
+  template <typename ContextType, typename T>
+  friend FMT_CONSTEXPR basic_format_arg<ContextType>
+    internal::make_arg(const T &value);
+
+  template <typename Visitor, typename Ctx>
+  friend FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
+    visit(Visitor &&vis, basic_format_arg<Ctx> arg);
+
+  friend class basic_format_args<Context>;
+  friend class internal::arg_map<Context>;
+
+  typedef typename Context::char_type char_type;
+
+ public:
+  class handle {
+   public:
+    explicit handle(internal::custom_value<Context> custom): custom_(custom) {}
+
+    void format(Context &ctx) const { custom_.format(custom_.value, ctx); }
+
+   private:
+    internal::custom_value<Context> custom_;
+  };
+
+  FMT_CONSTEXPR basic_format_arg() : type_(internal::none_type) {}
+
+  FMT_EXPLICIT operator bool() const FMT_NOEXCEPT {
+    return type_ != internal::none_type;
+  }
+
+  internal::type type() const { return type_; }
+
+  bool is_integral() const { return internal::is_integral(type_); }
+  bool is_arithmetic() const { return internal::is_arithmetic(type_); }
+};
+
+// Parsing context consisting of a format string range being parsed and an
+// argument counter for automatic indexing.
+template <typename Char, typename ErrorHandler = internal::error_handler>
+class basic_parse_context : private ErrorHandler {
+ private:
+  basic_string_view<Char> format_str_;
+  int next_arg_id_;
+
+ public:
+  typedef Char char_type;
+  typedef typename basic_string_view<Char>::iterator iterator;
+
+  explicit FMT_CONSTEXPR basic_parse_context(
+      basic_string_view<Char> format_str, ErrorHandler eh = ErrorHandler())
+    : ErrorHandler(eh), format_str_(format_str), next_arg_id_(0) {}
+
+  // Returns an iterator to the beginning of the format string range being
+  // parsed.
+  FMT_CONSTEXPR iterator begin() const FMT_NOEXCEPT {
+    return format_str_.begin();
+  }
+
+  // Returns an iterator past the end of the format string range being parsed.
+  FMT_CONSTEXPR iterator end() const FMT_NOEXCEPT { return format_str_.end(); }
+
+  // Advances the begin iterator to ``it``.
+  FMT_CONSTEXPR void advance_to(iterator it) {
+    format_str_.remove_prefix(it - begin());
+  }
+
+  // Returns the next argument index.
+  FMT_CONSTEXPR unsigned next_arg_id();
+
+  FMT_CONSTEXPR bool check_arg_id(unsigned) {
+    if (next_arg_id_ > 0) {
+      on_error("cannot switch from automatic to manual argument indexing");
+      return false;
+    }
+    next_arg_id_ = -1;
+    return true;
+  }
+  void check_arg_id(basic_string_view<Char>) {}
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    ErrorHandler::on_error(message);
+  }
+
+  FMT_CONSTEXPR ErrorHandler error_handler() const { return *this; }
+};
+
+typedef basic_parse_context<char> parse_context;
+typedef basic_parse_context<wchar_t> wparse_context;
+
+namespace internal {
+// A map from argument names to their values for named arguments.
+template <typename Context>
+class arg_map {
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(arg_map);
+
+  typedef typename Context::char_type char_type;
+
+  struct entry {
+    basic_string_view<char_type> name;
+    basic_format_arg<Context> arg;
+  };
+
+  entry *map_;
+  unsigned size_;
+
+  void push_back(value<Context> val) {
+    const internal::named_arg_base<char_type> &named = val.as_named_arg();
+    map_[size_] = entry{named.name, named.template deserialize<Context>()};
+    ++size_;
+  }
+
+ public:
+  arg_map() : map_(FMT_NULL), size_(0) {}
+  void init(const basic_format_args<Context> &args);
+  ~arg_map() { delete [] map_; }
+
+  basic_format_arg<Context> find(basic_string_view<char_type> name) const {
+    // The list is unsorted, so just return the first matching name.
+    for (auto it = map_, end = map_ + size_; it != end; ++it) {
+      if (it->name == name)
+        return it->arg;
+    }
+    return basic_format_arg<Context>();
+  }
+};
+
+template <typename OutputIt, typename Context, typename Char>
+class context_base {
+ public:
+  typedef OutputIt iterator;
+
+ private:
+  basic_parse_context<Char> parse_context_;
+  iterator out_;
+  basic_format_args<Context> args_;
+
+ protected:
+  typedef Char char_type;
+  typedef basic_format_arg<Context> format_arg;
+
+  context_base(OutputIt out, basic_string_view<char_type> format_str,
+               basic_format_args<Context> args)
+  : parse_context_(format_str), out_(out), args_(args) {}
+
+  // Returns the argument with specified index.
+  format_arg do_get_arg(unsigned arg_id) {
+    format_arg arg = args_.get(arg_id);
+    if (!arg)
+      parse_context_.on_error("argument index out of range");
+    return arg;
+  }
+
+  // Checks if manual indexing is used and returns the argument with
+  // specified index.
+  format_arg get_arg(unsigned arg_id) {
+    return this->parse_context().check_arg_id(arg_id) ?
+      this->do_get_arg(arg_id) : format_arg();
+  }
+
+ public:
+  basic_parse_context<char_type> &parse_context() {
+    return parse_context_;
+  }
+
+  internal::error_handler error_handler() {
+    return parse_context_.error_handler();
+  }
+
+  void on_error(const char *message) { parse_context_.on_error(message); }
+
+  // Returns an iterator to the beginning of the output range.
+  iterator out() { return out_; }
+  iterator begin() { return out_; }  // deprecated
+
+  // Advances the begin iterator to ``it``.
+  void advance_to(iterator it) { out_ = it; }
+
+  basic_format_args<Context> args() const { return args_; }
+};
+
+// Extracts a reference to the container from back_insert_iterator.
+template <typename Container>
+inline Container &get_container(std::back_insert_iterator<Container> it) {
+  typedef std::back_insert_iterator<Container> bi_iterator;
+  struct accessor: bi_iterator {
+    accessor(bi_iterator iter) : bi_iterator(iter) {}
+    using bi_iterator::container;
+  };
+  return *accessor(it).container;
+}
+}  // namespace internal
+
+// Formatting context.
+template <typename OutputIt, typename Char>
+class basic_format_context :
+  public internal::context_base<
+    OutputIt, basic_format_context<OutputIt, Char>, Char> {
+ public:
+  /** The character type for the output. */
+  typedef Char char_type;
+
+  // using formatter_type = formatter<T, char_type>;
+  template <typename T>
+  struct formatter_type { typedef formatter<T, char_type> type; };
+
+ private:
+  internal::arg_map<basic_format_context> map_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_format_context);
+
+  typedef internal::context_base<OutputIt, basic_format_context, Char> base;
+  typedef typename base::format_arg format_arg;
+  using base::get_arg;
+
+ public:
+  using typename base::iterator;
+
+  /**
+   Constructs a ``basic_format_context`` object. References to the arguments are
+   stored in the object so make sure they have appropriate lifetimes.
+   */
+  basic_format_context(OutputIt out, basic_string_view<char_type> format_str,
+                basic_format_args<basic_format_context> args)
+    : base(out, format_str, args) {}
+
+  format_arg next_arg() {
+    return this->do_get_arg(this->parse_context().next_arg_id());
+  }
+  format_arg get_arg(unsigned arg_id) { return this->do_get_arg(arg_id); }
+
+  // Checks if manual indexing is used and returns the argument with the
+  // specified name.
+  format_arg get_arg(basic_string_view<char_type> name);
+};
+
+template <typename Char>
+struct buffer_context {
+  typedef basic_format_context<
+    std::back_insert_iterator<internal::basic_buffer<Char>>, Char> type;
+};
+typedef buffer_context<char>::type format_context;
+typedef buffer_context<wchar_t>::type wformat_context;
+
+namespace internal {
+template <typename Context, typename T>
+struct get_type {
+  typedef decltype(make_value<Context>(
+        declval<typename std::decay<T>::type&>())) value_type;
+  static const type value = value_type::type_tag;
+};
+
+template <typename Context>
+FMT_CONSTEXPR uint64_t get_types() { return 0; }
+
+template <typename Context, typename Arg, typename... Args>
+FMT_CONSTEXPR uint64_t get_types() {
+  return get_type<Context, Arg>::value | (get_types<Context, Args...>() << 4);
+}
+
+template <typename Context, typename T>
+FMT_CONSTEXPR basic_format_arg<Context> make_arg(const T &value) {
+  basic_format_arg<Context> arg;
+  arg.type_ = get_type<Context, T>::value;
+  arg.value_ = make_value<Context>(value);
+  return arg;
+}
+
+template <bool IS_PACKED, typename Context, typename T>
+inline typename std::enable_if<IS_PACKED, value<Context>>::type
+    make_arg(const T &value) {
+  return make_value<Context>(value);
+}
+
+template <bool IS_PACKED, typename Context, typename T>
+inline typename std::enable_if<!IS_PACKED, basic_format_arg<Context>>::type
+    make_arg(const T &value) {
+  return make_arg<Context>(value);
+}
+}
+
+/**
+  \rst
+  An array of references to arguments. It can be implicitly converted into
+  `~fmt::basic_format_args` for passing into type-erased formatting functions
+  such as `~fmt::vformat`.
+  \endrst
+ */
+template <typename Context, typename ...Args>
+class format_arg_store {
+ private:
+  static const size_t NUM_ARGS = sizeof...(Args);
+
+  // Packed is a macro on MinGW so use IS_PACKED instead.
+  static const bool IS_PACKED = NUM_ARGS < internal::max_packed_args;
+
+  typedef typename std::conditional<IS_PACKED,
+    internal::value<Context>, basic_format_arg<Context>>::type value_type;
+
+  // If the arguments are not packed, add one more element to mark the end.
+  value_type data_[NUM_ARGS + (IS_PACKED && NUM_ARGS != 0 ? 0 : 1)];
+
+  friend class basic_format_args<Context>;
+
+  static FMT_CONSTEXPR uint64_t get_types() {
+    return IS_PACKED ? internal::get_types<Context, Args...>()
+                : -static_cast<int64_t>(NUM_ARGS);
+  }
+
+ public:
+#if FMT_USE_CONSTEXPR
+  static constexpr uint64_t TYPES = get_types();
+#else
+  static const uint64_t TYPES;
+#endif
+
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 405
+  // Workaround an array initialization bug in gcc 4.5 and earlier.
+  format_arg_store(const Args &... args) {
+    data_ = {internal::make_arg<IS_PACKED, Context>(args)...};
+  }
+#else
+  format_arg_store(const Args &... args)
+    : data_{internal::make_arg<IS_PACKED, Context>(args)...} {}
+#endif
+};
+
+#if !FMT_USE_CONSTEXPR
+template <typename Context, typename ...Args>
+const uint64_t format_arg_store<Context, Args...>::TYPES = get_types();
+#endif
+
+/**
+  \rst
+  Constructs an `~fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~fmt::format_args`. `Context` can
+  be omitted in which case it defaults to `~fmt::context`.
+  \endrst
+ */
+template <typename Context, typename ...Args>
+inline format_arg_store<Context, Args...>
+    make_format_args(const Args & ... args) {
+  return format_arg_store<Context, Args...>(args...);
+}
+
+template <typename ...Args>
+inline format_arg_store<format_context, Args...>
+    make_format_args(const Args & ... args) {
+  return format_arg_store<format_context, Args...>(args...);
+}
+
+/** Formatting arguments. */
+template <typename Context>
+class basic_format_args {
+ public:
+  typedef unsigned size_type;
+  typedef basic_format_arg<Context>  format_arg;
+
+ private:
+  // To reduce compiled code size per formatting function call, types of first
+  // max_packed_args arguments are passed in the types_ field.
+  uint64_t types_;
+  union {
+    // If the number of arguments is less than max_packed_args, the argument
+    // values are stored in values_, otherwise they are stored in args_.
+    // This is done to reduce compiled code size as storing larger objects
+    // may require more code (at least on x86-64) even if the same amount of
+    // data is actually copied to stack. It saves ~10% on the bloat test.
+    const internal::value<Context> *values_;
+    const format_arg *args_;
+  };
+
+  typename internal::type type(unsigned index) const {
+    unsigned shift = index * 4;
+    uint64_t mask = 0xf;
+    return static_cast<typename internal::type>(
+      (types_ & (mask << shift)) >> shift);
+  }
+
+  friend class internal::arg_map<Context>;
+
+  void set_data(const internal::value<Context> *values) { values_ = values; }
+  void set_data(const format_arg *args) { args_ = args; }
+
+  format_arg do_get(size_type index) const {
+    int64_t signed_types = static_cast<int64_t>(types_);
+    if (signed_types < 0) {
+      uint64_t num_args = -signed_types;
+      return index < num_args ? args_[index] : format_arg();
+    }
+    format_arg arg;
+    if (index > internal::max_packed_args)
+      return arg;
+    arg.type_ = type(index);
+    if (arg.type_ == internal::none_type)
+      return arg;
+    internal::value<Context> &val = arg.value_;
+    val = values_[index];
+    return arg;
+  }
+
+ public:
+  basic_format_args() : types_(0) {}
+
+  /**
+   \rst
+   Constructs a `basic_format_args` object from `~fmt::format_arg_store`.
+   \endrst
+   */
+  template <typename... Args>
+  basic_format_args(const format_arg_store<Context, Args...> &store)
+  : types_(store.TYPES) {
+    set_data(store.data_);
+  }
+
+  /** Returns the argument at specified index. */
+  format_arg get(size_type index) const {
+    format_arg arg = do_get(index);
+    return arg.type_ == internal::name_arg_type ?
+          arg.value_.as_named_arg().template deserialize<Context>() : arg;
+  }
+
+  unsigned max_size() const {
+    int64_t signed_types = static_cast<int64_t>(types_);
+    return static_cast<unsigned>(
+        signed_types < 0 ?
+        -signed_types : static_cast<int64_t>(internal::max_packed_args));
+  }
+};
+
+/** An alias to ``basic_format_args<context>``. */
+// It is a separate type rather than a typedef to make symbols readable.
+struct format_args: basic_format_args<format_context> {
+  template <typename ...Args>
+  format_args(Args && ... arg)
+  : basic_format_args<format_context>(std::forward<Args>(arg)...) {}
+};
+struct wformat_args : basic_format_args<wformat_context> {
+  template <typename ...Args>
+  wformat_args(Args && ... arg)
+  : basic_format_args<wformat_context>(std::forward<Args>(arg)...) {}
+};
+
+namespace internal {
+template <typename Char>
+struct named_arg_base {
+  basic_string_view<Char> name;
+
+  // Serialized value<context>.
+  mutable char data[sizeof(basic_format_arg<format_context>)];
+
+  named_arg_base(basic_string_view<Char> nm) : name(nm) {}
+
+  template <typename Context>
+  basic_format_arg<Context> deserialize() const {
+    basic_format_arg<Context> arg;
+    std::memcpy(&arg, data, sizeof(basic_format_arg<Context>));
+    return arg;
+  }
+};
+
+template <typename T, typename Char>
+struct named_arg : named_arg_base<Char> {
+  const T &value;
+
+  named_arg(basic_string_view<Char> name, const T &val)
+    : named_arg_base<Char>(name), value(val) {}
+};
+}
+
+/**
+  \rst
+  Returns a named argument to be used in a formatting function.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {s:.2f} seconds", fmt::arg("s", 1.23));
+  \endrst
+ */
+template <typename T>
+inline internal::named_arg<T, char> arg(string_view name, const T &arg) {
+  return internal::named_arg<T, char>(name, arg);
+}
+
+template <typename T>
+inline internal::named_arg<T, wchar_t> arg(wstring_view name, const T &arg) {
+  return internal::named_arg<T, wchar_t>(name, arg);
+}
+
+// This function template is deleted intentionally to disable nested named
+// arguments as in ``format("{}", arg("a", arg("b", 42)))``.
+template <typename S, typename T, typename Char>
+void arg(S, internal::named_arg<T, Char>) FMT_DELETED;
+
+enum color { black, red, green, yellow, blue, magenta, cyan, white };
+
+FMT_API void vprint_colored(color c, string_view format, format_args args);
+FMT_API void vprint_colored(color c, wstring_view format, wformat_args args);
+
+/**
+  Formats a string and prints it to stdout using ANSI escape sequences to
+  specify color (experimental).
+  Example:
+    fmt::print_colored(fmt::RED, "Elapsed time: {0:.2f} seconds", 1.23);
+ */
+template <typename... Args>
+inline void print_colored(color c, string_view format_str,
+                          const Args & ... args) {
+  vprint_colored(c, format_str, make_format_args(args...));
+}
+
+template <typename... Args>
+inline void print_colored(color c, wstring_view format_str,
+                          const Args & ... args) {
+  vprint_colored(c, format_str, make_format_args<wformat_context>(args...));
+}
+
+format_context::iterator vformat_to(
+    internal::buffer &buf, string_view format_str, format_args args);
+wformat_context::iterator vformat_to(
+    internal::wbuffer &buf, wstring_view format_str, wformat_args args);
+
+template <typename Container>
+struct is_contiguous : std::false_type {};
+
+template <typename Char>
+struct is_contiguous<std::basic_string<Char>> : std::true_type {};
+
+template <typename Char>
+struct is_contiguous<internal::basic_buffer<Char>> : std::true_type {};
+
+/** Formats a string and writes the output to ``out``. */
+template <typename Container>
+typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    vformat_to(std::back_insert_iterator<Container> out,
+               string_view format_str, format_args args) {
+  auto& container = internal::get_container(out);
+  internal::container_buffer<Container> buf(container);
+  vformat_to(buf, format_str, args);
+  return std::back_inserter(container);
+}
+
+template <typename Container>
+typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+  vformat_to(std::back_insert_iterator<Container> out,
+             wstring_view format_str, wformat_args args) {
+  auto& container = internal::get_container(out);
+  internal::container_buffer<Container> buf(container);
+  vformat_to(buf, format_str, args);
+  return std::back_inserter(container);
+}
+
+std::string vformat(string_view format_str, format_args args);
+std::wstring vformat(wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Formats arguments and returns the result as a string.
+
+  **Example**::
+
+    #include <fmt/core.h>
+    std::string message = fmt::format("The answer is {}", 42);
+  \endrst
+*/
+template <typename... Args>
+inline std::string format(string_view format_str, const Args & ... args) {
+  // This should be just
+  // return vformat(format_str, make_format_args(args...));
+  // but gcc has trouble optimizing the latter, so break it down.
+  format_arg_store<format_context, Args...> as{args...};
+  return vformat(format_str, as);
+}
+template <typename... Args>
+inline std::wstring format(wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as{args...};
+  return vformat(format_str, as);
+}
+
+FMT_API void vprint(std::FILE *f, string_view format_str, format_args args);
+FMT_API void vprint(std::FILE *f, wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to the file *f*.
+
+  **Example**::
+
+    fmt::print(stderr, "Don't {}!", "panic");
+  \endrst
+ */
+template <typename... Args>
+inline void print(std::FILE *f, string_view format_str, const Args & ... args) {
+  format_arg_store<format_context, Args...> as(args...);
+  vprint(f, format_str, as);
+}
+template <typename... Args>
+inline void print(std::FILE *f, wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as(args...);
+  vprint(f, format_str, as);
+}
+
+FMT_API void vprint(string_view format_str, format_args args);
+FMT_API void vprint(wstring_view format_str, wformat_args args);
+
+/**
+  \rst
+  Prints formatted data to ``stdout``.
+
+  **Example**::
+
+    fmt::print("Elapsed time: {0:.2f} seconds", 1.23);
+  \endrst
+ */
+template <typename... Args>
+inline void print(string_view format_str, const Args & ... args) {
+  format_arg_store<format_context, Args...> as{args...};
+  vprint(format_str, as);
+}
+
+template <typename... Args>
+inline void print(wstring_view format_str, const Args & ... args) {
+  format_arg_store<wformat_context, Args...> as(args...);
+  vprint(format_str, as);
+}
+FMT_END_NAMESPACE
+
+#endif  // FMT_CORE_H_

--- a/include/spdlog/fmt/bundled/format-inl.h
+++ b/include/spdlog/fmt/bundled/format-inl.h
@@ -1,0 +1,540 @@
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+
+#ifndef FMT_FORMAT_INL_H_
+#define FMT_FORMAT_INL_H_
+
+#include "format.h"
+
+#include <string.h>
+
+#include <cctype>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>  // for std::ptrdiff_t
+#include <locale>
+
+#if defined(_WIN32) && defined(__MINGW32__)
+# include <cstring>
+#endif
+
+#if FMT_USE_WINDOWS_H
+# if !defined(FMT_HEADER_ONLY) && !defined(WIN32_LEAN_AND_MEAN)
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# if defined(NOMINMAX) || defined(FMT_WIN_MINMAX)
+#  include <windows.h>
+# else
+#  define NOMINMAX
+#  include <windows.h>
+#  undef NOMINMAX
+# endif
+#endif
+
+#if FMT_EXCEPTIONS
+# define FMT_TRY try
+# define FMT_CATCH(x) catch (x)
+#else
+# define FMT_TRY if (true)
+# define FMT_CATCH(x) if (false)
+#endif
+
+#ifdef __GNUC__
+// Disable the warning about declaration shadowing because it affects too
+// many valid cases.
+# pragma GCC diagnostic ignored "-Wshadow"
+#endif
+
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable: 4127)  // conditional expression is constant
+# pragma warning(disable: 4702)  // unreachable code
+// Disable deprecation warning for strerror. The latter is not called but
+// MSVC fails to detect it.
+# pragma warning(disable: 4996)
+#endif
+
+// Dummy implementations of strerror_r and strerror_s called if corresponding
+// system functions are not available.
+inline fmt::internal::null<> strerror_r(int, char *, ...) {
+  return fmt::internal::null<>();
+}
+inline fmt::internal::null<> strerror_s(char *, std::size_t, ...) {
+  return fmt::internal::null<>();
+}
+
+FMT_BEGIN_NAMESPACE
+
+FMT_FUNC format_error::~format_error() throw() {}
+FMT_FUNC system_error::~system_error() FMT_DTOR_NOEXCEPT {}
+
+namespace {
+
+#ifndef _MSC_VER
+# define FMT_SNPRINTF snprintf
+#else  // _MSC_VER
+inline int fmt_snprintf(char *buffer, size_t size, const char *format, ...) {
+  va_list args;
+  va_start(args, format);
+  int result = vsnprintf_s(buffer, size, _TRUNCATE, format, args);
+  va_end(args);
+  return result;
+}
+# define FMT_SNPRINTF fmt_snprintf
+#endif  // _MSC_VER
+
+#if defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+# define FMT_SWPRINTF snwprintf
+#else
+# define FMT_SWPRINTF swprintf
+#endif // defined(_WIN32) && defined(__MINGW32__) && !defined(__NO_ISOCEXT)
+
+const char RESET_COLOR[] = "\x1b[0m";
+const wchar_t WRESET_COLOR[] = L"\x1b[0m"; 
+
+typedef void (*FormatFunc)(internal::buffer &, int, string_view);
+
+// Portable thread-safe version of strerror.
+// Sets buffer to point to a string describing the error code.
+// This can be either a pointer to a string stored in buffer,
+// or a pointer to some static immutable string.
+// Returns one of the following values:
+//   0      - success
+//   ERANGE - buffer is not large enough to store the error message
+//   other  - failure
+// Buffer should be at least of size 1.
+int safe_strerror(
+    int error_code, char *&buffer, std::size_t buffer_size) FMT_NOEXCEPT {
+  FMT_ASSERT(buffer != FMT_NULL && buffer_size != 0, "invalid buffer");
+
+  class dispatcher {
+   private:
+    int error_code_;
+    char *&buffer_;
+    std::size_t buffer_size_;
+
+    // A noop assignment operator to avoid bogus warnings.
+    void operator=(const dispatcher &) {}
+
+    // Handle the result of XSI-compliant version of strerror_r.
+    int handle(int result) {
+      // glibc versions before 2.13 return result in errno.
+      return result == -1 ? errno : result;
+    }
+
+    // Handle the result of GNU-specific version of strerror_r.
+    int handle(char *message) {
+      // If the buffer is full then the message is probably truncated.
+      if (message == buffer_ && strlen(buffer_) == buffer_size_ - 1)
+        return ERANGE;
+      buffer_ = message;
+      return 0;
+    }
+
+    // Handle the case when strerror_r is not available.
+    int handle(internal::null<>) {
+      return fallback(strerror_s(buffer_, buffer_size_, error_code_));
+    }
+
+    // Fallback to strerror_s when strerror_r is not available.
+    int fallback(int result) {
+      // If the buffer is full then the message is probably truncated.
+      return result == 0 && strlen(buffer_) == buffer_size_ - 1 ?
+            ERANGE : result;
+    }
+
+    // Fallback to strerror if strerror_r and strerror_s are not available.
+    int fallback(internal::null<>) {
+      errno = 0;
+      buffer_ = strerror(error_code_);
+      return errno;
+    }
+
+   public:
+    dispatcher(int err_code, char *&buf, std::size_t buf_size)
+      : error_code_(err_code), buffer_(buf), buffer_size_(buf_size) {}
+
+    int run() {
+      return handle(strerror_r(error_code_, buffer_, buffer_size_));
+    }
+  };
+  return dispatcher(error_code, buffer, buffer_size).run();
+}
+
+void format_error_code(internal::buffer &out, int error_code,
+                       string_view message) FMT_NOEXCEPT {
+  // Report error code making sure that the output fits into
+  // inline_buffer_size to avoid dynamic memory allocation and potential
+  // bad_alloc.
+  out.resize(0);
+  static const char SEP[] = ": ";
+  static const char ERROR_STR[] = "error ";
+  // Subtract 2 to account for terminating null characters in SEP and ERROR_STR.
+  std::size_t error_code_size = sizeof(SEP) + sizeof(ERROR_STR) - 2;
+  typedef internal::int_traits<int>::main_type main_type;
+  main_type abs_value = static_cast<main_type>(error_code);
+  if (internal::is_negative(error_code)) {
+    abs_value = 0 - abs_value;
+    ++error_code_size;
+  }
+  error_code_size += internal::count_digits(abs_value);
+  writer w(out);
+  if (message.size() <= inline_buffer_size - error_code_size) {
+    w.write(message);
+    w.write(SEP);
+  }
+  w.write(ERROR_STR);
+  w.write(error_code);
+  assert(out.size() <= inline_buffer_size);
+}
+
+void report_error(FormatFunc func, int error_code,
+                  string_view message) FMT_NOEXCEPT {
+  memory_buffer full_message;
+  func(full_message, error_code, message);
+  // Use Writer::data instead of Writer::c_str to avoid potential memory
+  // allocation.
+  std::fwrite(full_message.data(), full_message.size(), 1, stderr);
+  std::fputc('\n', stderr);
+}
+}  // namespace
+
+class locale {
+ private:
+  std::locale locale_;
+
+ public:
+  explicit locale(std::locale loc = std::locale()) : locale_(loc) {}
+  std::locale get() { return locale_; }
+};
+
+template <typename Char>
+FMT_FUNC Char internal::thousands_sep(locale_provider *lp) {
+  std::locale loc = lp ? lp->locale().get() : std::locale();
+  return std::use_facet<std::numpunct<Char>>(loc).thousands_sep();
+}
+
+FMT_FUNC void system_error::init(
+    int err_code, string_view format_str, format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  format_system_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+namespace internal {
+template <typename T>
+int char_traits<char>::format_float(
+    char *buffer, std::size_t size, const char *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SNPRINTF(buffer, size, format, value) :
+        FMT_SNPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SNPRINTF(buffer, size, format, width, value) :
+      FMT_SNPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+int char_traits<wchar_t>::format_float(
+    wchar_t *buffer, std::size_t size, const wchar_t *format,
+    unsigned width, int precision, T value) {
+  if (width == 0) {
+    return precision < 0 ?
+        FMT_SWPRINTF(buffer, size, format, value) :
+        FMT_SWPRINTF(buffer, size, format, precision, value);
+  }
+  return precision < 0 ?
+      FMT_SWPRINTF(buffer, size, format, width, value) :
+      FMT_SWPRINTF(buffer, size, format, width, precision, value);
+}
+
+template <typename T>
+const char basic_data<T>::DIGITS[] =
+    "0001020304050607080910111213141516171819"
+    "2021222324252627282930313233343536373839"
+    "4041424344454647484950515253545556575859"
+    "6061626364656667686970717273747576777879"
+    "8081828384858687888990919293949596979899";
+
+#define FMT_POWERS_OF_10(factor) \
+  factor * 10, \
+  factor * 100, \
+  factor * 1000, \
+  factor * 10000, \
+  factor * 100000, \
+  factor * 1000000, \
+  factor * 10000000, \
+  factor * 100000000, \
+  factor * 1000000000
+
+template <typename T>
+const uint32_t basic_data<T>::POWERS_OF_10_32[] = {
+  0, FMT_POWERS_OF_10(1)
+};
+
+template <typename T>
+const uint64_t basic_data<T>::POWERS_OF_10_64[] = {
+  0,
+  FMT_POWERS_OF_10(1),
+  FMT_POWERS_OF_10(1000000000ull),
+  10000000000000000000ull
+};
+
+// Normalized 64-bit significands of pow(10, k), for k = -348, -340, ..., 340.
+// These are generated by support/compute-powers.py.
+template <typename T>
+const uint64_t basic_data<T>::POW10_SIGNIFICANDS[] = {
+  0xfa8fd5a0081c0288ull, 0xbaaee17fa23ebf76ull, 0x8b16fb203055ac76ull,
+  0xcf42894a5dce35eaull, 0x9a6bb0aa55653b2dull, 0xe61acf033d1a45dfull,
+  0xab70fe17c79ac6caull, 0xff77b1fcbebcdc4full, 0xbe5691ef416bd60cull,
+  0x8dd01fad907ffc3cull, 0xd3515c2831559a83ull, 0x9d71ac8fada6c9b5ull,
+  0xea9c227723ee8bcbull, 0xaecc49914078536dull, 0x823c12795db6ce57ull,
+  0xc21094364dfb5637ull, 0x9096ea6f3848984full, 0xd77485cb25823ac7ull,
+  0xa086cfcd97bf97f4ull, 0xef340a98172aace5ull, 0xb23867fb2a35b28eull,
+  0x84c8d4dfd2c63f3bull, 0xc5dd44271ad3cdbaull, 0x936b9fcebb25c996ull,
+  0xdbac6c247d62a584ull, 0xa3ab66580d5fdaf6ull, 0xf3e2f893dec3f126ull,
+  0xb5b5ada8aaff80b8ull, 0x87625f056c7c4a8bull, 0xc9bcff6034c13053ull,
+  0x964e858c91ba2655ull, 0xdff9772470297ebdull, 0xa6dfbd9fb8e5b88full,
+  0xf8a95fcf88747d94ull, 0xb94470938fa89bcfull, 0x8a08f0f8bf0f156bull,
+  0xcdb02555653131b6ull, 0x993fe2c6d07b7facull, 0xe45c10c42a2b3b06ull,
+  0xaa242499697392d3ull, 0xfd87b5f28300ca0eull, 0xbce5086492111aebull,
+  0x8cbccc096f5088ccull, 0xd1b71758e219652cull, 0x9c40000000000000ull,
+  0xe8d4a51000000000ull, 0xad78ebc5ac620000ull, 0x813f3978f8940984ull,
+  0xc097ce7bc90715b3ull, 0x8f7e32ce7bea5c70ull, 0xd5d238a4abe98068ull,
+  0x9f4f2726179a2245ull, 0xed63a231d4c4fb27ull, 0xb0de65388cc8ada8ull,
+  0x83c7088e1aab65dbull, 0xc45d1df942711d9aull, 0x924d692ca61be758ull,
+  0xda01ee641a708deaull, 0xa26da3999aef774aull, 0xf209787bb47d6b85ull,
+  0xb454e4a179dd1877ull, 0x865b86925b9bc5c2ull, 0xc83553c5c8965d3dull,
+  0x952ab45cfa97a0b3ull, 0xde469fbd99a05fe3ull, 0xa59bc234db398c25ull,
+  0xf6c69a72a3989f5cull, 0xb7dcbf5354e9beceull, 0x88fcf317f22241e2ull,
+  0xcc20ce9bd35c78a5ull, 0x98165af37b2153dfull, 0xe2a0b5dc971f303aull,
+  0xa8d9d1535ce3b396ull, 0xfb9b7cd9a4a7443cull, 0xbb764c4ca7a44410ull,
+  0x8bab8eefb6409c1aull, 0xd01fef10a657842cull, 0x9b10a4e5e9913129ull,
+  0xe7109bfba19c0c9dull, 0xac2820d9623bf429ull, 0x80444b5e7aa7cf85ull,
+  0xbf21e44003acdd2dull, 0x8e679c2f5e44ff8full, 0xd433179d9c8cb841ull,
+  0x9e19db92b4e31ba9ull, 0xeb96bf6ebadf77d9ull, 0xaf87023b9bf0ee6bull
+};
+
+// Binary exponents of pow(10, k), for k = -348, -340, ..., 340, corresponding
+// to significands above.
+template <typename T>
+const int16_t basic_data<T>::POW10_EXPONENTS[] = {
+  -1220, -1193, -1166, -1140, -1113, -1087, -1060, -1034, -1007,  -980,  -954,
+   -927,  -901,  -874,  -847,  -821,  -794,  -768,  -741,  -715,  -688,  -661,
+   -635,  -608,  -582,  -555,  -529,  -502,  -475,  -449,  -422,  -396,  -369,
+   -343,  -316,  -289,  -263,  -236,  -210,  -183,  -157,  -130,  -103,   -77,
+    -50,   -24,     3,    30,    56,    83,   109,   136,   162,   189,   216,
+    242,   269,   295,   322,   348,   375,   402,   428,   455,   481,   508,
+    534,   561,   588,   614,   641,   667,   694,   720,   747,   774,   800,
+    827,   853,   880,   907,   933,   960,   986,  1013,  1039,  1066
+};
+
+FMT_FUNC fp operator*(fp x, fp y) {
+  // Multiply 32-bit parts of significands.
+  uint64_t mask = (1ULL << 32) - 1;
+  uint64_t a = x.f >> 32, b = x.f & mask;
+  uint64_t c = y.f >> 32, d = y.f & mask;
+  uint64_t ac = a * c, bc = b * c, ad = a * d, bd = b * d;
+  // Compute mid 64-bit of result and round.
+  uint64_t mid = (bd >> 32) + (ad & mask) + (bc & mask) + (1U << 31);
+  return fp(ac + (ad >> 32) + (bc >> 32) + (mid >> 32), x.e + y.e + 64);
+}
+}  // namespace internal
+
+#if FMT_USE_WINDOWS_H
+
+FMT_FUNC internal::utf8_to_utf16::utf8_to_utf16(string_view s) {
+  static const char ERROR_MSG[] = "cannot convert string from UTF-8 to UTF-16";
+  if (s.size() > INT_MAX)
+    FMT_THROW(windows_error(ERROR_INVALID_PARAMETER, ERROR_MSG));
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // MultiByteToWideChar does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return;
+  }
+
+  int length = MultiByteToWideChar(
+      CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, FMT_NULL, 0);
+  if (length == 0)
+    FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_.resize(length + 1);
+  length = MultiByteToWideChar(
+    CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s_size, &buffer_[0], length);
+  if (length == 0)
+    FMT_THROW(windows_error(GetLastError(), ERROR_MSG));
+  buffer_[length] = 0;
+}
+
+FMT_FUNC internal::utf16_to_utf8::utf16_to_utf8(wstring_view s) {
+  if (int error_code = convert(s)) {
+    FMT_THROW(windows_error(error_code,
+        "cannot convert string from UTF-16 to UTF-8"));
+  }
+}
+
+FMT_FUNC int internal::utf16_to_utf8::convert(wstring_view s) {
+  if (s.size() > INT_MAX)
+    return ERROR_INVALID_PARAMETER;
+  int s_size = static_cast<int>(s.size());
+  if (s_size == 0) {
+    // WideCharToMultiByte does not support zero length, handle separately.
+    buffer_.resize(1);
+    buffer_[0] = 0;
+    return 0;
+  }
+
+  int length = WideCharToMultiByte(
+        CP_UTF8, 0, s.data(), s_size, FMT_NULL, 0, FMT_NULL, FMT_NULL);
+  if (length == 0)
+    return GetLastError();
+  buffer_.resize(length + 1);
+  length = WideCharToMultiByte(
+    CP_UTF8, 0, s.data(), s_size, &buffer_[0], length, FMT_NULL, FMT_NULL);
+  if (length == 0)
+    return GetLastError();
+  buffer_[length] = 0;
+  return 0;
+}
+
+FMT_FUNC void windows_error::init(
+    int err_code, string_view format_str, format_args args) {
+  error_code_ = err_code;
+  memory_buffer buffer;
+  internal::format_windows_error(buffer, err_code, vformat(format_str, args));
+  std::runtime_error &base = *this;
+  base = std::runtime_error(to_string(buffer));
+}
+
+FMT_FUNC void internal::format_windows_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    wmemory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      wchar_t *system_message = &buf[0];
+      int result = FormatMessageW(
+          FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+          FMT_NULL, error_code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+          system_message, static_cast<uint32_t>(buf.size()), FMT_NULL);
+      if (result != 0) {
+        utf16_to_utf8 utf8_message;
+        if (utf8_message.convert(system_message) == ERROR_SUCCESS) {
+          writer w(out);
+          w.write(message);
+          w.write(": ");
+          w.write(utf8_message);
+          return;
+        }
+        break;
+      }
+      if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+#endif  // FMT_USE_WINDOWS_H
+
+FMT_FUNC void format_system_error(
+    internal::buffer &out, int error_code, string_view message) FMT_NOEXCEPT {
+  FMT_TRY {
+    memory_buffer buf;
+    buf.resize(inline_buffer_size);
+    for (;;) {
+      char *system_message = &buf[0];
+      int result = safe_strerror(error_code, system_message, buf.size());
+      if (result == 0) {
+        writer w(out);
+        w.write(message);
+        w.write(": ");
+        w.write(system_message);
+        return;
+      }
+      if (result != ERANGE)
+        break;  // Can't get error message, report error code instead.
+      buf.resize(buf.size() * 2);
+    }
+  } FMT_CATCH(...) {}
+  format_error_code(out, error_code, message);
+}
+
+template <typename Char>
+void basic_fixed_buffer<Char>::grow(std::size_t) {
+  FMT_THROW(std::runtime_error("buffer overflow"));
+}
+
+FMT_FUNC void internal::error_handler::on_error(const char *message) {
+  FMT_THROW(format_error(message));
+}
+
+FMT_FUNC void report_system_error(
+    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+  report_error(format_system_error, error_code, message);
+}
+
+#if FMT_USE_WINDOWS_H
+FMT_FUNC void report_windows_error(
+    int error_code, fmt::string_view message) FMT_NOEXCEPT {
+  report_error(internal::format_windows_error, error_code, message);
+}
+#endif
+
+FMT_FUNC void vprint(std::FILE *f, string_view format_str, format_args args) {
+  memory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  std::fwrite(buffer.data(), 1, buffer.size(), f);
+}
+
+FMT_FUNC void vprint(std::FILE *f, wstring_view format_str, wformat_args args) {
+  wmemory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  std::fwrite(buffer.data(), sizeof(wchar_t), buffer.size(), f);
+}
+
+FMT_FUNC void vprint(string_view format_str, format_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_FUNC void vprint(wstring_view format_str, wformat_args args) {
+  vprint(stdout, format_str, args);
+}
+
+FMT_FUNC void vprint_colored(color c, string_view format, format_args args) {
+  char escape[] = "\x1b[30m";
+  escape[3] = static_cast<char>('0' + c);
+  std::fputs(escape, stdout);
+  vprint(format, args);
+  std::fputs(RESET_COLOR, stdout);
+}
+
+FMT_FUNC void vprint_colored(color c, wstring_view format, wformat_args args) {
+  wchar_t escape[] = L"\x1b[30m";
+  escape[3] = static_cast<wchar_t>('0' + c);
+  std::fputws(escape, stdout);
+  vprint(format, args);
+  std::fputws(WRESET_COLOR, stdout);
+}
+
+FMT_FUNC locale locale_provider::locale() { return fmt::locale(); }
+
+FMT_END_NAMESPACE
+
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
+
+#endif  // FMT_FORMAT_INL_H_

--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -1,7 +1,7 @@
 /*
  Formatting library for C++
 
- Copyright (c) 2012 - 2016, Victor Zverovich
+ Copyright (c) 2012 - present, Victor Zverovich
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -28,1255 +28,1039 @@
 #ifndef FMT_FORMAT_H_
 #define FMT_FORMAT_H_
 
-#define FMT_INCLUDE
+#include <algorithm>
 #include <cassert>
-#include <clocale>
 #include <cmath>
-#include <cstdio>
 #include <cstring>
 #include <limits>
 #include <memory>
 #include <stdexcept>
-#include <string>
-#include <utility> // for std::pair
-#include <vector>
-#undef FMT_INCLUDE
+#include <stdint.h>
 
-// The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 40100
+#include "core.h"
 
-#if defined(__has_include)
-#define FMT_HAS_INCLUDE(x) __has_include(x)
+#ifdef _SECURE_SCL
+# define FMT_SECURE_SCL _SECURE_SCL
 #else
-#define FMT_HAS_INCLUDE(x) 0
-#endif
-
-#if (FMT_HAS_INCLUDE(<string_view>) && __cplusplus > 201402L) || (defined(_MSVC_LANG) && _MSVC_LANG > 201402L && _MSC_VER >= 1910)
-#include <string_view>
-#define FMT_HAS_STRING_VIEW 1
-#else
-#define FMT_HAS_STRING_VIEW 0
-#endif
-
-#if defined _SECURE_SCL && _SECURE_SCL
-#define FMT_SECURE_SCL _SECURE_SCL
-#else
-#define FMT_SECURE_SCL 0
+# define FMT_SECURE_SCL 0
 #endif
 
 #if FMT_SECURE_SCL
-#include <iterator>
-#endif
-
-#ifdef _MSC_VER
-#define FMT_MSC_VER _MSC_VER
-#else
-#define FMT_MSC_VER 0
-#endif
-
-#if FMT_MSC_VER && FMT_MSC_VER <= 1500
-typedef unsigned __int32 uint32_t;
-typedef unsigned __int64 uint64_t;
-typedef __int64 intmax_t;
-#else
-#include <stdint.h>
-#endif
-
-#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
-#ifdef FMT_EXPORT
-#define FMT_API __declspec(dllexport)
-#elif defined(FMT_SHARED)
-#define FMT_API __declspec(dllimport)
-#endif
-#endif
-#ifndef FMT_API
-#define FMT_API
-#endif
-
-#ifdef __GNUC__
-#define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
-#define FMT_GCC_EXTENSION __extension__
-#if FMT_GCC_VERSION >= 406
-#pragma GCC diagnostic push
-// Disable the warning about "long long" which is sometimes reported even
-// when using __extension__.
-#pragma GCC diagnostic ignored "-Wlong-long"
-// Disable the warning about declaration shadowing because it affects too
-// many valid cases.
-#pragma GCC diagnostic ignored "-Wshadow"
-// Disable the warning about implicit conversions that may change the sign of
-// an integer; silencing it otherwise would require many explicit casts.
-#pragma GCC diagnostic ignored "-Wsign-conversion"
-#endif
-#if __cplusplus >= 201103L || defined __GXX_EXPERIMENTAL_CXX0X__
-#define FMT_HAS_GXX_CXX11 1
-#endif
-#else
-#define FMT_GCC_VERSION 0
-#define FMT_GCC_EXTENSION
-#define FMT_HAS_GXX_CXX11 0
-#endif
-
-#if defined(__INTEL_COMPILER)
-#define FMT_ICC_VERSION __INTEL_COMPILER
-#elif defined(__ICL)
-#define FMT_ICC_VERSION __ICL
-#endif
-
-#if defined(__clang__) && !defined(FMT_ICC_VERSION)
-#define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
-#pragma clang diagnostic ignored "-Wpadded"
-#endif
-
-#ifdef __GNUC_LIBSTD__
-#define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
-#endif
-
-#ifdef __has_feature
-#define FMT_HAS_FEATURE(x) __has_feature(x)
-#else
-#define FMT_HAS_FEATURE(x) 0
+# include <iterator>
 #endif
 
 #ifdef __has_builtin
-#define FMT_HAS_BUILTIN(x) __has_builtin(x)
+# define FMT_HAS_BUILTIN(x) __has_builtin(x)
 #else
-#define FMT_HAS_BUILTIN(x) 0
+# define FMT_HAS_BUILTIN(x) 0
+#endif
+
+#ifdef __GNUC__
+# if FMT_GCC_VERSION >= 406
+#  pragma GCC diagnostic push
+
+// Disable the warning about declaration shadowing because it affects too
+// many valid cases.
+#  pragma GCC diagnostic ignored "-Wshadow"
+
+// Disable the warning about implicit conversions that may change the sign of
+// an integer; silencing it otherwise would require many explicit casts.
+#  pragma GCC diagnostic ignored "-Wsign-conversion"
+# endif
+#endif
+
+#ifdef __clang__
+# define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+#endif
+
+#if defined(__INTEL_COMPILER)
+# define FMT_ICC_VERSION __INTEL_COMPILER
+#elif defined(__ICL)
+# define FMT_ICC_VERSION __ICL
+#endif
+
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+# pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
+# pragma clang diagnostic ignored "-Wpadded"
+#endif
+
+#ifdef __GNUC_LIBSTD__
+# define FMT_GNUC_LIBSTD_VERSION (__GNUC_LIBSTD__ * 100 + __GNUC_LIBSTD_MINOR__)
 #endif
 
 #ifdef __has_cpp_attribute
-#define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+# define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
 #else
-#define FMT_HAS_CPP_ATTRIBUTE(x) 0
-#endif
-
-#if FMT_HAS_CPP_ATTRIBUTE(maybe_unused)
-#define FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
-// VC++ 1910 support /std: option and that will set _MSVC_LANG macro
-// Clang with Microsoft CodeGen doesn't define _MSVC_LANG macro
-#elif defined(_MSVC_LANG) && _MSVC_LANG > 201402 && _MSC_VER >= 1910
-#define FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
-#endif
-
-#ifdef FMT_HAS_CXX17_ATTRIBUTE_MAYBE_UNUSED
-#define FMT_MAYBE_UNUSED [[maybe_unused]]
-// g++/clang++ also support [[gnu::unused]]. However, we don't use it.
-#elif defined(__GNUC__)
-#define FMT_MAYBE_UNUSED __attribute__((unused))
-#else
-#define FMT_MAYBE_UNUSED
-#endif
-
-// Use the compiler's attribute noreturn
-#if defined(__MINGW32__) || defined(__MINGW64__)
-#define FMT_NORETURN __attribute__((noreturn))
-#elif FMT_HAS_CPP_ATTRIBUTE(noreturn) && __cplusplus >= 201103L
-#define FMT_NORETURN [[noreturn]]
-#else
-#define FMT_NORETURN
-#endif
-
-#ifndef FMT_USE_VARIADIC_TEMPLATES
-// Variadic templates are available in GCC since version 4.4
-// (http://gcc.gnu.org/projects/cxx0x.html) and in Visual C++
-// since version 2013.
-#define FMT_USE_VARIADIC_TEMPLATES                                                                                                         \
-    (FMT_HAS_FEATURE(cxx_variadic_templates) || (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1800)
-#endif
-
-#ifndef FMT_USE_RVALUE_REFERENCES
-// Don't use rvalue references when compiling with clang and an old libstdc++
-// as the latter doesn't provide std::move.
-#if defined(FMT_GNUC_LIBSTD_VERSION) && FMT_GNUC_LIBSTD_VERSION <= 402
-#define FMT_USE_RVALUE_REFERENCES 0
-#else
-#define FMT_USE_RVALUE_REFERENCES                                                                                                          \
-    (FMT_HAS_FEATURE(cxx_rvalue_references) || (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1600)
-#endif
-#endif
-
-#if __cplusplus >= 201103L || FMT_MSC_VER >= 1700
-#define FMT_USE_ALLOCATOR_TRAITS 1
-#else
-#define FMT_USE_ALLOCATOR_TRAITS 0
-#endif
-
-// Check if exceptions are disabled.
-#if defined(__GNUC__) && !defined(__EXCEPTIONS)
-#define FMT_EXCEPTIONS 0
-#endif
-#if FMT_MSC_VER && !_HAS_EXCEPTIONS
-#define FMT_EXCEPTIONS 0
-#endif
-#ifndef FMT_EXCEPTIONS
-#define FMT_EXCEPTIONS 1
+# define FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
 #ifndef FMT_THROW
-#if FMT_EXCEPTIONS
-#define FMT_THROW(x) throw x
-#else
-#define FMT_THROW(x) assert(false)
-#endif
-#endif
-
-// Define FMT_USE_NOEXCEPT to make fmt use noexcept (C++11 feature).
-#ifndef FMT_USE_NOEXCEPT
-#define FMT_USE_NOEXCEPT 0
-#endif
-
-#if FMT_USE_NOEXCEPT || FMT_HAS_FEATURE(cxx_noexcept) || (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
-#define FMT_DETECTED_NOEXCEPT noexcept
-#else
-#define FMT_DETECTED_NOEXCEPT throw()
-#endif
-
-#ifndef FMT_NOEXCEPT
-#if FMT_EXCEPTIONS
-#define FMT_NOEXCEPT FMT_DETECTED_NOEXCEPT
-#else
-#define FMT_NOEXCEPT
-#endif
-#endif
-
-// This is needed because GCC still uses throw() in its headers when exceptions
-// are disabled.
-#if FMT_GCC_VERSION
-#define FMT_DTOR_NOEXCEPT FMT_DETECTED_NOEXCEPT
-#else
-#define FMT_DTOR_NOEXCEPT FMT_NOEXCEPT
-#endif
-
-#ifndef FMT_OVERRIDE
-#if (defined(FMT_USE_OVERRIDE) && FMT_USE_OVERRIDE) || FMT_HAS_FEATURE(cxx_override) || (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) ||   \
-    FMT_MSC_VER >= 1900
-#define FMT_OVERRIDE override
-#else
-#define FMT_OVERRIDE
-#endif
-#endif
-
-#ifndef FMT_NULL
-#if FMT_HAS_FEATURE(cxx_nullptr) || (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1600
-#define FMT_NULL nullptr
-#else
-#define FMT_NULL NULL
-#endif
-#endif
-
-// A macro to disallow the copy constructor and operator= functions
-// This should be used in the private: declarations for a class
-#ifndef FMT_USE_DELETED_FUNCTIONS
-#define FMT_USE_DELETED_FUNCTIONS 0
-#endif
-
-#if FMT_USE_DELETED_FUNCTIONS || FMT_HAS_FEATURE(cxx_deleted_functions) || (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) ||                \
-    FMT_MSC_VER >= 1800
-#define FMT_DELETED_OR_UNDEFINED = delete
-#define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName)                                                                                             \
-    TypeName(const TypeName &) = delete;                                                                                                   \
-    TypeName &operator=(const TypeName &) = delete
-#else
-#define FMT_DELETED_OR_UNDEFINED
-#define FMT_DISALLOW_COPY_AND_ASSIGN(TypeName)                                                                                             \
-    TypeName(const TypeName &);                                                                                                            \
-    TypeName &operator=(const TypeName &)
-#endif
-
-#ifndef FMT_USE_DEFAULTED_FUNCTIONS
-#define FMT_USE_DEFAULTED_FUNCTIONS 0
-#endif
-
-#ifndef FMT_DEFAULTED_COPY_CTOR
-#if FMT_USE_DEFAULTED_FUNCTIONS || FMT_HAS_FEATURE(cxx_defaulted_functions) || (FMT_GCC_VERSION >= 404 && FMT_HAS_GXX_CXX11) ||            \
-    FMT_MSC_VER >= 1800
-#define FMT_DEFAULTED_COPY_CTOR(TypeName) TypeName(const TypeName &) = default;
-#else
-#define FMT_DEFAULTED_COPY_CTOR(TypeName)
-#endif
+# if FMT_EXCEPTIONS
+#  define FMT_THROW(x) throw x
+# else
+#  define FMT_THROW(x) assert(false)
+# endif
 #endif
 
 #ifndef FMT_USE_USER_DEFINED_LITERALS
-// All compilers which support UDLs also support variadic templates. This
-// makes the fmt::literals implementation easier. However, an explicit check
-// for variadic templates is added here just in case.
 // For Intel's compiler both it and the system gcc/msc must support UDLs.
-#if FMT_USE_VARIADIC_TEMPLATES && FMT_USE_RVALUE_REFERENCES &&                                                                             \
-    (FMT_HAS_FEATURE(cxx_user_literals) || (FMT_GCC_VERSION >= 407 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900) &&                        \
-    (!defined(FMT_ICC_VERSION) || FMT_ICC_VERSION >= 1500)
-#define FMT_USE_USER_DEFINED_LITERALS 1
-#else
-#define FMT_USE_USER_DEFINED_LITERALS 0
+# if (FMT_HAS_FEATURE(cxx_user_literals) || \
+      FMT_GCC_VERSION >= 407 || FMT_MSC_VER >= 1900) && \
+      (!defined(FMT_ICC_VERSION) || FMT_ICC_VERSION >= 1500)
+#  define FMT_USE_USER_DEFINED_LITERALS 1
+# else
+#  define FMT_USE_USER_DEFINED_LITERALS 0
+# endif
 #endif
+
+#if FMT_USE_USER_DEFINED_LITERALS && \
+    ((FMT_GCC_VERSION >= 600 && __cplusplus >= 201402L) || \
+    (defined(FMT_CLANG_VERSION) && FMT_CLANG_VERSION >= 304))
+# define FMT_UDL_TEMPLATE 1
+#else
+# define FMT_UDL_TEMPLATE 0
 #endif
 
 #ifndef FMT_USE_EXTERN_TEMPLATES
-#define FMT_USE_EXTERN_TEMPLATES (FMT_CLANG_VERSION >= 209 || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
+# ifndef FMT_HEADER_ONLY
+#  define FMT_USE_EXTERN_TEMPLATES \
+     (FMT_CLANG_VERSION >= 209 || (FMT_GCC_VERSION >= 303 && FMT_HAS_GXX_CXX11))
+# else
+#  define FMT_USE_EXTERN_TEMPLATES 0
+# endif
 #endif
 
-#ifdef FMT_HEADER_ONLY
-// If header only do not use extern templates.
-#undef FMT_USE_EXTERN_TEMPLATES
-#define FMT_USE_EXTERN_TEMPLATES 0
-#endif
-
-#ifndef FMT_ASSERT
-#define FMT_ASSERT(condition, message) assert((condition) && message)
+#if FMT_HAS_GXX_CXX11 || FMT_HAS_FEATURE(cxx_trailing_return) || FMT_MSC_VER >= 1600
+# define FMT_USE_TRAILING_RETURN 1
 #endif
 
 // __builtin_clz is broken in clang with Microsoft CodeGen:
 // https://github.com/fmtlib/fmt/issues/519
 #ifndef _MSC_VER
-#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
-#define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clz)
+#  define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+# endif
+
+# if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
+#  define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+# endif
 #endif
 
-#if FMT_GCC_VERSION >= 400 || FMT_HAS_BUILTIN(__builtin_clzll)
-#define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
-#endif
-#endif
-
-// Some compilers masquerade as both MSVC and GCC-likes or
-// otherwise support __builtin_clz and __builtin_clzll, so
-// only define FMT_BUILTIN_CLZ using the MSVC intrinsics
-// if the clz and clzll builtins are not available.
-#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
-#include <intrin.h> // _BitScanReverse, _BitScanReverse64
-
-namespace fmt {
-namespace internal {
-// avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning
-#ifndef __clang__
-#pragma intrinsic(_BitScanReverse)
-#endif
-inline uint32_t clz(uint32_t x)
-{
-    unsigned long r = 0;
-    _BitScanReverse(&r, x);
-
-    assert(x != 0);
-    // Static analysis complains about using uninitialized data
-    // "r", but the only way that can happen is if "x" is 0,
-    // which the callers guarantee to not happen.
-#pragma warning(suppress : 6102)
-    return 31 - r;
-}
-#define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
-
-// avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning
-#if defined(_WIN64) && !defined(__clang__)
-#pragma intrinsic(_BitScanReverse64)
-#endif
-
-inline uint32_t clzll(uint64_t x)
-{
-    unsigned long r = 0;
-#ifdef _WIN64
-    _BitScanReverse64(&r, x);
+// A workaround for gcc 4.4 that doesn't support union members with ctors.
+#if FMT_GCC_VERSION && FMT_GCC_VERSION <= 404
+# define FMT_UNION struct
 #else
-    // Scan the high 32 bits.
-    if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
-        return 63 - (r + 32);
-
-    // Scan the low 32 bits.
-    _BitScanReverse(&r, static_cast<uint32_t>(x));
+# define FMT_UNION union
 #endif
 
-    assert(x != 0);
-    // Static analysis complains about using uninitialized data
-    // "r", but the only way that can happen is if "x" is 0,
-    // which the callers guarantee to not happen.
-#pragma warning(suppress : 6102)
-    return 63 - r;
-}
-#define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
-} // namespace internal
-} // namespace fmt
-#endif
+// Some compilers masquerade as both MSVC and GCC-likes or otherwise support
+// __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
+// MSVC intrinsics if the clz and clzll builtins are not available.
+#if FMT_MSC_VER && !defined(FMT_BUILTIN_CLZLL) && !defined(_MANAGED)
+# include <intrin.h>  // _BitScanReverse, _BitScanReverse64
 
-namespace fmt {
+FMT_BEGIN_NAMESPACE
 namespace internal {
-struct DummyInt
-{
-    int data[2];
-    operator int() const
-    {
-        return 0;
-    }
+// Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
+# ifndef __clang__
+#  pragma intrinsic(_BitScanReverse)
+# endif
+inline uint32_t clz(uint32_t x) {
+  unsigned long r = 0;
+  _BitScanReverse(&r, x);
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+# pragma warning(suppress: 6102)
+  return 31 - r;
+}
+# define FMT_BUILTIN_CLZ(n) fmt::internal::clz(n)
+
+# if defined(_WIN64) && !defined(__clang__)
+#  pragma intrinsic(_BitScanReverse64)
+# endif
+
+inline uint32_t clzll(uint64_t x) {
+  unsigned long r = 0;
+# ifdef _WIN64
+  _BitScanReverse64(&r, x);
+# else
+  // Scan the high 32 bits.
+  if (_BitScanReverse(&r, static_cast<uint32_t>(x >> 32)))
+    return 63 - (r + 32);
+
+  // Scan the low 32 bits.
+  _BitScanReverse(&r, static_cast<uint32_t>(x));
+# endif
+
+  assert(x != 0);
+  // Static analysis complains about using uninitialized data
+  // "r", but the only way that can happen is if "x" is 0,
+  // which the callers guarantee to not happen.
+# pragma warning(suppress: 6102)
+  return 63 - r;
+}
+# define FMT_BUILTIN_CLZLL(n) fmt::internal::clzll(n)
+}
+FMT_END_NAMESPACE
+#endif
+
+FMT_BEGIN_NAMESPACE
+namespace internal {
+
+// An equivalent of `*reinterpret_cast<Dest*>(&source)` that doesn't produce
+// undefined behavior (e.g. due to type aliasing).
+// Example: uint64_t d = bit_cast<uint64_t>(2.718);
+template <typename Dest, typename Source>
+inline Dest bit_cast(const Source& source) {
+  static_assert(sizeof(Dest) == sizeof(Source), "size mismatch");
+  Dest dest;
+  std::memcpy(&dest, &source, sizeof(dest));
+  return dest;
+}
+
+// An implementation of begin and end for pre-C++11 compilers such as gcc 4.
+template <typename C>
+FMT_CONSTEXPR auto begin(const C &c) -> decltype(c.begin()) {
+  return c.begin();
+}
+template <typename T, std::size_t N>
+FMT_CONSTEXPR T *begin(T (&array)[N]) FMT_NOEXCEPT { return array; }
+template <typename C>
+FMT_CONSTEXPR auto end(const C &c) -> decltype(c.end()) { return c.end(); }
+template <typename T, std::size_t N>
+FMT_CONSTEXPR T *end(T (&array)[N]) FMT_NOEXCEPT { return array + N; }
+
+// For std::result_of in gcc 4.4.
+template <typename Result>
+struct function {
+  template <typename T>
+  struct result { typedef Result type; };
 };
-typedef std::numeric_limits<fmt::internal::DummyInt> FPUtil;
+
+struct dummy_int {
+  int data[2];
+  operator int() const { return 0; }
+};
+typedef std::numeric_limits<internal::dummy_int> fputil;
 
 // Dummy implementations of system functions such as signbit and ecvt called
 // if the latter are not available.
-inline DummyInt signbit(...)
-{
-    return DummyInt();
+inline dummy_int signbit(...) { return dummy_int(); }
+inline dummy_int _ecvt_s(...) { return dummy_int(); }
+inline dummy_int isinf(...) { return dummy_int(); }
+inline dummy_int _finite(...) { return dummy_int(); }
+inline dummy_int isnan(...) { return dummy_int(); }
+inline dummy_int _isnan(...) { return dummy_int(); }
+
+// A handmade floating-point number f * pow(2, e).
+struct fp {
+  uint64_t f;
+  int e;
+
+  fp(uint64_t f, int e): f(f), e(e) {}
+
+  // Constructs fp from an IEEE754 double. It is a template to prevent compile
+  // errors on platforms where double is not IEEE754.
+  template <typename Double>
+  explicit fp(Double d) {
+    // Assume double is in the format [sign][exponent][significand].
+    typedef std::numeric_limits<Double> limits;
+    const int double_size =
+      sizeof(Double) * std::numeric_limits<unsigned char>::digits;
+    // Subtract 1 to account for an implicit most significant bit in the
+    // normalized form.
+    const int significand_size = limits::digits - 1;
+    const int exponent_size = double_size - significand_size - 1;  // -1 for sign
+    const uint64_t implicit_bit = 1ull << significand_size;
+    const uint64_t significand_mask = implicit_bit - 1;
+    const uint64_t exponent_mask = (~0ull >> 1) & ~significand_mask;
+    const int exponent_bias = (1 << exponent_size) - limits::max_exponent - 1;
+    auto u = bit_cast<uint64_t>(d);
+    auto biased_e = (u & exponent_mask) >> significand_size;
+    f = u & significand_mask;
+    if (biased_e != 0)
+      f += implicit_bit;
+    else
+      biased_e = 1;  // Subnormals use biased exponent 1 (min exponent).
+    e = biased_e - exponent_bias - significand_size;
+  }
+};
+
+// Returns an fp number representing x - y. Result may not be normalized.
+inline fp operator-(fp x, fp y) {
+  FMT_ASSERT(x.f >= y.f && x.e == y.e, "invalid operands");
+  return fp(x.f - y.f, x.e);
 }
-inline DummyInt _ecvt_s(...)
-{
-    return DummyInt();
+
+// Computes an fp number r with r.f = x.f * y.f / pow(2, 32) rounded to nearest
+// with half-up tie breaking, r.e = x.e + y.e + 32. Result may not be normalized.
+fp operator*(fp x, fp y);
+
+// Compute k such that its cached power c_k = c_k.f * pow(2, c_k.e) satisfies
+// min_exponent <= c_k.e + e <= min_exponent + 3.
+inline int compute_cached_power_index(int e, int min_exponent) {
+  const double one_over_log2_10 = 0.30102999566398114;  // 1 / log2(10)
+  return static_cast<int>(std::ceil((min_exponent - e + 63) * one_over_log2_10));
 }
-inline DummyInt isinf(...)
-{
-    return DummyInt();
-}
-inline DummyInt _finite(...)
-{
-    return DummyInt();
-}
-inline DummyInt isnan(...)
-{
-    return DummyInt();
-}
-inline DummyInt _isnan(...)
-{
-    return DummyInt();
+
+template <typename Allocator>
+typename Allocator::value_type *allocate(Allocator& alloc, std::size_t n) {
+#if __cplusplus >= 201103L || FMT_MSC_VER >= 1700
+  return std::allocator_traits<Allocator>::allocate(alloc, n);
+#else
+  return alloc.allocate(n);
+#endif
 }
 
 // A helper function to suppress bogus "conditional expression is constant"
 // warnings.
-template<typename T>
-inline T const_check(T value)
-{
-    return value;
-}
-} // namespace internal
-} // namespace fmt
+template <typename T>
+inline T const_check(T value) { return value; }
+}  // namespace internal
+FMT_END_NAMESPACE
 
 namespace std {
 // Standard permits specialization of std::numeric_limits. This specialization
 // is used to resolve ambiguity between isinf and std::isinf in glibc:
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
 // and the same for isnan and signbit.
-template<>
-class numeric_limits<fmt::internal::DummyInt> : public std::numeric_limits<int>
-{
-public:
-    // Portable version of isinf.
-    template<typename T>
-    static bool isinfinity(T x)
-    {
-        using namespace fmt::internal;
-        // The resolution "priority" is:
-        // isinf macro > std::isinf > ::isinf > fmt::internal::isinf
-        if (const_check(sizeof(isinf(x)) == sizeof(bool) || sizeof(isinf(x)) == sizeof(int)))
-        {
-            return isinf(x) != 0;
-        }
-        return !_finite(static_cast<double>(x));
-    }
+template <>
+class numeric_limits<fmt::internal::dummy_int> :
+    public std::numeric_limits<int> {
+ public:
+  // Portable version of isinf.
+  template <typename T>
+  static bool isinfinity(T x) {
+    using namespace fmt::internal;
+    // The resolution "priority" is:
+    // isinf macro > std::isinf > ::isinf > fmt::internal::isinf
+    if (const_check(sizeof(isinf(x)) != sizeof(dummy_int)))
+      return isinf(x) != 0;
+    return !_finite(static_cast<double>(x));
+  }
 
-    // Portable version of isnan.
-    template<typename T>
-    static bool isnotanumber(T x)
-    {
-        using namespace fmt::internal;
-        if (const_check(sizeof(isnan(x)) == sizeof(bool) || sizeof(isnan(x)) == sizeof(int)))
-        {
-            return isnan(x) != 0;
-        }
-        return _isnan(static_cast<double>(x)) != 0;
-    }
+  // Portable version of isnan.
+  template <typename T>
+  static bool isnotanumber(T x) {
+    using namespace fmt::internal;
+    if (const_check(sizeof(isnan(x)) != sizeof(fmt::internal::dummy_int)))
+      return isnan(x) != 0;
+    return _isnan(static_cast<double>(x)) != 0;
+  }
 
-    // Portable version of signbit.
-    static bool isnegative(double x)
-    {
-        using namespace fmt::internal;
-        if (const_check(sizeof(signbit(x)) == sizeof(bool) || sizeof(signbit(x)) == sizeof(int)))
-        {
-            return signbit(x) != 0;
-        }
-        if (x < 0)
-            return true;
-        if (!isnotanumber(x))
-            return false;
-        int dec = 0, sign = 0;
-        char buffer[2]; // The buffer size must be >= 2 or _ecvt_s will fail.
-        _ecvt_s(buffer, sizeof(buffer), x, 0, &dec, &sign);
-        return sign != 0;
-    }
+  // Portable version of signbit.
+  static bool isnegative(double x) {
+    using namespace fmt::internal;
+    if (const_check(sizeof(signbit(x)) != sizeof(fmt::internal::dummy_int)))
+      return signbit(x) != 0;
+    if (x < 0) return true;
+    if (!isnotanumber(x)) return false;
+    int dec = 0, sign = 0;
+    char buffer[2];  // The buffer size must be >= 2 or _ecvt_s will fail.
+    _ecvt_s(buffer, sizeof(buffer), x, 0, &dec, &sign);
+    return sign != 0;
+  }
 };
-} // namespace std
+}  // namespace std
 
-namespace fmt {
-
-// Fix the warning about long long on older versions of GCC
-// that don't support the diagnostic pragma.
-FMT_GCC_EXTENSION typedef long long LongLong;
-FMT_GCC_EXTENSION typedef unsigned long long ULongLong;
-
-#if FMT_USE_RVALUE_REFERENCES
-using std::move;
-#endif
-
-template<typename Char>
-class BasicWriter;
-
-typedef BasicWriter<char> Writer;
-typedef BasicWriter<wchar_t> WWriter;
-
-template<typename Char>
-class ArgFormatter;
-
-struct FormatSpec;
-
-template<typename Impl, typename Char, typename Spec = fmt::FormatSpec>
-class BasicPrintfArgFormatter;
-
-template<typename CharType, typename ArgFormatter = fmt::ArgFormatter<CharType>>
-class BasicFormatter;
-
-/**
-  \rst
-  A string reference. It can be constructed from a C string or
-  ``std::basic_string``.
-
-  You can use one of the following typedefs for common character types:
-
-  +------------+-------------------------+
-  | Type       | Definition              |
-  +============+=========================+
-  | StringRef  | BasicStringRef<char>    |
-  +------------+-------------------------+
-  | WStringRef | BasicStringRef<wchar_t> |
-  +------------+-------------------------+
-
-  This class is most useful as a parameter type to allow passing
-  different types of strings to a function, for example::
-
-    template <typename... Args>
-    std::string format(StringRef format_str, const Args & ... args);
-
-    format("{}", 42);
-    format(std::string("{}"), 42);
-  \endrst
- */
-template<typename Char>
-class BasicStringRef
-{
-private:
-    const Char *data_;
-    std::size_t size_;
-
-public:
-    /** Constructs a string reference object from a C string and a size. */
-    BasicStringRef(const Char *s, std::size_t size)
-        : data_(s)
-        , size_(size)
-    {
-    }
-
-    /**
-      \rst
-      Constructs a string reference object from a C string computing
-      the size with ``std::char_traits<Char>::length``.
-      \endrst
-     */
-    BasicStringRef(const Char *s)
-        : data_(s)
-        , size_(std::char_traits<Char>::length(s))
-    {
-    }
-
-    /**
-      \rst
-      Constructs a string reference from a ``std::basic_string`` object.
-      \endrst
-     */
-    template<typename Allocator>
-    BasicStringRef(const std::basic_string<Char, std::char_traits<Char>, Allocator> &s)
-        : data_(s.c_str())
-        , size_(s.size())
-    {
-    }
-
-#if FMT_HAS_STRING_VIEW
-    /**
-      \rst
-      Constructs a string reference from a ``std::basic_string_view`` object.
-      \endrst
-     */
-    BasicStringRef(const std::basic_string_view<Char, std::char_traits<Char>> &s)
-        : data_(s.data())
-        , size_(s.size())
-    {
-    }
-
-    /**
-     \rst
-     Converts a string reference to an ``std::string_view`` object.
-     \endrst
-    */
-    explicit operator std::basic_string_view<Char>() const FMT_NOEXCEPT
-    {
-        return std::basic_string_view<Char>(data_, size_);
-    }
-#endif
-
-    /**
-      \rst
-      Converts a string reference to an ``std::string`` object.
-      \endrst
-     */
-    std::basic_string<Char> to_string() const
-    {
-        return std::basic_string<Char>(data_, size_);
-    }
-
-    /** Returns a pointer to the string data. */
-    const Char *data() const
-    {
-        return data_;
-    }
-
-    /** Returns the string size. */
-    std::size_t size() const
-    {
-        return size_;
-    }
-
-    // Lexicographically compare this string reference to other.
-    int compare(BasicStringRef other) const
-    {
-        std::size_t size = size_ < other.size_ ? size_ : other.size_;
-        int result = std::char_traits<Char>::compare(data_, other.data_, size);
-        if (result == 0)
-            result = size_ == other.size_ ? 0 : (size_ < other.size_ ? -1 : 1);
-        return result;
-    }
-
-    friend bool operator==(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) == 0;
-    }
-    friend bool operator!=(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) != 0;
-    }
-    friend bool operator<(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) < 0;
-    }
-    friend bool operator<=(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) <= 0;
-    }
-    friend bool operator>(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) > 0;
-    }
-    friend bool operator>=(BasicStringRef lhs, BasicStringRef rhs)
-    {
-        return lhs.compare(rhs) >= 0;
-    }
-};
-
-typedef BasicStringRef<char> StringRef;
-typedef BasicStringRef<wchar_t> WStringRef;
-
-/**
-  \rst
-  A reference to a null terminated string. It can be constructed from a C
-  string or ``std::basic_string``.
-
-  You can use one of the following typedefs for common character types:
-
-  +-------------+--------------------------+
-  | Type        | Definition               |
-  +=============+==========================+
-  | CStringRef  | BasicCStringRef<char>    |
-  +-------------+--------------------------+
-  | WCStringRef | BasicCStringRef<wchar_t> |
-  +-------------+--------------------------+
-
-  This class is most useful as a parameter type to allow passing
-  different types of strings to a function, for example::
-
-    template <typename... Args>
-    std::string format(CStringRef format_str, const Args & ... args);
-
-    format("{}", 42);
-    format(std::string("{}"), 42);
-  \endrst
- */
-template<typename Char>
-class BasicCStringRef
-{
-private:
-    const Char *data_;
-
-public:
-    /** Constructs a string reference object from a C string. */
-    BasicCStringRef(const Char *s)
-        : data_(s)
-    {
-    }
-
-    /**
-      \rst
-      Constructs a string reference from a ``std::basic_string`` object.
-      \endrst
-     */
-    template<typename Allocator>
-    BasicCStringRef(const std::basic_string<Char, std::char_traits<Char>, Allocator> &s)
-        : data_(s.c_str())
-    {
-    }
-
-    /** Returns the pointer to a C string. */
-    const Char *c_str() const
-    {
-        return data_;
-    }
-};
-
-typedef BasicCStringRef<char> CStringRef;
-typedef BasicCStringRef<wchar_t> WCStringRef;
+FMT_BEGIN_NAMESPACE
+template <typename Range>
+class basic_writer;
 
 /** A formatting error such as invalid format string. */
-class FormatError : public std::runtime_error
-{
-public:
-    explicit FormatError(CStringRef message)
-        : std::runtime_error(message.c_str())
-    {
-    }
-    FormatError(const FormatError &ferr)
-        : std::runtime_error(ferr)
-    {
-    }
-    FMT_API ~FormatError() FMT_DTOR_NOEXCEPT FMT_OVERRIDE;
+class format_error : public std::runtime_error {
+ public:
+  explicit format_error(const char *message)
+  : std::runtime_error(message) {}
+
+  explicit format_error(const std::string &message)
+  : std::runtime_error(message) {}
+
+  FMT_API ~format_error() throw();
 };
 
 namespace internal {
 
-// MakeUnsigned<T>::Type gives an unsigned type corresponding to integer type T.
-template<typename T>
-struct MakeUnsigned
-{
-    typedef T Type;
-};
-
-#define FMT_SPECIALIZE_MAKE_UNSIGNED(T, U)                                                                                                 \
-    template<>                                                                                                                             \
-    struct MakeUnsigned<T>                                                                                                                 \
-    {                                                                                                                                      \
-        typedef U Type;                                                                                                                    \
-    }
-
-FMT_SPECIALIZE_MAKE_UNSIGNED(char, unsigned char);
-FMT_SPECIALIZE_MAKE_UNSIGNED(signed char, unsigned char);
-FMT_SPECIALIZE_MAKE_UNSIGNED(short, unsigned short);
-FMT_SPECIALIZE_MAKE_UNSIGNED(int, unsigned);
-FMT_SPECIALIZE_MAKE_UNSIGNED(long, unsigned long);
-FMT_SPECIALIZE_MAKE_UNSIGNED(LongLong, ULongLong);
-
 // Casts nonnegative integer to unsigned.
-template<typename Int>
-inline typename MakeUnsigned<Int>::Type to_unsigned(Int value)
-{
-    FMT_ASSERT(value >= 0, "negative value");
-    return static_cast<typename MakeUnsigned<Int>::Type>(value);
+template <typename Int>
+FMT_CONSTEXPR typename std::make_unsigned<Int>::type to_unsigned(Int value) {
+  FMT_ASSERT(value >= 0, "negative value");
+  return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
-
-// The number of characters to store in the MemoryBuffer object itself
-// to avoid dynamic memory allocation.
-enum
-{
-    INLINE_BUFFER_SIZE = 500
-};
 
 #if FMT_SECURE_SCL
-// Use checked iterator to avoid warnings on MSVC.
-template<typename T>
-inline stdext::checked_array_iterator<T *> make_ptr(T *ptr, std::size_t size)
-{
-    return stdext::checked_array_iterator<T *>(ptr, size);
+template <typename T>
+struct checked { typedef stdext::checked_array_iterator<T*> type; };
+
+// Make a checked iterator to avoid warnings on MSVC.
+template <typename T>
+inline stdext::checked_array_iterator<T*> make_checked(T *p, std::size_t size) {
+  return {p, size};
 }
 #else
-template<typename T>
-inline T *make_ptr(T *ptr, std::size_t)
-{
-    return ptr;
-}
+template <typename T>
+struct checked { typedef T *type; };
+template <typename T>
+inline T *make_checked(T *p, std::size_t) { return p; }
 #endif
-} // namespace internal
+
+template <typename T>
+template <typename U>
+void basic_buffer<T>::append(const U *begin, const U *end) {
+  std::size_t new_size = size_ + internal::to_unsigned(end - begin);
+  reserve(new_size);
+  std::uninitialized_copy(begin, end,
+                          internal::make_checked(ptr_, capacity_) + size_);
+  size_ = new_size;
+}
+}  // namespace internal
+
+// A wrapper around std::locale used to reduce compile times since <locale>
+// is very heavy.
+class locale;
+
+class locale_provider {
+ public:
+  virtual ~locale_provider() {}
+  virtual fmt::locale locale();
+};
+
+// The number of characters to store in the basic_memory_buffer object itself
+// to avoid dynamic memory allocation.
+enum { inline_buffer_size = 500 };
 
 /**
   \rst
-  A buffer supporting a subset of ``std::vector``'s operations.
+  A dynamically growing memory buffer for trivially copyable/constructible types
+  with the first ``SIZE`` elements stored in the object itself.
+
+  You can use one of the following typedefs for common character types:
+
+  +----------------+------------------------------+
+  | Type           | Definition                   |
+  +================+==============================+
+  | memory_buffer  | basic_memory_buffer<char>    |
+  +----------------+------------------------------+
+  | wmemory_buffer | basic_memory_buffer<wchar_t> |
+  +----------------+------------------------------+
+
+  **Example**::
+
+     fmt::memory_buffer out;
+     format_to(out, "The answer is {}.", 42);
+
+  This will write the following output to the ``out`` object:
+
+  .. code-block:: none
+
+     The answer is 42.
+
+  The output can be converted to an ``std::string`` with ``to_string(out)``.
   \endrst
  */
-template<typename T>
-class Buffer
-{
-private:
-    FMT_DISALLOW_COPY_AND_ASSIGN(Buffer);
+template <typename T, std::size_t SIZE = inline_buffer_size,
+          typename Allocator = std::allocator<T> >
+class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
+ private:
+  T store_[SIZE];
 
-protected:
-    T *ptr_;
-    std::size_t size_;
-    std::size_t capacity_;
+  // Deallocate memory allocated by the buffer.
+  void deallocate() {
+    T* data = this->data();
+    if (data != store_) Allocator::deallocate(data, this->capacity());
+  }
 
-    Buffer(T *ptr = FMT_NULL, std::size_t capacity = 0)
-        : ptr_(ptr)
-        , size_(0)
-        , capacity_(capacity)
-    {
+ protected:
+  void grow(std::size_t size) FMT_OVERRIDE;
+
+ public:
+  explicit basic_memory_buffer(const Allocator &alloc = Allocator())
+      : Allocator(alloc) {
+    this->set(store_, SIZE);
+  }
+  ~basic_memory_buffer() { deallocate(); }
+
+ private:
+  // Move data from other to this buffer.
+  void move(basic_memory_buffer &other) {
+    Allocator &this_alloc = *this, &other_alloc = other;
+    this_alloc = std::move(other_alloc);
+    T* data = other.data();
+    std::size_t size = other.size(), capacity = other.capacity();
+    if (data == other.store_) {
+      this->set(store_, capacity);
+      std::uninitialized_copy(other.store_, other.store_ + size,
+                              internal::make_checked(store_, capacity));
+    } else {
+      this->set(data, capacity);
+      // Set pointer to the inline array so that delete is not called
+      // when deallocating.
+      other.set(other.store_, 0);
     }
+    this->resize(size);
+  }
 
-    /**
-      \rst
-      Increases the buffer capacity to hold at least *size* elements updating
-      ``ptr_`` and ``capacity_``.
-      \endrst
-     */
-    virtual void grow(std::size_t size) = 0;
+ public:
+  /**
+    \rst
+    Constructs a :class:`fmt::basic_memory_buffer` object moving the content
+    of the other object to it.
+    \endrst
+   */
+  basic_memory_buffer(basic_memory_buffer &&other) {
+    move(other);
+  }
 
-public:
-    virtual ~Buffer() {}
+  /**
+    \rst
+    Moves the content of the other ``basic_memory_buffer`` object to this one.
+    \endrst
+   */
+  basic_memory_buffer &operator=(basic_memory_buffer &&other) {
+    assert(this != &other);
+    deallocate();
+    move(other);
+    return *this;
+  }
 
-    /** Returns the size of this buffer. */
-    std::size_t size() const
-    {
-        return size_;
-    }
-
-    /** Returns the capacity of this buffer. */
-    std::size_t capacity() const
-    {
-        return capacity_;
-    }
-
-    /**
-      Resizes the buffer. If T is a POD type new elements may not be initialized.
-     */
-    void resize(std::size_t new_size)
-    {
-        if (new_size > capacity_)
-            grow(new_size);
-        size_ = new_size;
-    }
-
-    /**
-      \rst
-      Reserves space to store at least *capacity* elements.
-      \endrst
-     */
-    void reserve(std::size_t capacity)
-    {
-        if (capacity > capacity_)
-            grow(capacity);
-    }
-
-    void clear() FMT_NOEXCEPT
-    {
-        size_ = 0;
-    }
-
-    void push_back(const T &value)
-    {
-        if (size_ == capacity_)
-            grow(size_ + 1);
-        ptr_[size_++] = value;
-    }
-
-    /** Appends data to the end of the buffer. */
-    template<typename U>
-    void append(const U *begin, const U *end);
-
-    T &operator[](std::size_t index)
-    {
-        return ptr_[index];
-    }
-    const T &operator[](std::size_t index) const
-    {
-        return ptr_[index];
-    }
+  // Returns a copy of the allocator associated with this buffer.
+  Allocator get_allocator() const { return *this; }
 };
 
-template<typename T>
-template<typename U>
-void Buffer<T>::append(const U *begin, const U *end)
-{
-    FMT_ASSERT(end >= begin, "negative value");
-    std::size_t new_size = size_ + static_cast<std::size_t>(end - begin);
-    if (new_size > capacity_)
-        grow(new_size);
-    std::uninitialized_copy(begin, end, internal::make_ptr(ptr_, capacity_) + size_);
-    size_ = new_size;
+template <typename T, std::size_t SIZE, typename Allocator>
+void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
+  std::size_t old_capacity = this->capacity();
+  std::size_t new_capacity = old_capacity + old_capacity / 2;
+  if (size > new_capacity)
+      new_capacity = size;
+  T *old_data = this->data();
+  T *new_data = internal::allocate<Allocator>(*this, new_capacity);
+  // The following code doesn't throw, so the raw pointer above doesn't leak.
+  std::uninitialized_copy(old_data, old_data + this->size(),
+                          internal::make_checked(new_data, new_capacity));
+  this->set(new_data, new_capacity);
+  // deallocate must not throw according to the standard, but even if it does,
+  // the buffer already uses the new storage and will deallocate it in
+  // destructor.
+  if (old_data != store_)
+    Allocator::deallocate(old_data, old_capacity);
 }
+
+typedef basic_memory_buffer<char> memory_buffer;
+typedef basic_memory_buffer<wchar_t> wmemory_buffer;
+
+/**
+  \rst
+  A fixed-size memory buffer. For a dynamically growing buffer use
+  :class:`fmt::basic_memory_buffer`.
+
+  Trying to increase the buffer size past the initial capacity will throw
+  ``std::runtime_error``.
+  \endrst
+ */
+template <typename Char>
+class basic_fixed_buffer : public internal::basic_buffer<Char> {
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
+   given size.
+   \endrst
+   */
+  basic_fixed_buffer(Char *array, std::size_t size) {
+    this->set(array, size);
+  }
+
+  /**
+   \rst
+   Constructs a :class:`fmt::basic_fixed_buffer` object for *array* of the
+   size known at compile time.
+   \endrst
+   */
+  template <std::size_t SIZE>
+  explicit basic_fixed_buffer(Char (&array)[SIZE]) {
+    this->set(array, SIZE);
+  }
+
+ protected:
+  FMT_API void grow(std::size_t size) FMT_OVERRIDE;
+};
 
 namespace internal {
 
-// A memory buffer for trivially copyable/constructible types with the first
-// SIZE elements stored in the object itself.
-template<typename T, std::size_t SIZE, typename Allocator = std::allocator<T>>
-class MemoryBuffer : private Allocator, public Buffer<T>
-{
-private:
-    T data_[SIZE];
+template <typename Char>
+struct char_traits;
 
-    // Deallocate memory allocated by the buffer.
-    void deallocate()
-    {
-        if (this->ptr_ != data_)
-            Allocator::deallocate(this->ptr_, this->capacity_);
-    }
-
-protected:
-    void grow(std::size_t size) FMT_OVERRIDE;
-
-public:
-    explicit MemoryBuffer(const Allocator &alloc = Allocator())
-        : Allocator(alloc)
-        , Buffer<T>(data_, SIZE)
-    {
-    }
-    ~MemoryBuffer() FMT_OVERRIDE
-    {
-        deallocate();
-    }
-
-#if FMT_USE_RVALUE_REFERENCES
-private:
-    // Move data from other to this buffer.
-    void move(MemoryBuffer &other)
-    {
-        Allocator &this_alloc = *this, &other_alloc = other;
-        this_alloc = std::move(other_alloc);
-        this->size_ = other.size_;
-        this->capacity_ = other.capacity_;
-        if (other.ptr_ == other.data_)
-        {
-            this->ptr_ = data_;
-            std::uninitialized_copy(other.data_, other.data_ + this->size_, make_ptr(data_, this->capacity_));
-        }
-        else
-        {
-            this->ptr_ = other.ptr_;
-            // Set pointer to the inline array so that delete is not called
-            // when deallocating.
-            other.ptr_ = other.data_;
-        }
-    }
-
-public:
-    MemoryBuffer(MemoryBuffer &&other)
-    {
-        move(other);
-    }
-
-    MemoryBuffer &operator=(MemoryBuffer &&other)
-    {
-        assert(this != &other);
-        deallocate();
-        move(other);
-        return *this;
-    }
-#endif
-
-    // Returns a copy of the allocator associated with this buffer.
-    Allocator get_allocator() const
-    {
-        return *this;
-    }
+template <>
+struct char_traits<char> {
+  // Formats a floating-point number.
+  template <typename T>
+  FMT_API static int format_float(char *buffer, std::size_t size,
+      const char *format, unsigned width, int precision, T value);
 };
 
-template<typename T, std::size_t SIZE, typename Allocator>
-void MemoryBuffer<T, SIZE, Allocator>::grow(std::size_t size)
-{
-    std::size_t new_capacity = this->capacity_ + this->capacity_ / 2;
-    if (size > new_capacity)
-        new_capacity = size;
-#if FMT_USE_ALLOCATOR_TRAITS
-    T *new_ptr = std::allocator_traits<Allocator>::allocate(*this, new_capacity, FMT_NULL);
-#else
-    T *new_ptr = this->allocate(new_capacity, FMT_NULL);
+template <>
+struct char_traits<wchar_t> {
+  template <typename T>
+  FMT_API static int format_float(wchar_t *buffer, std::size_t size,
+      const wchar_t *format, unsigned width, int precision, T value);
+};
+
+#if FMT_USE_EXTERN_TEMPLATES
+extern template int char_traits<char>::format_float<double>(
+    char *buffer, std::size_t size, const char* format, unsigned width,
+    int precision, double value);
+extern template int char_traits<char>::format_float<long double>(
+    char *buffer, std::size_t size, const char* format, unsigned width,
+    int precision, long double value);
+
+extern template int char_traits<wchar_t>::format_float<double>(
+    wchar_t *buffer, std::size_t size, const wchar_t* format, unsigned width,
+    int precision, double value);
+extern template int char_traits<wchar_t>::format_float<long double>(
+    wchar_t *buffer, std::size_t size, const wchar_t* format, unsigned width,
+    int precision, long double value);
 #endif
-    // The following code doesn't throw, so the raw pointer above doesn't leak.
-    std::uninitialized_copy(this->ptr_, this->ptr_ + this->size_, make_ptr(new_ptr, new_capacity));
-    std::size_t old_capacity = this->capacity_;
-    T *old_ptr = this->ptr_;
-    this->capacity_ = new_capacity;
-    this->ptr_ = new_ptr;
-    // deallocate may throw (at least in principle), but it doesn't matter since
-    // the buffer already uses the new storage and will deallocate it in case
-    // of exception.
-    if (old_ptr != data_)
-        Allocator::deallocate(old_ptr, old_capacity);
+
+template <typename Container>
+inline typename std::enable_if<
+  is_contiguous<Container>::value,
+  typename checked<typename Container::value_type>::type>::type
+    reserve(std::back_insert_iterator<Container> &it, std::size_t n) {
+  Container &c = internal::get_container(it);
+  std::size_t size = c.size();
+  c.resize(size + n);
+  return make_checked(&c[size], n);
 }
 
-// A fixed-size buffer.
-template<typename Char>
-class FixedBuffer : public fmt::Buffer<Char>
-{
-public:
-    FixedBuffer(Char *array, std::size_t size)
-        : fmt::Buffer<Char>(array, size)
-    {
-    }
+template <typename Iterator>
+inline Iterator &reserve(Iterator &it, std::size_t) { return it; }
 
-protected:
-    FMT_API void grow(std::size_t size) FMT_OVERRIDE;
+template <typename Char>
+class null_terminating_iterator;
+
+template <typename Char>
+FMT_CONSTEXPR_DECL const Char *pointer_from(null_terminating_iterator<Char> it);
+
+// An iterator that produces a null terminator on *end. This simplifies parsing
+// and allows comparing the performance of processing a null-terminated string
+// vs string_view.
+template <typename Char>
+class null_terminating_iterator {
+ public:
+  typedef std::ptrdiff_t difference_type;
+  typedef Char value_type;
+  typedef const Char* pointer;
+  typedef const Char& reference;
+  typedef std::random_access_iterator_tag iterator_category;
+
+  null_terminating_iterator() : ptr_(0), end_(0) {}
+
+  FMT_CONSTEXPR null_terminating_iterator(const Char *ptr, const Char *end)
+    : ptr_(ptr), end_(end) {}
+
+  template <typename Range>
+  FMT_CONSTEXPR explicit null_terminating_iterator(const Range &r)
+    : ptr_(r.begin()), end_(r.end()) {}
+
+  null_terminating_iterator &operator=(const Char *ptr) {
+    assert(ptr <= end_);
+    ptr_ = ptr;
+    return *this;
+  }
+
+  FMT_CONSTEXPR Char operator*() const {
+    return ptr_ != end_ ? *ptr_ : 0;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator++() {
+    ++ptr_;
+    return *this;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator++(int) {
+    null_terminating_iterator result(*this);
+    ++ptr_;
+    return result;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator--() {
+    --ptr_;
+    return *this;
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator+(difference_type n) {
+    return null_terminating_iterator(ptr_ + n, end_);
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator-(difference_type n) {
+    return null_terminating_iterator(ptr_ - n, end_);
+  }
+
+  FMT_CONSTEXPR null_terminating_iterator operator+=(difference_type n) {
+    ptr_ += n;
+    return *this;
+  }
+
+  FMT_CONSTEXPR difference_type operator-(
+      null_terminating_iterator other) const {
+    return ptr_ - other.ptr_;
+  }
+
+  FMT_CONSTEXPR bool operator!=(null_terminating_iterator other) const {
+    return ptr_ != other.ptr_;
+  }
+
+  bool operator>=(null_terminating_iterator other) const {
+    return ptr_ >= other.ptr_;
+  }
+
+  // This should be a friend specialization pointer_from<Char> but the latter
+  // doesn't compile by gcc 5.1 due to a compiler bug.
+  template <typename CharT>
+  friend FMT_CONSTEXPR_DECL const CharT *pointer_from(
+      null_terminating_iterator<CharT> it);
+
+ private:
+  const Char *ptr_;
+  const Char *end_;
 };
 
-template<typename Char>
-class BasicCharTraits
-{
-public:
-#if FMT_SECURE_SCL
-    typedef stdext::checked_array_iterator<Char *> CharPtr;
-#else
-    typedef Char *CharPtr;
-#endif
-    static Char cast(int value)
-    {
-        return static_cast<Char>(value);
-    }
+template <typename T>
+FMT_CONSTEXPR const T *pointer_from(const T *p) { return p; }
+
+template <typename Char>
+FMT_CONSTEXPR const Char *pointer_from(null_terminating_iterator<Char> it) {
+  return it.ptr_;
+}
+
+// An output iterator that counts the number of objects written to it and
+// discards them.
+template <typename T>
+class counting_iterator {
+ private:
+  std::size_t count_;
+  mutable T blackhole_;
+
+ public:
+  typedef std::output_iterator_tag iterator_category;
+  typedef T value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T* pointer;
+  typedef T& reference;
+  typedef counting_iterator _Unchecked_type;  // Mark iterator as checked.
+
+  counting_iterator(): count_(0) {}
+
+  std::size_t count() const { return count_; }
+
+  counting_iterator& operator++() {
+    ++count_;
+    return *this;
+  }
+
+  counting_iterator operator++(int) { return ++*this; }
+
+  T &operator*() const { return blackhole_; }
 };
 
-template<typename Char>
-class CharTraits;
+// An output iterator that truncates the output and counts the number of objects
+// written to it.
+template <typename OutputIt>
+class truncating_iterator {
+ private:
+  typedef std::iterator_traits<OutputIt> traits;
 
-template<>
-class CharTraits<char> : public BasicCharTraits<char>
-{
-private:
-    // Conversion from wchar_t to char is not allowed.
-    static char convert(wchar_t);
+  OutputIt out_;
+  std::size_t limit_;
+  std::size_t count_;
+  mutable typename traits::value_type blackhole_;
 
-public:
-    static char convert(char value)
-    {
-        return value;
-    }
+ public:
+  typedef std::output_iterator_tag iterator_category;
+  typedef typename traits::value_type value_type;
+  typedef typename traits::difference_type difference_type;
+  typedef typename traits::pointer pointer;
+  typedef typename traits::reference reference;
+  typedef truncating_iterator _Unchecked_type;  // Mark iterator as checked.
 
-    // Formats a floating-point number.
-    template<typename T>
-    FMT_API static int format_float(char *buffer, std::size_t size, const char *format, unsigned width, int precision, T value);
-};
+  truncating_iterator(OutputIt out, std::size_t limit)
+    : out_(out), limit_(limit), count_(0) {}
 
-#if FMT_USE_EXTERN_TEMPLATES
-extern template int CharTraits<char>::format_float<double>(
-    char *buffer, std::size_t size, const char *format, unsigned width, int precision, double value);
-extern template int CharTraits<char>::format_float<long double>(
-    char *buffer, std::size_t size, const char *format, unsigned width, int precision, long double value);
-#endif
+  OutputIt base() const { return out_; }
+  std::size_t count() const { return count_; }
 
-template<>
-class CharTraits<wchar_t> : public BasicCharTraits<wchar_t>
-{
-public:
-    static wchar_t convert(char value)
-    {
-        return value;
-    }
-    static wchar_t convert(wchar_t value)
-    {
-        return value;
-    }
+  truncating_iterator& operator++() {
+    if (count_++ < limit_)
+      ++out_;
+    return *this;
+  }
 
-    template<typename T>
-    FMT_API static int format_float(wchar_t *buffer, std::size_t size, const wchar_t *format, unsigned width, int precision, T value);
-};
+  truncating_iterator operator++(int) { return ++*this; }
 
-#if FMT_USE_EXTERN_TEMPLATES
-extern template int CharTraits<wchar_t>::format_float<double>(
-    wchar_t *buffer, std::size_t size, const wchar_t *format, unsigned width, int precision, double value);
-extern template int CharTraits<wchar_t>::format_float<long double>(
-    wchar_t *buffer, std::size_t size, const wchar_t *format, unsigned width, int precision, long double value);
-#endif
-
-// Checks if a number is negative - used to avoid warnings.
-template<bool IsSigned>
-struct SignChecker
-{
-    template<typename T>
-    static bool is_negative(T value)
-    {
-        return value < 0;
-    }
-};
-
-template<>
-struct SignChecker<false>
-{
-    template<typename T>
-    static bool is_negative(T)
-    {
-        return false;
-    }
+  reference operator*() const { return count_ < limit_ ? *out_ : blackhole_; }
 };
 
 // Returns true if value is negative, false otherwise.
 // Same as (value < 0) but doesn't produce warnings if T is an unsigned type.
-template<typename T>
-inline bool is_negative(T value)
-{
-    return SignChecker<std::numeric_limits<T>::is_signed>::is_negative(value);
+template <typename T>
+FMT_CONSTEXPR typename std::enable_if<
+    std::numeric_limits<T>::is_signed, bool>::type is_negative(T value) {
+  return value < 0;
+}
+template <typename T>
+FMT_CONSTEXPR typename std::enable_if<
+    !std::numeric_limits<T>::is_signed, bool>::type is_negative(T) {
+  return false;
 }
 
-// Selects uint32_t if FitsIn32Bits is true, uint64_t otherwise.
-template<bool FitsIn32Bits>
-struct TypeSelector
-{
-    typedef uint32_t Type;
+template <typename T>
+struct int_traits {
+  // Smallest of uint32_t and uint64_t that is large enough to represent
+  // all values of T.
+  typedef typename std::conditional<
+    std::numeric_limits<T>::digits <= 32, uint32_t, uint64_t>::type main_type;
 };
-
-template<>
-struct TypeSelector<false>
-{
-    typedef uint64_t Type;
-};
-
-template<typename T>
-struct IntTraits
-{
-    // Smallest of uint32_t and uint64_t that is large enough to represent
-    // all values of T.
-    typedef typename TypeSelector<std::numeric_limits<T>::digits <= 32>::Type MainType;
-};
-
-FMT_API FMT_NORETURN void report_unknown_type(char code, const char *type);
 
 // Static data is placed in this class template to allow header-only
 // configuration.
-template<typename T = void>
-struct FMT_API BasicData
-{
-    static const uint32_t POWERS_OF_10_32[];
-    static const uint64_t POWERS_OF_10_64[];
-    static const char DIGITS[];
+template <typename T = void>
+struct FMT_API basic_data {
+  static const uint32_t POWERS_OF_10_32[];
+  static const uint64_t POWERS_OF_10_64[];
+  static const uint64_t POW10_SIGNIFICANDS[];
+  static const int16_t POW10_EXPONENTS[];
+  static const char DIGITS[];
 };
 
 #if FMT_USE_EXTERN_TEMPLATES
-extern template struct BasicData<void>;
+extern template struct basic_data<void>;
 #endif
 
-typedef BasicData<> Data;
+typedef basic_data<> data;
 
 #ifdef FMT_BUILTIN_CLZLL
 // Returns the number of decimal digits in n. Leading zeros are not counted
 // except for n == 0 in which case count_digits returns 1.
-inline unsigned count_digits(uint64_t n)
-{
-    // Based on http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
-    // and the benchmark https://github.com/localvoid/cxx-benchmark-count-digits.
-    int t = (64 - FMT_BUILTIN_CLZLL(n | 1)) * 1233 >> 12;
-    return to_unsigned(t) - (n < Data::POWERS_OF_10_64[t]) + 1;
+inline unsigned count_digits(uint64_t n) {
+  // Based on http://graphics.stanford.edu/~seander/bithacks.html#IntegerLog10
+  // and the benchmark https://github.com/localvoid/cxx-benchmark-count-digits.
+  int t = (64 - FMT_BUILTIN_CLZLL(n | 1)) * 1233 >> 12;
+  return to_unsigned(t) - (n < data::POWERS_OF_10_64[t]) + 1;
 }
 #else
 // Fallback version of count_digits used when __builtin_clz is not available.
-inline unsigned count_digits(uint64_t n)
-{
-    unsigned count = 1;
-    for (;;)
-    {
-        // Integer division is slow so do it for a group of four digits instead
-        // of for every digit. The idea comes from the talk by Alexandrescu
-        // "Three Optimization Tips for C++". See speed-test for a comparison.
-        if (n < 10)
-            return count;
-        if (n < 100)
-            return count + 1;
-        if (n < 1000)
-            return count + 2;
-        if (n < 10000)
-            return count + 3;
-        n /= 10000u;
-        count += 4;
-    }
+inline unsigned count_digits(uint64_t n) {
+  unsigned count = 1;
+  for (;;) {
+    // Integer division is slow so do it for a group of four digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    if (n < 10) return count;
+    if (n < 100) return count + 1;
+    if (n < 1000) return count + 2;
+    if (n < 10000) return count + 3;
+    n /= 10000u;
+    count += 4;
+  }
 }
 #endif
 
+#if FMT_HAS_CPP_ATTRIBUTE(always_inline)
+# define FMT_ALWAYS_INLINE __attribute__((always_inline))
+#else
+# define FMT_ALWAYS_INLINE
+#endif
+
+template <typename Handler>
+inline char *lg(uint32_t n, Handler h) FMT_ALWAYS_INLINE;
+
+// Computes g = floor(log10(n)) and calls h.on<g>(n);
+template <typename Handler>
+inline char *lg(uint32_t n, Handler h) {
+  return n < 100 ? n < 10 ? h.template on<0>(n) : h.template on<1>(n)
+                 : n < 1000000
+                       ? n < 10000 ? n < 1000 ? h.template on<2>(n)
+                                              : h.template on<3>(n)
+                                   : n < 100000 ? h.template on<4>(n)
+                                                : h.template on<5>(n)
+                       : n < 100000000 ? n < 10000000 ? h.template on<6>(n)
+                                                      : h.template on<7>(n)
+                                       : n < 1000000000 ? h.template on<8>(n)
+                                                        : h.template on<9>(n);
+}
+
+// An lg handler that formats a decimal number.
+// Usage: lg(n, decimal_formatter(buffer));
+class decimal_formatter {
+ private:
+  char *buffer_;
+
+  void write_pair(unsigned N, uint32_t index) {
+    std::memcpy(buffer_ + N, data::DIGITS + index * 2, 2);
+  }
+
+ public:
+  explicit decimal_formatter(char *buf) : buffer_(buf) {}
+
+  template <unsigned N> char *on(uint32_t u) {
+    if (N == 0) {
+      *buffer_ = static_cast<char>(u) + '0';
+    } else if (N == 1) {
+      write_pair(0, u);
+    } else {
+      // The idea of using 4.32 fixed-point numbers is based on
+      // https://github.com/jeaiii/itoa
+      unsigned n = N - 1;
+      unsigned a = n / 5 * n * 53 / 16;
+      uint64_t t = ((1ULL << (32 + a)) / data::POWERS_OF_10_32[n] + 1 - n / 9);
+      t = ((t * u) >> a) + n / 5 * 4;
+      write_pair(0, t >> 32);
+      for (int i = 2; i < N; i += 2) {
+        t = 100ULL * static_cast<uint32_t>(t);
+        write_pair(i, t >> 32);
+      }
+      if (N % 2 == 0) {
+        buffer_[N] = static_cast<char>(
+          (10ULL * static_cast<uint32_t>(t)) >> 32) + '0';
+      }
+    }
+    return buffer_ += N + 1;
+  }
+};
+
+// An lg handler that formats a decimal number with a terminating null.
+class decimal_formatter_null : public decimal_formatter {
+ public:
+  explicit decimal_formatter_null(char *buf) : decimal_formatter(buf) {}
+
+  template <unsigned N> char *on(uint32_t u) {
+    char *buf = decimal_formatter::on<N>(u);
+    *buf = '\0';
+    return buf;
+  }
+};
+
 #ifdef FMT_BUILTIN_CLZ
 // Optional version of count_digits for better performance on 32-bit platforms.
-inline unsigned count_digits(uint32_t n)
-{
-    int t = (32 - FMT_BUILTIN_CLZ(n | 1)) * 1233 >> 12;
-    return to_unsigned(t) - (n < Data::POWERS_OF_10_32[t]) + 1;
+inline unsigned count_digits(uint32_t n) {
+  int t = (32 - FMT_BUILTIN_CLZ(n | 1)) * 1233 >> 12;
+  return to_unsigned(t) - (n < data::POWERS_OF_10_32[t]) + 1;
 }
 #endif
 
 // A functor that doesn't add a thousands separator.
-struct NoThousandsSep
-{
-    template<typename Char>
-    void operator()(Char *)
-    {
-    }
+struct no_thousands_sep {
+  typedef char char_type;
+
+  template <typename Char>
+  void operator()(Char *) {}
 };
 
 // A functor that adds a thousands separator.
-class ThousandsSep
-{
-private:
-    fmt::StringRef sep_;
+template <typename Char>
+class add_thousands_sep {
+ private:
+  basic_string_view<Char> sep_;
 
-    // Index of a decimal digit with the least significant digit having index 0.
-    unsigned digit_index_;
+  // Index of a decimal digit with the least significant digit having index 0.
+  unsigned digit_index_;
 
-public:
-    explicit ThousandsSep(fmt::StringRef sep)
-        : sep_(sep)
-        , digit_index_(0)
-    {
-    }
+ public:
+  typedef Char char_type;
 
-    template<typename Char>
-    void operator()(Char *&buffer)
-    {
-        if (++digit_index_ % 3 != 0)
-            return;
-        buffer -= sep_.size();
-        std::uninitialized_copy(sep_.data(), sep_.data() + sep_.size(), internal::make_ptr(buffer, sep_.size()));
-    }
+  explicit add_thousands_sep(basic_string_view<Char> sep)
+    : sep_(sep), digit_index_(0) {}
+
+  void operator()(Char *&buffer) {
+    if (++digit_index_ % 3 != 0)
+      return;
+    buffer -= sep_.size();
+    std::uninitialized_copy(sep_.data(), sep_.data() + sep_.size(),
+                            internal::make_checked(buffer, sep_.size()));
+  }
 };
+
+template <typename Char>
+FMT_API Char thousands_sep(locale_provider *lp);
 
 // Formats a decimal unsigned integer value writing into buffer.
 // thousands_sep is a functor that is called after writing each char to
 // add a thousands separator if necessary.
-template<typename UInt, typename Char, typename ThousandsSep>
-inline void format_decimal(Char *buffer, UInt value, unsigned num_digits, ThousandsSep thousands_sep)
-{
-    buffer += num_digits;
-    while (value >= 100)
-    {
-        // Integer division is slow so do it for a group of two digits instead
-        // of for every digit. The idea comes from the talk by Alexandrescu
-        // "Three Optimization Tips for C++". See speed-test for a comparison.
-        unsigned index = static_cast<unsigned>((value % 100) * 2);
-        value /= 100;
-        *--buffer = Data::DIGITS[index + 1];
-        thousands_sep(buffer);
-        *--buffer = Data::DIGITS[index];
-        thousands_sep(buffer);
-    }
-    if (value < 10)
-    {
-        *--buffer = static_cast<char>('0' + value);
-        return;
-    }
-    unsigned index = static_cast<unsigned>(value * 2);
-    *--buffer = Data::DIGITS[index + 1];
+template <typename UInt, typename Char, typename ThousandsSep>
+inline Char *format_decimal(Char *buffer, UInt value, unsigned num_digits,
+                            ThousandsSep thousands_sep) {
+  buffer += num_digits;
+  Char *end = buffer;
+  while (value >= 100) {
+    // Integer division is slow so do it for a group of two digits instead
+    // of for every digit. The idea comes from the talk by Alexandrescu
+    // "Three Optimization Tips for C++". See speed-test for a comparison.
+    unsigned index = static_cast<unsigned>((value % 100) * 2);
+    value /= 100;
+    *--buffer = data::DIGITS[index + 1];
     thousands_sep(buffer);
-    *--buffer = Data::DIGITS[index];
+    *--buffer = data::DIGITS[index];
+    thousands_sep(buffer);
+  }
+  if (value < 10) {
+    *--buffer = static_cast<char>('0' + value);
+    return end;
+  }
+  unsigned index = static_cast<unsigned>(value * 2);
+  *--buffer = data::DIGITS[index + 1];
+  thousands_sep(buffer);
+  *--buffer = data::DIGITS[index];
+  return end;
 }
 
-template<typename UInt, typename Char>
-inline void format_decimal(Char *buffer, UInt value, unsigned num_digits)
-{
-    format_decimal(buffer, value, num_digits, NoThousandsSep());
-    return;
+template <typename UInt, typename Iterator, typename ThousandsSep>
+inline Iterator format_decimal(
+    Iterator out, UInt value, unsigned num_digits, ThousandsSep sep) {
+  typedef typename ThousandsSep::char_type char_type;
+  // Buffer should be large enough to hold all digits (digits10 + 1) and null.
+  char_type buffer[std::numeric_limits<UInt>::digits10 + 2];
+  format_decimal(buffer, value, num_digits, sep);
+  return std::copy_n(buffer, num_digits, out);
+}
+
+template <typename It, typename UInt>
+inline It format_decimal(It out, UInt value, unsigned num_digits) {
+  return format_decimal(out, value, num_digits, no_thousands_sep());
+}
+
+template <unsigned BASE_BITS, typename Char, typename UInt>
+inline Char *format_uint(Char *buffer, UInt value, unsigned num_digits,
+                         bool upper = false) {
+  buffer += num_digits;
+  Char *end = buffer;
+  do {
+    const char *digits = upper ? "0123456789ABCDEF" : "0123456789abcdef";
+    unsigned digit = (value & ((1 << BASE_BITS) - 1));
+    *--buffer = BASE_BITS < 4 ? static_cast<char>('0' + digit) : digits[digit];
+  } while ((value >>= BASE_BITS) != 0);
+  return end;
+}
+
+template <unsigned BASE_BITS, typename It, typename UInt>
+inline It format_uint(It out, UInt value, unsigned num_digits,
+                      bool upper = false) {
+  // Buffer should be large enough to hold all digits (digits / BASE_BITS + 1)
+  // and null.
+  char buffer[std::numeric_limits<UInt>::digits / BASE_BITS + 2];
+  format_uint<BASE_BITS>(buffer, value, num_digits, upper);
+  return std::copy_n(buffer, num_digits, out);
 }
 
 #ifndef _WIN32
-#define FMT_USE_WINDOWS_H 0
+# define FMT_USE_WINDOWS_H 0
 #elif !defined(FMT_USE_WINDOWS_H)
-#define FMT_USE_WINDOWS_H 1
+# define FMT_USE_WINDOWS_H 1
 #endif
 
 // Define FMT_USE_WINDOWS_H to 0 to disable use of windows.h.
@@ -1284,1816 +1068,1249 @@ inline void format_decimal(Char *buffer, UInt value, unsigned num_digits)
 #if FMT_USE_WINDOWS_H
 // A converter from UTF-8 to UTF-16.
 // It is only provided for Windows since other systems support UTF-8 natively.
-class UTF8ToUTF16
-{
-private:
-    MemoryBuffer<wchar_t, INLINE_BUFFER_SIZE> buffer_;
+class utf8_to_utf16 {
+ private:
+  wmemory_buffer buffer_;
 
-public:
-    FMT_API explicit UTF8ToUTF16(StringRef s);
-    operator WStringRef() const
-    {
-        return WStringRef(&buffer_[0], size());
-    }
-    size_t size() const
-    {
-        return buffer_.size() - 1;
-    }
-    const wchar_t *c_str() const
-    {
-        return &buffer_[0];
-    }
-    std::wstring str() const
-    {
-        return std::wstring(&buffer_[0], size());
-    }
+ public:
+  FMT_API explicit utf8_to_utf16(string_view s);
+  operator wstring_view() const { return wstring_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const wchar_t *c_str() const { return &buffer_[0]; }
+  std::wstring str() const { return std::wstring(&buffer_[0], size()); }
 };
 
 // A converter from UTF-16 to UTF-8.
 // It is only provided for Windows since other systems support UTF-8 natively.
-class UTF16ToUTF8
-{
-private:
-    MemoryBuffer<char, INLINE_BUFFER_SIZE> buffer_;
+class utf16_to_utf8 {
+ private:
+  memory_buffer buffer_;
 
-public:
-    UTF16ToUTF8() {}
-    FMT_API explicit UTF16ToUTF8(WStringRef s);
-    operator StringRef() const
-    {
-        return StringRef(&buffer_[0], size());
-    }
-    size_t size() const
-    {
-        return buffer_.size() - 1;
-    }
-    const char *c_str() const
-    {
-        return &buffer_[0];
-    }
-    std::string str() const
-    {
-        return std::string(&buffer_[0], size());
-    }
+ public:
+  utf16_to_utf8() {}
+  FMT_API explicit utf16_to_utf8(wstring_view s);
+  operator string_view() const { return string_view(&buffer_[0], size()); }
+  size_t size() const { return buffer_.size() - 1; }
+  const char *c_str() const { return &buffer_[0]; }
+  std::string str() const { return std::string(&buffer_[0], size()); }
 
-    // Performs conversion returning a system error code instead of
-    // throwing exception on conversion error. This method may still throw
-    // in case of memory allocation error.
-    FMT_API int convert(WStringRef s);
+  // Performs conversion returning a system error code instead of
+  // throwing exception on conversion error. This method may still throw
+  // in case of memory allocation error.
+  FMT_API int convert(wstring_view s);
 };
 
-FMT_API void format_windows_error(fmt::Writer &out, int error_code, fmt::StringRef message) FMT_NOEXCEPT;
+FMT_API void format_windows_error(fmt::internal::buffer &out, int error_code,
+                                  fmt::string_view message) FMT_NOEXCEPT;
 #endif
 
-// A formatting argument value.
-struct Value
-{
-    template<typename Char>
-    struct StringValue
-    {
-        const Char *value;
-        std::size_t size;
-    };
-
-    typedef void (*FormatFunc)(void *formatter, const void *arg, void *format_str_ptr);
-
-    struct CustomValue
-    {
-        const void *value;
-        FormatFunc format;
-    };
-
-    union
-    {
-        int int_value;
-        unsigned uint_value;
-        LongLong long_long_value;
-        ULongLong ulong_long_value;
-        double double_value;
-        long double long_double_value;
-        const void *pointer;
-        StringValue<char> string;
-        StringValue<signed char> sstring;
-        StringValue<unsigned char> ustring;
-        StringValue<wchar_t> wstring;
-        CustomValue custom;
-    };
-
-    enum Type
-    {
-        NONE,
-        NAMED_ARG,
-        // Integer types should go first,
-        INT,
-        UINT,
-        LONG_LONG,
-        ULONG_LONG,
-        BOOL,
-        CHAR,
-        LAST_INTEGER_TYPE = CHAR,
-        // followed by floating-point types.
-        DOUBLE,
-        LONG_DOUBLE,
-        LAST_NUMERIC_TYPE = LONG_DOUBLE,
-        CSTRING,
-        STRING,
-        WSTRING,
-        POINTER,
-        CUSTOM
-    };
-};
-
-// A formatting argument. It is a trivially copyable/constructible type to
-// allow storage in internal::MemoryBuffer.
-struct Arg : Value
-{
-    Type type;
-};
-
-template<typename Char>
-struct NamedArg;
-template<typename Char, typename T>
-struct NamedArgWithType;
-
-template<typename T = void>
-struct Null
-{
-};
-
-// A helper class template to enable or disable overloads taking wide
-// characters and strings in MakeValue.
-template<typename T, typename Char>
-struct WCharHelper
-{
-    typedef Null<T> Supported;
-    typedef T Unsupported;
-};
-
-template<typename T>
-struct WCharHelper<T, wchar_t>
-{
-    typedef T Supported;
-    typedef Null<T> Unsupported;
-};
-
-typedef char Yes[1];
-typedef char No[2];
-
-template<typename T>
-T &get();
-
-// These are non-members to workaround an overload resolution bug in bcc32.
-Yes &convert(fmt::ULongLong);
-No &convert(...);
-
-template<typename T, bool ENABLE_CONVERSION>
-struct ConvertToIntImpl
-{
-    enum
-    {
-        value = ENABLE_CONVERSION
-    };
-};
-
-template<typename T, bool ENABLE_CONVERSION>
-struct ConvertToIntImpl2
-{
-    enum
-    {
-        value = false
-    };
-};
-
-template<typename T>
-struct ConvertToIntImpl2<T, true>
-{
-    enum
-    {
-        // Don't convert numeric types.
-        value = ConvertToIntImpl<T, !std::numeric_limits<T>::is_specialized>::value
-    };
-};
-
-template<typename T>
-struct ConvertToInt
-{
-    enum
-    {
-        enable_conversion = sizeof(fmt::internal::convert(get<T>())) == sizeof(Yes)
-    };
-    enum
-    {
-        value = ConvertToIntImpl2<T, enable_conversion>::value
-    };
-};
-
-#define FMT_DISABLE_CONVERSION_TO_INT(Type)                                                                                                \
-    template<>                                                                                                                             \
-    struct ConvertToInt<Type>                                                                                                              \
-    {                                                                                                                                      \
-        enum                                                                                                                               \
-        {                                                                                                                                  \
-            value = 0                                                                                                                      \
-        };                                                                                                                                 \
-    }
-
-// Silence warnings about convering float to int.
-FMT_DISABLE_CONVERSION_TO_INT(float);
-FMT_DISABLE_CONVERSION_TO_INT(double);
-FMT_DISABLE_CONVERSION_TO_INT(long double);
-
-template<bool B, class T = void>
-struct EnableIf
-{
-};
-
-template<class T>
-struct EnableIf<true, T>
-{
-    typedef T type;
-};
-
-template<bool B, class T, class F>
-struct Conditional
-{
-    typedef T type;
-};
-
-template<class T, class F>
-struct Conditional<false, T, F>
-{
-    typedef F type;
-};
-
-// For bcc32 which doesn't understand ! in template arguments.
-template<bool>
-struct Not
-{
-    enum
-    {
-        value = 0
-    };
-};
-
-template<>
-struct Not<false>
-{
-    enum
-    {
-        value = 1
-    };
-};
-
-template<typename T>
-struct FalseType
-{
-    enum
-    {
-        value = 0
-    };
-};
-
-template<typename T, T>
-struct LConvCheck
-{
-    LConvCheck(int) {}
-};
-
-// Returns the thousands separator for the current locale.
-// We check if ``lconv`` contains ``thousands_sep`` because on Android
-// ``lconv`` is stubbed as an empty struct.
-template<typename LConv>
-inline StringRef thousands_sep(LConv *lc, LConvCheck<char * LConv::*, &LConv::thousands_sep> = 0)
-{
-    return lc->thousands_sep;
-}
-
-inline fmt::StringRef thousands_sep(...)
-{
-    return "";
-}
-
-#define FMT_CONCAT(a, b) a##b
-
-#if FMT_GCC_VERSION >= 303
-#define FMT_UNUSED __attribute__((unused))
-#else
-#define FMT_UNUSED
-#endif
-
-#ifndef FMT_USE_STATIC_ASSERT
-#define FMT_USE_STATIC_ASSERT 0
-#endif
-
-#if FMT_USE_STATIC_ASSERT || FMT_HAS_FEATURE(cxx_static_assert) || (FMT_GCC_VERSION >= 403 && FMT_HAS_GXX_CXX11) || _MSC_VER >= 1600
-#define FMT_STATIC_ASSERT(cond, message) static_assert(cond, message)
-#else
-#define FMT_CONCAT_(a, b) FMT_CONCAT(a, b)
-#define FMT_STATIC_ASSERT(cond, message) typedef int FMT_CONCAT_(Assert, __LINE__)[(cond) ? 1 : -1] FMT_UNUSED
-#endif
-
-template<typename Formatter>
-void format_arg(Formatter &, ...)
-{
-    FMT_STATIC_ASSERT(FalseType<Formatter>::value, "Cannot format argument. To enable the use of ostream "
-                                                   "operator<< include fmt/ostream.h. Otherwise provide "
-                                                   "an overload of format_arg.");
-}
-
-// Makes an Arg object from any type.
-template<typename Formatter>
-class MakeValue : public Arg
-{
-public:
-    typedef typename Formatter::Char Char;
-
-private:
-    // The following two methods are private to disallow formatting of
-    // arbitrary pointers. If you want to output a pointer cast it to
-    // "void *" or "const void *". In particular, this forbids formatting
-    // of "[const] volatile char *" which is printed as bool by iostreams.
-    // Do not implement!
-    template<typename T>
-    MakeValue(const T *value);
-    template<typename T>
-    MakeValue(T *value);
-
-    // The following methods are private to disallow formatting of wide
-    // characters and strings into narrow strings as in
-    //   fmt::format("{}", L"test");
-    // To fix this, use a wide format string: fmt::format(L"{}", L"test").
-#if !FMT_MSC_VER || defined(_NATIVE_WCHAR_T_DEFINED)
-    MakeValue(typename WCharHelper<wchar_t, Char>::Unsupported);
-#endif
-    MakeValue(typename WCharHelper<wchar_t *, Char>::Unsupported);
-    MakeValue(typename WCharHelper<const wchar_t *, Char>::Unsupported);
-    MakeValue(typename WCharHelper<const std::wstring &, Char>::Unsupported);
-#if FMT_HAS_STRING_VIEW
-    MakeValue(typename WCharHelper<const std::wstring_view &, Char>::Unsupported);
-#endif
-    MakeValue(typename WCharHelper<WStringRef, Char>::Unsupported);
-
-    void set_string(StringRef str)
-    {
-        string.value = str.data();
-        string.size = str.size();
-    }
-
-    void set_string(WStringRef str)
-    {
-        wstring.value = str.data();
-        wstring.size = str.size();
-    }
-
-    // Formats an argument of a custom type, such as a user-defined class.
-    template<typename T>
-    static void format_custom_arg(void *formatter, const void *arg, void *format_str_ptr)
-    {
-        format_arg(*static_cast<Formatter *>(formatter), *static_cast<const Char **>(format_str_ptr), *static_cast<const T *>(arg));
-    }
-
-public:
-    MakeValue() {}
-
-#define FMT_MAKE_VALUE_(Type, field, TYPE, rhs)                                                                                            \
-    MakeValue(Type value)                                                                                                                  \
-    {                                                                                                                                      \
-        field = rhs;                                                                                                                       \
-    }                                                                                                                                      \
-    static uint64_t type(Type)                                                                                                             \
-    {                                                                                                                                      \
-        return Arg::TYPE;                                                                                                                  \
-    }
-
-#define FMT_MAKE_VALUE(Type, field, TYPE) FMT_MAKE_VALUE_(Type, field, TYPE, value)
-
-    FMT_MAKE_VALUE(bool, int_value, BOOL)
-    FMT_MAKE_VALUE(short, int_value, INT)
-    FMT_MAKE_VALUE(unsigned short, uint_value, UINT)
-    FMT_MAKE_VALUE(int, int_value, INT)
-    FMT_MAKE_VALUE(unsigned, uint_value, UINT)
-
-    MakeValue(long value)
-    {
-        // To minimize the number of types we need to deal with, long is
-        // translated either to int or to long long depending on its size.
-        if (const_check(sizeof(long) == sizeof(int)))
-            int_value = static_cast<int>(value);
-        else
-            long_long_value = value;
-    }
-    static uint64_t type(long)
-    {
-        return sizeof(long) == sizeof(int) ? Arg::INT : Arg::LONG_LONG;
-    }
-
-    MakeValue(unsigned long value)
-    {
-        if (const_check(sizeof(unsigned long) == sizeof(unsigned)))
-            uint_value = static_cast<unsigned>(value);
-        else
-            ulong_long_value = value;
-    }
-    static uint64_t type(unsigned long)
-    {
-        return sizeof(unsigned long) == sizeof(unsigned) ? Arg::UINT : Arg::ULONG_LONG;
-    }
-
-    FMT_MAKE_VALUE(LongLong, long_long_value, LONG_LONG)
-    FMT_MAKE_VALUE(ULongLong, ulong_long_value, ULONG_LONG)
-    FMT_MAKE_VALUE(float, double_value, DOUBLE)
-    FMT_MAKE_VALUE(double, double_value, DOUBLE)
-    FMT_MAKE_VALUE(long double, long_double_value, LONG_DOUBLE)
-    FMT_MAKE_VALUE(signed char, int_value, INT)
-    FMT_MAKE_VALUE(unsigned char, uint_value, UINT)
-    FMT_MAKE_VALUE(char, int_value, CHAR)
-
-#if __cplusplus >= 201103L
-    template<typename T, typename = typename std::enable_if<std::is_enum<T>::value && ConvertToInt<T>::value>::type>
-    MakeValue(T value)
-    {
-        int_value = value;
-    }
-
-    template<typename T, typename = typename std::enable_if<std::is_enum<T>::value && ConvertToInt<T>::value>::type>
-    static uint64_t type(T)
-    {
-        return Arg::INT;
-    }
-#endif
-
-#if !defined(_MSC_VER) || defined(_NATIVE_WCHAR_T_DEFINED)
-    MakeValue(typename WCharHelper<wchar_t, Char>::Supported value)
-    {
-        int_value = value;
-    }
-    static uint64_t type(wchar_t)
-    {
-        return Arg::CHAR;
-    }
-#endif
-
-#define FMT_MAKE_STR_VALUE(Type, TYPE)                                                                                                     \
-    MakeValue(Type value)                                                                                                                  \
-    {                                                                                                                                      \
-        set_string(value);                                                                                                                 \
-    }                                                                                                                                      \
-    static uint64_t type(Type)                                                                                                             \
-    {                                                                                                                                      \
-        return Arg::TYPE;                                                                                                                  \
-    }
-
-    FMT_MAKE_VALUE(char *, string.value, CSTRING)
-    FMT_MAKE_VALUE(const char *, string.value, CSTRING)
-    FMT_MAKE_VALUE(signed char *, sstring.value, CSTRING)
-    FMT_MAKE_VALUE(const signed char *, sstring.value, CSTRING)
-    FMT_MAKE_VALUE(unsigned char *, ustring.value, CSTRING)
-    FMT_MAKE_VALUE(const unsigned char *, ustring.value, CSTRING)
-    FMT_MAKE_STR_VALUE(const std::string &, STRING)
-#if FMT_HAS_STRING_VIEW
-    FMT_MAKE_STR_VALUE(const std::string_view &, STRING)
-#endif
-    FMT_MAKE_STR_VALUE(StringRef, STRING)
-    FMT_MAKE_VALUE_(CStringRef, string.value, CSTRING, value.c_str())
-
-#define FMT_MAKE_WSTR_VALUE(Type, TYPE)                                                                                                    \
-    MakeValue(typename WCharHelper<Type, Char>::Supported value)                                                                           \
-    {                                                                                                                                      \
-        set_string(value);                                                                                                                 \
-    }                                                                                                                                      \
-    static uint64_t type(Type)                                                                                                             \
-    {                                                                                                                                      \
-        return Arg::TYPE;                                                                                                                  \
-    }
-
-    FMT_MAKE_WSTR_VALUE(wchar_t *, WSTRING)
-    FMT_MAKE_WSTR_VALUE(const wchar_t *, WSTRING)
-    FMT_MAKE_WSTR_VALUE(const std::wstring &, WSTRING)
-#if FMT_HAS_STRING_VIEW
-    FMT_MAKE_WSTR_VALUE(const std::wstring_view &, WSTRING)
-#endif
-    FMT_MAKE_WSTR_VALUE(WStringRef, WSTRING)
-
-    FMT_MAKE_VALUE(void *, pointer, POINTER)
-    FMT_MAKE_VALUE(const void *, pointer, POINTER)
-
-    template<typename T>
-    MakeValue(const T &value, typename EnableIf<Not<ConvertToInt<T>::value>::value, int>::type = 0)
-    {
-        custom.value = &value;
-        custom.format = &format_custom_arg<T>;
-    }
-
-    template<typename T>
-    static typename EnableIf<Not<ConvertToInt<T>::value>::value, uint64_t>::type type(const T &)
-    {
-        return Arg::CUSTOM;
-    }
-
-    // Additional template param `Char_` is needed here because make_type always
-    // uses char.
-    template<typename Char_>
-    MakeValue(const NamedArg<Char_> &value)
-    {
-        pointer = &value;
-    }
-    template<typename Char_, typename T>
-    MakeValue(const NamedArgWithType<Char_, T> &value)
-    {
-        pointer = &value;
-    }
-
-    template<typename Char_>
-    static uint64_t type(const NamedArg<Char_> &)
-    {
-        return Arg::NAMED_ARG;
-    }
-    template<typename Char_, typename T>
-    static uint64_t type(const NamedArgWithType<Char_, T> &)
-    {
-        return Arg::NAMED_ARG;
-    }
-};
-
-template<typename Formatter>
-class MakeArg : public Arg
-{
-public:
-    MakeArg()
-    {
-        type = Arg::NONE;
-    }
-
-    template<typename T>
-    MakeArg(const T &value)
-        : Arg(MakeValue<Formatter>(value))
-    {
-        type = static_cast<Arg::Type>(MakeValue<Formatter>::type(value));
-    }
-};
-
-template<typename Char>
-struct NamedArg : Arg
-{
-    BasicStringRef<Char> name;
-
-    template<typename T>
-    NamedArg(BasicStringRef<Char> argname, const T &value)
-        : Arg(MakeArg<BasicFormatter<Char>>(value))
-        , name(argname)
-    {
-    }
-};
-
-template<typename Char, typename T>
-struct NamedArgWithType : NamedArg<Char>
-{
-    NamedArgWithType(BasicStringRef<Char> argname, const T &value)
-        : NamedArg<Char>(argname, value)
-    {
-    }
-};
-
-class RuntimeError : public std::runtime_error
-{
-protected:
-    RuntimeError()
-        : std::runtime_error("")
-    {
-    }
-    RuntimeError(const RuntimeError &rerr)
-        : std::runtime_error(rerr)
-    {
-    }
-    FMT_API ~RuntimeError() FMT_DTOR_NOEXCEPT FMT_OVERRIDE;
-};
-
-template<typename Char>
-class ArgMap;
-} // namespace internal
-
-/** An argument list. */
-class ArgList
-{
-private:
-    // To reduce compiled code size per formatting function call, types of first
-    // MAX_PACKED_ARGS arguments are passed in the types_ field.
-    uint64_t types_;
-    union
-    {
-        // If the number of arguments is less than MAX_PACKED_ARGS, the argument
-        // values are stored in values_, otherwise they are stored in args_.
-        // This is done to reduce compiled code size as storing larger objects
-        // may require more code (at least on x86-64) even if the same amount of
-        // data is actually copied to stack. It saves ~10% on the bloat test.
-        const internal::Value *values_;
-        const internal::Arg *args_;
-    };
-
-    internal::Arg::Type type(unsigned index) const
-    {
-        return type(types_, index);
-    }
-
-    template<typename Char>
-    friend class internal::ArgMap;
-
-public:
-    // Maximum number of arguments with packed types.
-    enum
-    {
-        MAX_PACKED_ARGS = 16
-    };
-
-    ArgList()
-        : types_(0)
-    {
-    }
-
-    ArgList(ULongLong types, const internal::Value *values)
-        : types_(types)
-        , values_(values)
-    {
-    }
-    ArgList(ULongLong types, const internal::Arg *args)
-        : types_(types)
-        , args_(args)
-    {
-    }
-
-    uint64_t types() const
-    {
-        return types_;
-    }
-
-    /** Returns the argument at specified index. */
-    internal::Arg operator[](unsigned index) const
-    {
-        using internal::Arg;
-        Arg arg;
-        bool use_values = type(MAX_PACKED_ARGS - 1) == Arg::NONE;
-        if (index < MAX_PACKED_ARGS)
-        {
-            Arg::Type arg_type = type(index);
-            internal::Value &val = arg;
-            if (arg_type != Arg::NONE)
-                val = use_values ? values_[index] : args_[index];
-            arg.type = arg_type;
-            return arg;
-        }
-        if (use_values)
-        {
-            // The index is greater than the number of arguments that can be stored
-            // in values, so return a "none" argument.
-            arg.type = Arg::NONE;
-            return arg;
-        }
-        for (unsigned i = MAX_PACKED_ARGS; i <= index; ++i)
-        {
-            if (args_[i].type == Arg::NONE)
-                return args_[i];
-        }
-        return args_[index];
-    }
-
-    static internal::Arg::Type type(uint64_t types, unsigned index)
-    {
-        unsigned shift = index * 4;
-        uint64_t mask = 0xf;
-        return static_cast<internal::Arg::Type>((types & (mask << shift)) >> shift);
-    }
-};
-
-#define FMT_DISPATCH(call) static_cast<Impl *>(this)->call
+template <typename T = void>
+struct null {};
+}  // namespace internal
+
+struct monostate {};
 
 /**
   \rst
-  An argument visitor based on the `curiously recurring template pattern
-  <http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern>`_.
-
-  To use `~fmt::ArgVisitor` define a subclass that implements some or all of the
-  visit methods with the same signatures as the methods in `~fmt::ArgVisitor`,
-  for example, `~fmt::ArgVisitor::visit_int()`.
-  Pass the subclass as the *Impl* template parameter. Then calling
-  `~fmt::ArgVisitor::visit` for some argument will dispatch to a visit method
-  specific to the argument type. For example, if the argument type is
-  ``double`` then the `~fmt::ArgVisitor::visit_double()` method of a subclass
-  will be called. If the subclass doesn't contain a method with this signature,
-  then a corresponding method of `~fmt::ArgVisitor` will be called.
-
-  **Example**::
-
-    class MyArgVisitor : public fmt::ArgVisitor<MyArgVisitor, void> {
-     public:
-      void visit_int(int value) { fmt::print("{}", value); }
-      void visit_double(double value) { fmt::print("{}", value ); }
-    };
+  Visits an argument dispatching to the appropriate visit method based on
+  the argument type. For example, if the argument type is ``double`` then
+  ``vis(value)`` will be called with the value of type ``double``.
   \endrst
  */
-template<typename Impl, typename Result>
-class ArgVisitor
-{
-private:
-    typedef internal::Arg Arg;
+template <typename Visitor, typename Context>
+FMT_CONSTEXPR typename internal::result_of<Visitor(int)>::type
+    visit(Visitor &&vis, basic_format_arg<Context> arg) {
+  typedef typename Context::char_type char_type;
+  switch (arg.type_) {
+  case internal::none_type:
+    break;
+  case internal::name_arg_type:
+    FMT_ASSERT(false, "invalid argument type");
+    break;
+  case internal::int_type:
+    return vis(arg.value_.int_value);
+  case internal::uint_type:
+    return vis(arg.value_.uint_value);
+  case internal::long_long_type:
+    return vis(arg.value_.long_long_value);
+  case internal::ulong_long_type:
+    return vis(arg.value_.ulong_long_value);
+  case internal::bool_type:
+    return vis(arg.value_.int_value != 0);
+  case internal::char_type:
+    return vis(static_cast<char_type>(arg.value_.int_value));
+  case internal::double_type:
+    return vis(arg.value_.double_value);
+  case internal::long_double_type:
+    return vis(arg.value_.long_double_value);
+  case internal::cstring_type:
+    return vis(arg.value_.string.value);
+  case internal::string_type:
+    return vis(basic_string_view<char_type>(
+                 arg.value_.string.value, arg.value_.string.size));
+  case internal::pointer_type:
+    return vis(arg.value_.pointer);
+  case internal::custom_type:
+    return vis(typename basic_format_arg<Context>::handle(arg.value_.custom));
+  }
+  return vis(monostate());
+}
 
-public:
-    void report_unhandled_arg() {}
-
-    Result visit_unhandled_arg()
-    {
-        FMT_DISPATCH(report_unhandled_arg());
-        return Result();
-    }
-
-    /** Visits an ``int`` argument. **/
-    Result visit_int(int value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits a ``long long`` argument. **/
-    Result visit_long_long(LongLong value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits an ``unsigned`` argument. **/
-    Result visit_uint(unsigned value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits an ``unsigned long long`` argument. **/
-    Result visit_ulong_long(ULongLong value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits a ``bool`` argument. **/
-    Result visit_bool(bool value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits a ``char`` or ``wchar_t`` argument. **/
-    Result visit_char(int value)
-    {
-        return FMT_DISPATCH(visit_any_int(value));
-    }
-
-    /** Visits an argument of any integral type. **/
-    template<typename T>
-    Result visit_any_int(T)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits a ``double`` argument. **/
-    Result visit_double(double value)
-    {
-        return FMT_DISPATCH(visit_any_double(value));
-    }
-
-    /** Visits a ``long double`` argument. **/
-    Result visit_long_double(long double value)
-    {
-        return FMT_DISPATCH(visit_any_double(value));
-    }
-
-    /** Visits a ``double`` or ``long double`` argument. **/
-    template<typename T>
-    Result visit_any_double(T)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits a null-terminated C string (``const char *``) argument. **/
-    Result visit_cstring(const char *)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits a string argument. **/
-    Result visit_string(Arg::StringValue<char>)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits a wide string argument. **/
-    Result visit_wstring(Arg::StringValue<wchar_t>)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits a pointer argument. **/
-    Result visit_pointer(const void *)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /** Visits an argument of a custom (user-defined) type. **/
-    Result visit_custom(Arg::CustomValue)
-    {
-        return FMT_DISPATCH(visit_unhandled_arg());
-    }
-
-    /**
-      \rst
-      Visits an argument dispatching to the appropriate visit method based on
-      the argument type. For example, if the argument type is ``double`` then
-      the `~fmt::ArgVisitor::visit_double()` method of the *Impl* class will be
-      called.
-      \endrst
-     */
-    Result visit(const Arg &arg)
-    {
-        switch (arg.type)
-        {
-        case Arg::NONE:
-        case Arg::NAMED_ARG:
-            FMT_ASSERT(false, "invalid argument type");
-            break;
-        case Arg::INT:
-            return FMT_DISPATCH(visit_int(arg.int_value));
-        case Arg::UINT:
-            return FMT_DISPATCH(visit_uint(arg.uint_value));
-        case Arg::LONG_LONG:
-            return FMT_DISPATCH(visit_long_long(arg.long_long_value));
-        case Arg::ULONG_LONG:
-            return FMT_DISPATCH(visit_ulong_long(arg.ulong_long_value));
-        case Arg::BOOL:
-            return FMT_DISPATCH(visit_bool(arg.int_value != 0));
-        case Arg::CHAR:
-            return FMT_DISPATCH(visit_char(arg.int_value));
-        case Arg::DOUBLE:
-            return FMT_DISPATCH(visit_double(arg.double_value));
-        case Arg::LONG_DOUBLE:
-            return FMT_DISPATCH(visit_long_double(arg.long_double_value));
-        case Arg::CSTRING:
-            return FMT_DISPATCH(visit_cstring(arg.string.value));
-        case Arg::STRING:
-            return FMT_DISPATCH(visit_string(arg.string));
-        case Arg::WSTRING:
-            return FMT_DISPATCH(visit_wstring(arg.wstring));
-        case Arg::POINTER:
-            return FMT_DISPATCH(visit_pointer(arg.pointer));
-        case Arg::CUSTOM:
-            return FMT_DISPATCH(visit_custom(arg.custom));
-        }
-        return Result();
-    }
-};
-
-enum Alignment
-{
-    ALIGN_DEFAULT,
-    ALIGN_LEFT,
-    ALIGN_RIGHT,
-    ALIGN_CENTER,
-    ALIGN_NUMERIC
+enum alignment {
+  ALIGN_DEFAULT, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_CENTER, ALIGN_NUMERIC
 };
 
 // Flags.
-enum
-{
-    SIGN_FLAG = 1,
-    PLUS_FLAG = 2,
-    MINUS_FLAG = 4,
-    HASH_FLAG = 8,
-    CHAR_FLAG = 0x10 // Argument has char type - used in error reporting.
+enum {SIGN_FLAG = 1, PLUS_FLAG = 2, MINUS_FLAG = 4, HASH_FLAG = 8};
+
+enum format_spec_tag {fill_tag, align_tag, width_tag, type_tag};
+
+// Format specifier.
+template <typename T, format_spec_tag>
+class format_spec {
+ private:
+  T value_;
+
+ public:
+  typedef T value_type;
+
+  explicit format_spec(T value) : value_(value) {}
+
+  T value() const { return value_; }
 };
+
+// template <typename Char>
+// typedef format_spec<Char, fill_tag> fill_spec;
+template <typename Char>
+class fill_spec : public format_spec<Char, fill_tag> {
+ public:
+  explicit fill_spec(Char value) : format_spec<Char, fill_tag>(value) {}
+};
+
+typedef format_spec<unsigned, width_tag> width_spec;
+typedef format_spec<char, type_tag> type_spec;
 
 // An empty format specifier.
-struct EmptySpec
-{
-};
-
-// A type specifier.
-template<char TYPE>
-struct TypeSpec : EmptySpec
-{
-    Alignment align() const
-    {
-        return ALIGN_DEFAULT;
-    }
-    unsigned width() const
-    {
-        return 0;
-    }
-    int precision() const
-    {
-        return -1;
-    }
-    bool flag(unsigned) const
-    {
-        return false;
-    }
-    char type() const
-    {
-        return TYPE;
-    }
-    char type_prefix() const
-    {
-        return TYPE;
-    }
-    char fill() const
-    {
-        return ' ';
-    }
-};
-
-// A width specifier.
-struct WidthSpec
-{
-    unsigned width_;
-    // Fill is always wchar_t and cast to char if necessary to avoid having
-    // two specialization of WidthSpec and its subclasses.
-    wchar_t fill_;
-
-    WidthSpec(unsigned width, wchar_t fill)
-        : width_(width)
-        , fill_(fill)
-    {
-    }
-
-    unsigned width() const
-    {
-        return width_;
-    }
-    wchar_t fill() const
-    {
-        return fill_;
-    }
-};
+struct empty_spec {};
 
 // An alignment specifier.
-struct AlignSpec : WidthSpec
-{
-    Alignment align_;
+struct align_spec : empty_spec {
+  unsigned width_;
+  // Fill is always wchar_t and cast to char if necessary to avoid having
+  // two specialization of AlignSpec and its subclasses.
+  wchar_t fill_;
+  alignment align_;
 
-    AlignSpec(unsigned width, wchar_t fill, Alignment align = ALIGN_DEFAULT)
-        : WidthSpec(width, fill)
-        , align_(align)
-    {
-    }
+  FMT_CONSTEXPR align_spec(
+      unsigned width, wchar_t fill, alignment align = ALIGN_DEFAULT)
+  : width_(width), fill_(fill), align_(align) {}
 
-    Alignment align() const
-    {
-        return align_;
-    }
+  FMT_CONSTEXPR unsigned width() const { return width_; }
+  FMT_CONSTEXPR wchar_t fill() const { return fill_; }
+  FMT_CONSTEXPR alignment align() const { return align_; }
 
-    int precision() const
-    {
-        return -1;
-    }
+  int precision() const { return -1; }
 };
 
-// An alignment and type specifier.
-template<char TYPE>
-struct AlignTypeSpec : AlignSpec
-{
-    AlignTypeSpec(unsigned width, wchar_t fill)
-        : AlignSpec(width, fill)
-    {
-    }
+// Format specifiers.
+template <typename Char>
+class basic_format_specs : public align_spec {
+ private:
+  template <typename FillChar>
+  typename std::enable_if<std::is_same<FillChar, Char>::value ||
+                          std::is_same<FillChar, char>::value, void>::type
+      set(fill_spec<FillChar> fill) {
+    fill_ = fill.value();
+  }
 
-    bool flag(unsigned) const
-    {
-        return false;
-    }
-    char type() const
-    {
-        return TYPE;
-    }
-    char type_prefix() const
-    {
-        return TYPE;
-    }
+  void set(width_spec width) {
+    width_ = width.value();
+  }
+
+  void set(type_spec type) {
+    type_ = type.value();
+  }
+
+  template <typename Spec, typename... Specs>
+  void set(Spec spec, Specs... tail) {
+    set(spec);
+    set(tail...);
+  }
+
+ public:
+  unsigned flags_;
+  int precision_;
+  Char type_;
+
+  FMT_CONSTEXPR basic_format_specs(
+      unsigned width = 0, char type = 0, wchar_t fill = ' ')
+  : align_spec(width, fill), flags_(0), precision_(-1), type_(type) {}
+
+  template <typename... FormatSpecs>
+  explicit basic_format_specs(FormatSpecs... specs)
+    : align_spec(0, ' '), flags_(0), precision_(-1), type_(0) {
+    set(specs...);
+  }
+
+  FMT_CONSTEXPR bool flag(unsigned f) const { return (flags_ & f) != 0; }
+  FMT_CONSTEXPR int precision() const { return precision_; }
+  FMT_CONSTEXPR Char type() const { return type_; }
 };
 
-// A full format specifier.
-struct FormatSpec : AlignSpec
-{
-    unsigned flags_;
-    int precision_;
-    char type_;
+typedef basic_format_specs<char> format_specs;
 
-    FormatSpec(unsigned width = 0, char type = 0, wchar_t fill = ' ')
-        : AlignSpec(width, fill)
-        , flags_(0)
-        , precision_(-1)
-        , type_(type)
-    {
-    }
-
-    bool flag(unsigned f) const
-    {
-        return (flags_ & f) != 0;
-    }
-    int precision() const
-    {
-        return precision_;
-    }
-    char type() const
-    {
-        return type_;
-    }
-    char type_prefix() const
-    {
-        return type_;
-    }
-};
-
-// An integer format specifier.
-template<typename T, typename SpecT = TypeSpec<0>, typename Char = char>
-class IntFormatSpec : public SpecT
-{
-private:
-    T value_;
-
-public:
-    IntFormatSpec(T val, const SpecT &spec = SpecT())
-        : SpecT(spec)
-        , value_(val)
-    {
-    }
-
-    T value() const
-    {
-        return value_;
-    }
-};
-
-// A string format specifier.
-template<typename Char>
-class StrFormatSpec : public AlignSpec
-{
-private:
-    const Char *str_;
-
-public:
-    template<typename FillChar>
-    StrFormatSpec(const Char *str, unsigned width, FillChar fill)
-        : AlignSpec(width, fill)
-        , str_(str)
-    {
-        internal::CharTraits<Char>::convert(FillChar());
-    }
-
-    const Char *str() const
-    {
-        return str_;
-    }
-};
-
-/**
-  Returns an integer format specifier to format the value in base 2.
- */
-IntFormatSpec<int, TypeSpec<'b'>> bin(int value);
-
-/**
-  Returns an integer format specifier to format the value in base 8.
- */
-IntFormatSpec<int, TypeSpec<'o'>> oct(int value);
-
-/**
-  Returns an integer format specifier to format the value in base 16 using
-  lower-case letters for the digits above 9.
- */
-IntFormatSpec<int, TypeSpec<'x'>> hex(int value);
-
-/**
-  Returns an integer formatter format specifier to format in base 16 using
-  upper-case letters for the digits above 9.
- */
-IntFormatSpec<int, TypeSpec<'X'>> hexu(int value);
-
-/**
-  \rst
-  Returns an integer format specifier to pad the formatted argument with the
-  fill character to the specified width using the default (right) numeric
-  alignment.
-
-  **Example**::
-
-    MemoryWriter out;
-    out << pad(hex(0xcafe), 8, '0');
-    // out.str() == "0000cafe"
-
-  \endrst
- */
-template<char TYPE_CODE, typename Char>
-IntFormatSpec<int, AlignTypeSpec<TYPE_CODE>, Char> pad(int value, unsigned width, Char fill = ' ');
-
-#define FMT_DEFINE_INT_FORMATTERS(TYPE)                                                                                                    \
-    inline IntFormatSpec<TYPE, TypeSpec<'b'>> bin(TYPE value)                                                                              \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, TypeSpec<'b'>>(value, TypeSpec<'b'>());                                                                 \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    inline IntFormatSpec<TYPE, TypeSpec<'o'>> oct(TYPE value)                                                                              \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, TypeSpec<'o'>>(value, TypeSpec<'o'>());                                                                 \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    inline IntFormatSpec<TYPE, TypeSpec<'x'>> hex(TYPE value)                                                                              \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, TypeSpec<'x'>>(value, TypeSpec<'x'>());                                                                 \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    inline IntFormatSpec<TYPE, TypeSpec<'X'>> hexu(TYPE value)                                                                             \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, TypeSpec<'X'>>(value, TypeSpec<'X'>());                                                                 \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    template<char TYPE_CODE>                                                                                                               \
-    inline IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>> pad(IntFormatSpec<TYPE, TypeSpec<TYPE_CODE>> f, unsigned width)                   \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>>(f.value(), AlignTypeSpec<TYPE_CODE>(width, ' '));                             \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    /* For compatibility with older compilers we provide two overloads for pad, */                                                         \
-    /* one that takes a fill character and one that doesn't. In the future this */                                                         \
-    /* can be replaced with one overload making the template argument Char      */                                                         \
-    /* default to char (C++11). */                                                                                                         \
-    template<char TYPE_CODE, typename Char>                                                                                                \
-    inline IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>, Char> pad(                                                                        \
-        IntFormatSpec<TYPE, TypeSpec<TYPE_CODE>, Char> f, unsigned width, Char fill)                                                       \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, AlignTypeSpec<TYPE_CODE>, Char>(f.value(), AlignTypeSpec<TYPE_CODE>(width, fill));                      \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    inline IntFormatSpec<TYPE, AlignTypeSpec<0>> pad(TYPE value, unsigned width)                                                           \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, AlignTypeSpec<0>>(value, AlignTypeSpec<0>(width, ' '));                                                 \
-    }                                                                                                                                      \
-                                                                                                                                           \
-    template<typename Char>                                                                                                                \
-    inline IntFormatSpec<TYPE, AlignTypeSpec<0>, Char> pad(TYPE value, unsigned width, Char fill)                                          \
-    {                                                                                                                                      \
-        return IntFormatSpec<TYPE, AlignTypeSpec<0>, Char>(value, AlignTypeSpec<0>(width, fill));                                          \
-    }
-
-FMT_DEFINE_INT_FORMATTERS(int)
-FMT_DEFINE_INT_FORMATTERS(long)
-FMT_DEFINE_INT_FORMATTERS(unsigned)
-FMT_DEFINE_INT_FORMATTERS(unsigned long)
-FMT_DEFINE_INT_FORMATTERS(LongLong)
-FMT_DEFINE_INT_FORMATTERS(ULongLong)
-
-/**
-  \rst
-  Returns a string formatter that pads the formatted argument with the fill
-  character to the specified width using the default (left) string alignment.
-
-  **Example**::
-
-    std::string s = str(MemoryWriter() << pad("abc", 8));
-    // s == "abc     "
-
-  \endrst
- */
-template<typename Char>
-inline StrFormatSpec<Char> pad(const Char *str, unsigned width, Char fill = ' ')
-{
-    return StrFormatSpec<Char>(str, width, fill);
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR unsigned basic_parse_context<Char, ErrorHandler>::next_arg_id() {
+  if (next_arg_id_ >= 0)
+    return internal::to_unsigned(next_arg_id_++);
+  on_error("cannot switch from manual to automatic argument indexing");
+  return 0;
 }
 
-inline StrFormatSpec<wchar_t> pad(const wchar_t *str, unsigned width, char fill = ' ')
-{
-    return StrFormatSpec<wchar_t>(str, width, fill);
-}
+struct format_string {};
 
 namespace internal {
 
-template<typename Char>
-class ArgMap
-{
-private:
-    typedef std::vector<std::pair<fmt::BasicStringRef<Char>, internal::Arg>> MapType;
-    typedef typename MapType::value_type Pair;
-
-    MapType map_;
-
-public:
-    void init(const ArgList &args);
-
-    const internal::Arg *find(const fmt::BasicStringRef<Char> &name) const
-    {
-        // The list is unsorted, so just return the first matching name.
-        for (typename MapType::const_iterator it = map_.begin(), end = map_.end(); it != end; ++it)
-        {
-            if (it->first == name)
-                return &it->second;
-        }
-        return FMT_NULL;
-    }
-};
-
-template<typename Char>
-void ArgMap<Char>::init(const ArgList &args)
-{
-    if (!map_.empty())
-        return;
-    typedef internal::NamedArg<Char> NamedArg;
-    const NamedArg *named_arg = FMT_NULL;
-    bool use_values = args.type(ArgList::MAX_PACKED_ARGS - 1) == internal::Arg::NONE;
-    if (use_values)
-    {
-        for (unsigned i = 0; /*nothing*/; ++i)
-        {
-            internal::Arg::Type arg_type = args.type(i);
-            switch (arg_type)
-            {
-            case internal::Arg::NONE:
-                return;
-            case internal::Arg::NAMED_ARG:
-                named_arg = static_cast<const NamedArg *>(args.values_[i].pointer);
-                map_.push_back(Pair(named_arg->name, *named_arg));
-                break;
-            default:
-                /*nothing*/
-                ;
-            }
-        }
-        return;
-    }
-    for (unsigned i = 0; i != ArgList::MAX_PACKED_ARGS; ++i)
-    {
-        internal::Arg::Type arg_type = args.type(i);
-        if (arg_type == internal::Arg::NAMED_ARG)
-        {
-            named_arg = static_cast<const NamedArg *>(args.args_[i].pointer);
-            map_.push_back(Pair(named_arg->name, *named_arg));
-        }
-    }
-    for (unsigned i = ArgList::MAX_PACKED_ARGS; /*nothing*/; ++i)
-    {
-        switch (args.args_[i].type)
-        {
-        case internal::Arg::NONE:
-            return;
-        case internal::Arg::NAMED_ARG:
-            named_arg = static_cast<const NamedArg *>(args.args_[i].pointer);
-            map_.push_back(Pair(named_arg->name, *named_arg));
-            break;
-        default:
-            /*nothing*/
-            ;
-        }
-    }
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_int_type_spec(Char spec, Handler &&handler) {
+  switch (spec) {
+  case 0: case 'd':
+    handler.on_dec();
+    break;
+  case 'x': case 'X':
+    handler.on_hex();
+    break;
+  case 'b': case 'B':
+    handler.on_bin();
+    break;
+  case 'o':
+    handler.on_oct();
+    break;
+  case 'n':
+    handler.on_num();
+    break;
+  default:
+    handler.on_error();
+  }
 }
 
-template<typename Impl, typename Char, typename Spec = fmt::FormatSpec>
-class ArgFormatterBase : public ArgVisitor<Impl, void>
-{
-private:
-    BasicWriter<Char> &writer_;
-    Spec &spec_;
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_float_type_spec(Char spec, Handler &&handler) {
+  switch (spec) {
+  case 0: case 'g': case 'G':
+    handler.on_general();
+    break;
+  case 'e': case 'E':
+    handler.on_exp();
+    break;
+  case 'f': case 'F':
+    handler.on_fixed();
+    break;
+   case 'a': case 'A':
+    handler.on_hex();
+    break;
+  default:
+    handler.on_error();
+    break;
+  }
+}
 
-    FMT_DISALLOW_COPY_AND_ASSIGN(ArgFormatterBase);
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_char_specs(
+    const basic_format_specs<Char> &specs, Handler &&handler) {
+  if (specs.type() && specs.type() != 'c') {
+    handler.on_int();
+    return;
+  }
+  if (specs.align() == ALIGN_NUMERIC || specs.flag(~0u) != 0)
+    handler.on_error("invalid format specifier for char");
+  handler.on_char();
+}
 
-    void write_pointer(const void *p)
-    {
-        spec_.flags_ = HASH_FLAG;
-        spec_.type_ = 'x';
-        writer_.write_int(reinterpret_cast<uintptr_t>(p), spec_);
-    }
+template <typename Char, typename Handler>
+FMT_CONSTEXPR void handle_cstring_type_spec(Char spec, Handler &&handler) {
+  if (spec == 0 || spec == 's')
+    handler.on_string();
+  else if (spec == 'p')
+    handler.on_pointer();
+  else
+    handler.on_error("invalid type specifier");
+}
 
-    // workaround MSVC two-phase lookup issue
-    typedef internal::Arg Arg;
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_string_type_spec(Char spec, ErrorHandler &&eh) {
+  if (spec != 0 && spec != 's')
+    eh.on_error("invalid type specifier");
+}
 
-protected:
-    BasicWriter<Char> &writer()
-    {
-        return writer_;
-    }
-    Spec &spec()
-    {
-        return spec_;
-    }
+template <typename Char, typename ErrorHandler>
+FMT_CONSTEXPR void check_pointer_type_spec(Char spec, ErrorHandler &&eh) {
+  if (spec != 0 && spec != 'p')
+    eh.on_error("invalid type specifier");
+}
 
-    void write(bool value)
-    {
-        const char *str_value = value ? "true" : "false";
-        Arg::StringValue<char> str = {str_value, std::strlen(str_value)};
-        writer_.write_str(str, spec_);
-    }
+template <typename ErrorHandler>
+class int_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit int_type_checker(ErrorHandler eh) : ErrorHandler(eh) {}
 
-    void write(const char *value)
-    {
-        Arg::StringValue<char> str = {value, value ? std::strlen(value) : 0};
-        writer_.write_str(str, spec_);
-    }
+  FMT_CONSTEXPR void on_dec() {}
+  FMT_CONSTEXPR void on_hex() {}
+  FMT_CONSTEXPR void on_bin() {}
+  FMT_CONSTEXPR void on_oct() {}
+  FMT_CONSTEXPR void on_num() {}
 
-public:
-    typedef Spec SpecType;
-
-    ArgFormatterBase(BasicWriter<Char> &w, Spec &s)
-        : writer_(w)
-        , spec_(s)
-    {
-    }
-
-    template<typename T>
-    void visit_any_int(T value)
-    {
-        writer_.write_int(value, spec_);
-    }
-
-    template<typename T>
-    void visit_any_double(T value)
-    {
-        writer_.write_double(value, spec_);
-    }
-
-    void visit_bool(bool value)
-    {
-        if (spec_.type_)
-        {
-            visit_any_int(value);
-            return;
-        }
-        write(value);
-    }
-
-    void visit_char(int value)
-    {
-        if (spec_.type_ && spec_.type_ != 'c')
-        {
-            spec_.flags_ |= CHAR_FLAG;
-            writer_.write_int(value, spec_);
-            return;
-        }
-        if (spec_.align_ == ALIGN_NUMERIC || spec_.flags_ != 0)
-            FMT_THROW(FormatError("invalid format specifier for char"));
-        typedef typename BasicWriter<Char>::CharPtr CharPtr;
-        Char fill = internal::CharTraits<Char>::cast(spec_.fill());
-        CharPtr out = CharPtr();
-        const unsigned CHAR_SIZE = 1;
-        if (spec_.width_ > CHAR_SIZE)
-        {
-            out = writer_.grow_buffer(spec_.width_);
-            if (spec_.align_ == ALIGN_RIGHT)
-            {
-                std::uninitialized_fill_n(out, spec_.width_ - CHAR_SIZE, fill);
-                out += spec_.width_ - CHAR_SIZE;
-            }
-            else if (spec_.align_ == ALIGN_CENTER)
-            {
-                out = writer_.fill_padding(out, spec_.width_, internal::const_check(CHAR_SIZE), fill);
-            }
-            else
-            {
-                std::uninitialized_fill_n(out + CHAR_SIZE, spec_.width_ - CHAR_SIZE, fill);
-            }
-        }
-        else
-        {
-            out = writer_.grow_buffer(CHAR_SIZE);
-        }
-        *out = internal::CharTraits<Char>::cast(value);
-    }
-
-    void visit_cstring(const char *value)
-    {
-        if (spec_.type_ == 'p')
-            return write_pointer(value);
-        write(value);
-    }
-
-    // Qualification with "internal" here and below is a workaround for nvcc.
-    void visit_string(internal::Arg::StringValue<char> value)
-    {
-        writer_.write_str(value, spec_);
-    }
-
-    using ArgVisitor<Impl, void>::visit_wstring;
-
-    void visit_wstring(internal::Arg::StringValue<Char> value)
-    {
-        writer_.write_str(value, spec_);
-    }
-
-    void visit_pointer(const void *value)
-    {
-        if (spec_.type_ && spec_.type_ != 'p')
-            report_unknown_type(spec_.type_, "pointer");
-        write_pointer(value);
-    }
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
 };
 
-class FormatterBase
-{
-private:
-    ArgList args_;
-    int next_arg_index_;
+template <typename ErrorHandler>
+class float_type_checker : private ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit float_type_checker(ErrorHandler eh)
+    : ErrorHandler(eh) {}
 
-    // Returns the argument with specified index.
-    FMT_API Arg do_get_arg(unsigned arg_index, const char *&error);
+  FMT_CONSTEXPR void on_general() {}
+  FMT_CONSTEXPR void on_exp() {}
+  FMT_CONSTEXPR void on_fixed() {}
+  FMT_CONSTEXPR void on_hex() {}
 
-protected:
-    const ArgList &args() const
-    {
-        return args_;
-    }
-
-    explicit FormatterBase(const ArgList &args)
-    {
-        args_ = args;
-        next_arg_index_ = 0;
-    }
-
-    // Returns the next argument.
-    Arg next_arg(const char *&error)
-    {
-        if (next_arg_index_ >= 0)
-            return do_get_arg(internal::to_unsigned(next_arg_index_++), error);
-        error = "cannot switch from manual to automatic argument indexing";
-        return Arg();
-    }
-
-    // Checks if manual indexing is used and returns the argument with
-    // specified index.
-    Arg get_arg(unsigned arg_index, const char *&error)
-    {
-        return check_no_auto_index(error) ? do_get_arg(arg_index, error) : Arg();
-    }
-
-    bool check_no_auto_index(const char *&error)
-    {
-        if (next_arg_index_ > 0)
-        {
-            error = "cannot switch from automatic to manual argument indexing";
-            return false;
-        }
-        next_arg_index_ = -1;
-        return true;
-    }
-
-    template<typename Char>
-    void write(BasicWriter<Char> &w, const Char *start, const Char *end)
-    {
-        if (start != end)
-            w << BasicStringRef<Char>(start, internal::to_unsigned(end - start));
-    }
+  FMT_CONSTEXPR void on_error() {
+    ErrorHandler::on_error("invalid type specifier");
+  }
 };
-} // namespace internal
 
-/**
-  \rst
-  An argument formatter based on the `curiously recurring template pattern
-  <http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern>`_.
+template <typename ErrorHandler, typename CharType>
+class char_specs_checker : public ErrorHandler {
+ private:
+  CharType type_;
 
-  To use `~fmt::BasicArgFormatter` define a subclass that implements some or
-  all of the visit methods with the same signatures as the methods in
-  `~fmt::ArgVisitor`, for example, `~fmt::ArgVisitor::visit_int()`.
-  Pass the subclass as the *Impl* template parameter. When a formatting
-  function processes an argument, it will dispatch to a visit method
-  specific to the argument type. For example, if the argument type is
-  ``double`` then the `~fmt::ArgVisitor::visit_double()` method of a subclass
-  will be called. If the subclass doesn't contain a method with this signature,
-  then a corresponding method of `~fmt::BasicArgFormatter` or its superclass
-  will be called.
-  \endrst
- */
-template<typename Impl, typename Char, typename Spec = fmt::FormatSpec>
-class BasicArgFormatter : public internal::ArgFormatterBase<Impl, Char, Spec>
-{
-private:
-    BasicFormatter<Char, Impl> &formatter_;
-    const Char *format_;
+ public:
+  FMT_CONSTEXPR char_specs_checker(CharType type, ErrorHandler eh)
+    : ErrorHandler(eh), type_(type) {}
 
-public:
-    /**
-      \rst
-      Constructs an argument formatter object.
-      *formatter* is a reference to the main formatter object, *spec* contains
-      format specifier information for standard argument types, and *fmt* points
-      to the part of the format string being parsed for custom argument types.
-      \endrst
-     */
-    BasicArgFormatter(BasicFormatter<Char, Impl> &formatter, Spec &spec, const Char *fmt)
-        : internal::ArgFormatterBase<Impl, Char, Spec>(formatter.writer(), spec)
-        , formatter_(formatter)
-        , format_(fmt)
-    {
-    }
-
-    /** Formats an argument of a custom (user-defined) type. */
-    void visit_custom(internal::Arg::CustomValue c)
-    {
-        c.format(&formatter_, c.value, &format_);
-    }
+  FMT_CONSTEXPR void on_int() {
+    handle_int_type_spec(type_, int_type_checker<ErrorHandler>(*this));
+  }
+  FMT_CONSTEXPR void on_char() {}
 };
+
+template <typename ErrorHandler>
+class cstring_type_checker : public ErrorHandler {
+ public:
+  FMT_CONSTEXPR explicit cstring_type_checker(ErrorHandler eh)
+    : ErrorHandler(eh) {}
+
+  FMT_CONSTEXPR void on_string() {}
+  FMT_CONSTEXPR void on_pointer() {}
+};
+
+template <typename Context>
+void arg_map<Context>::init(const basic_format_args<Context> &args) {
+  if (map_)
+    return;
+  map_ = new entry[args.max_size()];
+  bool use_values = args.type(max_packed_args - 1) == internal::none_type;
+  if (use_values) {
+    for (unsigned i = 0;/*nothing*/; ++i) {
+      internal::type arg_type = args.type(i);
+      switch (arg_type) {
+        case internal::none_type:
+          return;
+        case internal::name_arg_type:
+          push_back(args.values_[i]);
+          break;
+        default:
+          break; // Do nothing.
+      }
+    }
+    return;
+  }
+  for (unsigned i = 0; i != max_packed_args; ++i) {
+    if (args.type(i) == internal::name_arg_type)
+      push_back(args.args_[i].value_);
+  }
+  for (unsigned i = max_packed_args; ; ++i) {
+    switch (args.args_[i].type_) {
+      case internal::none_type:
+        return;
+      case internal::name_arg_type:
+        push_back(args.args_[i].value_);
+        break;
+      default:
+        break; // Do nothing.
+    }
+  }
+}
+
+template <typename Range>
+class arg_formatter_base {
+ public:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef basic_format_specs<char_type> format_specs;
+
+ private:
+  typedef basic_writer<Range> writer_type;
+  writer_type writer_;
+  format_specs &specs_;
+
+  FMT_DISALLOW_COPY_AND_ASSIGN(arg_formatter_base);
+
+  struct char_writer {
+    char_type value;
+    template <typename It>
+    void operator()(It &&it) const { *it++ = value; }
+  };
+
+  void write_char(char_type value) {
+    writer_.write_padded(1, specs_, char_writer{value});
+  }
+
+  void write_pointer(const void *p) {
+    format_specs specs = specs_;
+    specs.flags_ = HASH_FLAG;
+    specs.type_ = 'x';
+    writer_.write_int(reinterpret_cast<uintptr_t>(p), specs);
+  }
+
+ protected:
+  writer_type &writer() { return writer_; }
+  format_specs &spec() { return specs_; }
+  iterator out() { return writer_.out(); }
+
+  void write(bool value) {
+    writer_.write_str(string_view(value ? "true" : "false"), specs_);
+  }
+
+  void write(const char_type *value) {
+    if (!value)
+      FMT_THROW(format_error("string pointer is null"));
+    auto length = std::char_traits<char_type>::length(value);
+    writer_.write_str(basic_string_view<char_type>(value, length), specs_);
+  }
+
+ public:
+  arg_formatter_base(Range r, format_specs &s): writer_(r), specs_(s) {}
+
+  iterator operator()(monostate) {
+    FMT_ASSERT(false, "invalid argument type");
+    return out();
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, iterator>::type
+      operator()(T value) {
+    writer_.write_int(value, specs_);
+    return out();
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_floating_point<T>::value, iterator>::type
+      operator()(T value) {
+    writer_.write_double(value, specs_);
+    return out();
+  }
+
+  iterator operator()(bool value) {
+    if (specs_.type_)
+      return (*this)(value ? 1 : 0);
+    write(value);
+    return out();
+  }
+
+  struct char_spec_handler : internal::error_handler {
+    arg_formatter_base &formatter;
+    char_type value;
+
+    char_spec_handler(arg_formatter_base& f, char_type val)
+      : formatter(f), value(val) {}
+
+    void on_int() { formatter.writer_.write_int(value, formatter.specs_); }
+    void on_char() { formatter.write_char(value); }
+  };
+
+  iterator operator()(char_type value) {
+    internal::handle_char_specs(specs_, char_spec_handler(*this, value));
+    return out();
+  }
+
+  struct cstring_spec_handler : internal::error_handler {
+    arg_formatter_base &formatter;
+    const char_type *value;
+
+    cstring_spec_handler(arg_formatter_base &f, const char_type *val)
+      : formatter(f), value(val) {}
+
+    void on_string() { formatter.write(value); }
+    void on_pointer() { formatter.write_pointer(value); }
+  };
+
+  iterator operator()(const char_type *value) {
+    internal::handle_cstring_type_spec(
+          specs_.type_, cstring_spec_handler(*this, value));
+    return out();
+  }
+
+  iterator operator()(basic_string_view<char_type> value) {
+    internal::check_string_type_spec(specs_.type_, internal::error_handler());
+    writer_.write_str(value, specs_);
+    return out();
+  }
+
+  iterator operator()(const void *value) {
+    check_pointer_type_spec(specs_.type_, internal::error_handler());
+    write_pointer(value);
+    return out();
+  }
+};
+
+template <typename S>
+struct is_format_string:
+  std::integral_constant<bool, std::is_base_of<format_string, S>::value> {};
+
+template <typename Char>
+FMT_CONSTEXPR bool is_name_start(Char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
+}
+
+// Parses the input as an unsigned integer. This function assumes that the
+// first character is a digit and presence of a non-digit character at the end.
+// it: an iterator pointing to the beginning of the input range.
+template <typename Iterator, typename ErrorHandler>
+FMT_CONSTEXPR unsigned parse_nonnegative_int(Iterator &it, ErrorHandler &&eh) {
+  assert('0' <= *it && *it <= '9');
+  unsigned value = 0;
+  // Convert to unsigned to prevent a warning.
+  unsigned max_int = (std::numeric_limits<int>::max)();
+  unsigned big = max_int / 10;
+  do {
+    // Check for overflow.
+    if (value > big) {
+      value = max_int + 1;
+      break;
+    }
+    value = value * 10 + (*it - '0');
+    // Workaround for MSVC "setup_exception stack overflow" error:
+    auto next = it;
+    ++next;
+    it = next;
+  } while ('0' <= *it && *it <= '9');
+  if (value > max_int)
+    eh.on_error("number is too big");
+  return value;
+}
+
+template <typename Char, typename Context>
+class custom_formatter: public function<bool> {
+ private:
+  Context &ctx_;
+
+ public:
+  explicit custom_formatter(Context &ctx): ctx_(ctx) {}
+
+  bool operator()(typename basic_format_arg<Context>::handle h) const {
+    h.format(ctx_);
+    return true;
+  }
+
+  template <typename T>
+  bool operator()(T) const { return false; }
+};
+
+template <typename T>
+struct is_integer {
+  enum {
+    value = std::is_integral<T>::value && !std::is_same<T, bool>::value &&
+            !std::is_same<T, char>::value && !std::is_same<T, wchar_t>::value
+  };
+};
+
+template <typename ErrorHandler>
+class width_checker: public function<unsigned long long> {
+ public:
+  explicit FMT_CONSTEXPR width_checker(ErrorHandler &eh) : handler_(eh) {}
+
+  template <typename T>
+  FMT_CONSTEXPR
+  typename std::enable_if<
+      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+    if (is_negative(value))
+      handler_.on_error("negative width");
+    return value;
+  }
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+    handler_.on_error("width is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler &handler_;
+};
+
+template <typename ErrorHandler>
+class precision_checker: public function<unsigned long long> {
+ public:
+  explicit FMT_CONSTEXPR precision_checker(ErrorHandler &eh) : handler_(eh) {}
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      is_integer<T>::value, unsigned long long>::type operator()(T value) {
+    if (is_negative(value))
+      handler_.on_error("negative precision");
+    return value;
+  }
+
+  template <typename T>
+  FMT_CONSTEXPR typename std::enable_if<
+      !is_integer<T>::value, unsigned long long>::type operator()(T) {
+    handler_.on_error("precision is not integer");
+    return 0;
+  }
+
+ private:
+  ErrorHandler &handler_;
+};
+
+// A format specifier handler that sets fields in basic_format_specs.
+template <typename Char>
+class specs_setter {
+ public:
+  explicit FMT_CONSTEXPR specs_setter(basic_format_specs<Char> &specs):
+    specs_(specs) {}
+
+  FMT_CONSTEXPR specs_setter(const specs_setter &other) : specs_(other.specs_) {}
+
+  FMT_CONSTEXPR void on_align(alignment align) { specs_.align_ = align; }
+  FMT_CONSTEXPR void on_fill(Char fill) { specs_.fill_ = fill; }
+  FMT_CONSTEXPR void on_plus() { specs_.flags_ |= SIGN_FLAG | PLUS_FLAG; }
+  FMT_CONSTEXPR void on_minus() { specs_.flags_ |= MINUS_FLAG; }
+  FMT_CONSTEXPR void on_space() { specs_.flags_ |= SIGN_FLAG; }
+  FMT_CONSTEXPR void on_hash() { specs_.flags_ |= HASH_FLAG; }
+
+  FMT_CONSTEXPR void on_zero() {
+    specs_.align_ = ALIGN_NUMERIC;
+    specs_.fill_ = '0';
+  }
+
+  FMT_CONSTEXPR void on_width(unsigned width) { specs_.width_ = width; }
+  FMT_CONSTEXPR void on_precision(unsigned precision) {
+    specs_.precision_ = precision;
+  }
+  FMT_CONSTEXPR void end_precision() {}
+
+  FMT_CONSTEXPR void on_type(Char type) { specs_.type_ = type; }
+
+ protected:
+  basic_format_specs<Char> &specs_;
+};
+
+// A format specifier handler that checks if specifiers are consistent with the
+// argument type.
+template <typename Handler>
+class specs_checker : public Handler {
+ public:
+  FMT_CONSTEXPR specs_checker(const Handler& handler, internal::type arg_type)
+    : Handler(handler), arg_type_(arg_type) {}
+
+  FMT_CONSTEXPR specs_checker(const specs_checker &other)
+    : Handler(other), arg_type_(other.arg_type_) {}
+
+  FMT_CONSTEXPR void on_align(alignment align) {
+    if (align == ALIGN_NUMERIC)
+      require_numeric_argument();
+    Handler::on_align(align);
+  }
+
+  FMT_CONSTEXPR void on_plus() {
+    check_sign();
+    Handler::on_plus();
+  }
+
+  FMT_CONSTEXPR void on_minus() {
+    check_sign();
+    Handler::on_minus();
+  }
+
+  FMT_CONSTEXPR void on_space() {
+    check_sign();
+    Handler::on_space();
+  }
+
+  FMT_CONSTEXPR void on_hash() {
+    require_numeric_argument();
+    Handler::on_hash();
+  }
+
+  FMT_CONSTEXPR void on_zero() {
+    require_numeric_argument();
+    Handler::on_zero();
+  }
+
+  FMT_CONSTEXPR void end_precision() {
+    if (is_integral(arg_type_) || arg_type_ == pointer_type)
+      this->on_error("precision not allowed for this argument type");
+  }
+
+ private:
+  FMT_CONSTEXPR void require_numeric_argument() {
+    if (!is_arithmetic(arg_type_))
+      this->on_error("format specifier requires numeric argument");
+  }
+
+  FMT_CONSTEXPR void check_sign() {
+    require_numeric_argument();
+    if (is_integral(arg_type_) && arg_type_ != int_type &&
+        arg_type_ != long_long_type && arg_type_ != internal::char_type) {
+      this->on_error("format specifier requires signed argument");
+    }
+  }
+
+  internal::type arg_type_;
+};
+
+template <template <typename> class Handler, typename T,
+          typename Context, typename ErrorHandler>
+FMT_CONSTEXPR void set_dynamic_spec(
+    T &value, basic_format_arg<Context> arg, ErrorHandler eh) {
+  unsigned long long big_value = visit(Handler<ErrorHandler>(eh), arg);
+  if (big_value > (std::numeric_limits<int>::max)())
+    eh.on_error("number is too big");
+  value = static_cast<int>(big_value);
+}
+
+struct auto_id {};
+
+// The standard format specifier handler with checking.
+template <typename Context>
+class specs_handler: public specs_setter<typename Context::char_type> {
+ public:
+  typedef typename Context::char_type char_type;
+
+  FMT_CONSTEXPR specs_handler(basic_format_specs<char_type> &specs, Context &ctx)
+    : specs_setter<char_type>(specs), context_(ctx) {}
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    set_dynamic_spec<width_checker>(
+          this->specs_.width_, get_arg(arg_id), context_.error_handler());
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    set_dynamic_spec<precision_checker>(
+          this->specs_.precision_, get_arg(arg_id), context_.error_handler());
+  }
+
+  void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  FMT_CONSTEXPR basic_format_arg<Context> get_arg(auto_id) {
+    return context_.next_arg();
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR basic_format_arg<Context> get_arg(Id arg_id) {
+    context_.parse_context().check_arg_id(arg_id);
+    return context_.get_arg(arg_id);
+  }
+
+  Context &context_;
+};
+
+// An argument reference.
+template <typename Char>
+struct arg_ref {
+  enum Kind { NONE, INDEX, NAME };
+
+  FMT_CONSTEXPR arg_ref() : kind(NONE), index(0) {}
+  FMT_CONSTEXPR explicit arg_ref(unsigned index) : kind(INDEX), index(index) {}
+  explicit arg_ref(basic_string_view<Char> name) : kind(NAME), name(name) {}
+
+  FMT_CONSTEXPR arg_ref &operator=(unsigned idx) {
+    kind = INDEX;
+    index = idx;
+    return *this;
+  }
+
+  Kind kind;
+  FMT_UNION {
+    unsigned index;
+    basic_string_view<Char> name;
+  };
+};
+
+// Format specifiers with width and precision resolved at formatting rather
+// than parsing time to allow re-using the same parsed specifiers with
+// differents sets of arguments (precompilation of format strings).
+template <typename Char>
+struct dynamic_format_specs : basic_format_specs<Char> {
+  arg_ref<Char> width_ref;
+  arg_ref<Char> precision_ref;
+};
+
+// Format spec handler that saves references to arguments representing dynamic
+// width and precision to be resolved at formatting time.
+template <typename ParseContext>
+class dynamic_specs_handler :
+    public specs_setter<typename ParseContext::char_type> {
+ public:
+  typedef typename ParseContext::char_type char_type;
+
+  FMT_CONSTEXPR dynamic_specs_handler(
+      dynamic_format_specs<char_type> &specs, ParseContext &ctx)
+    : specs_setter<char_type>(specs), specs_(specs), context_(ctx) {}
+
+  FMT_CONSTEXPR dynamic_specs_handler(const dynamic_specs_handler &other)
+    : specs_setter<char_type>(other),
+      specs_(other.specs_), context_(other.context_) {}
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_width(Id arg_id) {
+    specs_.width_ref = make_arg_ref(arg_id);
+  }
+
+  template <typename Id>
+  FMT_CONSTEXPR void on_dynamic_precision(Id arg_id) {
+    specs_.precision_ref = make_arg_ref(arg_id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  typedef arg_ref<char_type> arg_ref_type;
+
+  template <typename Id>
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(Id arg_id) {
+    context_.check_arg_id(arg_id);
+    return arg_ref_type(arg_id);
+  }
+
+  FMT_CONSTEXPR arg_ref_type make_arg_ref(auto_id) {
+    return arg_ref_type(context_.next_arg_id());
+  }
+
+  dynamic_format_specs<char_type> &specs_;
+  ParseContext &context_;
+};
+
+template <typename Iterator, typename IDHandler>
+FMT_CONSTEXPR Iterator parse_arg_id(Iterator it, IDHandler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  char_type c = *it;
+  if (c == '}' || c == ':') {
+    handler();
+    return it;
+  }
+  if (c >= '0' && c <= '9') {
+    unsigned index = parse_nonnegative_int(it, handler);
+    if (*it != '}' && *it != ':') {
+      handler.on_error("invalid format string");
+      return it;
+    }
+    handler(index);
+    return it;
+  }
+  if (!is_name_start(c)) {
+    handler.on_error("invalid format string");
+    return it;
+  }
+  auto start = it;
+  do {
+    c = *++it;
+  } while (is_name_start(c) || ('0' <= c && c <= '9'));
+  handler(basic_string_view<char_type>(pointer_from(start), it - start));
+  return it;
+}
+
+// Adapts SpecHandler to IDHandler API for dynamic width.
+template <typename SpecHandler, typename Char>
+struct width_adapter {
+  explicit FMT_CONSTEXPR width_adapter(SpecHandler &h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_width(auto_id()); }
+  FMT_CONSTEXPR void operator()(unsigned id) { handler.on_dynamic_width(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_width(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    handler.on_error(message);
+  }
+
+  SpecHandler &handler;
+};
+
+// Adapts SpecHandler to IDHandler API for dynamic precision.
+template <typename SpecHandler, typename Char>
+struct precision_adapter {
+  explicit FMT_CONSTEXPR precision_adapter(SpecHandler &h) : handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_dynamic_precision(auto_id()); }
+  FMT_CONSTEXPR void operator()(unsigned id) {
+    handler.on_dynamic_precision(id);
+  }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_dynamic_precision(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) { handler.on_error(message); }
+
+  SpecHandler &handler;
+};
+
+// Parses standard format specifiers and sends notifications about parsed
+// components to handler.
+// it: an iterator pointing to the beginning of a null-terminated range of
+//     characters, possibly emulated via null_terminating_iterator, representing
+//     format specifiers.
+template <typename Iterator, typename SpecHandler>
+FMT_CONSTEXPR Iterator parse_format_specs(Iterator it, SpecHandler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  // Parse fill and alignment.
+  if (char_type c = *it) {
+    alignment align = ALIGN_DEFAULT;
+    int i = 1;
+    do {
+      auto p = it + i;
+      switch (*p) {
+        case '<':
+          align = ALIGN_LEFT;
+          break;
+        case '>':
+          align = ALIGN_RIGHT;
+          break;
+        case '=':
+          align = ALIGN_NUMERIC;
+          break;
+        case '^':
+          align = ALIGN_CENTER;
+          break;
+      }
+      if (align != ALIGN_DEFAULT) {
+        handler.on_align(align);
+        if (p != it) {
+          if (c == '}') break;
+          if (c == '{') {
+            handler.on_error("invalid fill character '{'");
+            return it;
+          }
+          it += 2;
+          handler.on_fill(c);
+        } else ++it;
+        break;
+      }
+    } while (--i >= 0);
+  }
+
+  // Parse sign.
+  switch (*it) {
+    case '+':
+      handler.on_plus();
+      ++it;
+      break;
+    case '-':
+      handler.on_minus();
+      ++it;
+      break;
+    case ' ':
+      handler.on_space();
+      ++it;
+      break;
+  }
+
+  if (*it == '#') {
+    handler.on_hash();
+    ++it;
+  }
+
+  // Parse zero flag.
+  if (*it == '0') {
+    handler.on_zero();
+    ++it;
+  }
+
+  // Parse width.
+  if ('0' <= *it && *it <= '9') {
+    handler.on_width(parse_nonnegative_int(it, handler));
+  } else if (*it == '{') {
+    it = parse_arg_id(it + 1, width_adapter<SpecHandler, char_type>(handler));
+    if (*it++ != '}') {
+      handler.on_error("invalid format string");
+      return it;
+    }
+  }
+
+  // Parse precision.
+  if (*it == '.') {
+    ++it;
+    if ('0' <= *it && *it <= '9') {
+      handler.on_precision(parse_nonnegative_int(it, handler));
+    } else if (*it == '{') {
+      it = parse_arg_id(
+            it + 1, precision_adapter<SpecHandler, char_type>(handler));
+      if (*it++ != '}') {
+        handler.on_error("invalid format string");
+        return it;
+      }
+    } else {
+      handler.on_error("missing precision specifier");
+      return it;
+    }
+    handler.end_precision();
+  }
+
+  // Parse type.
+  if (*it != '}' && *it)
+    handler.on_type(*it++);
+  return it;
+}
+
+template <typename Handler, typename Char>
+struct id_adapter {
+  FMT_CONSTEXPR explicit id_adapter(Handler &h): handler(h) {}
+
+  FMT_CONSTEXPR void operator()() { handler.on_arg_id(); }
+  FMT_CONSTEXPR void operator()(unsigned id) { handler.on_arg_id(id); }
+  FMT_CONSTEXPR void operator()(basic_string_view<Char> id) {
+    handler.on_arg_id(id);
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    handler.on_error(message);
+  }
+
+  Handler &handler;
+};
+
+template <typename Iterator, typename Handler>
+FMT_CONSTEXPR void parse_format_string(Iterator it, Handler &&handler) {
+  typedef typename std::iterator_traits<Iterator>::value_type char_type;
+  auto start = it;
+  while (*it) {
+    char_type ch = *it++;
+    if (ch != '{' && ch != '}') continue;
+    if (*it == ch) {
+      handler.on_text(start, it);
+      start = ++it;
+      continue;
+    }
+    if (ch == '}') {
+      handler.on_error("unmatched '}' in format string");
+      return;
+    }
+    handler.on_text(start, it - 1);
+
+    it = parse_arg_id(it, id_adapter<Handler, char_type>(handler));
+    if (*it == '}') {
+      handler.on_replacement_field(it);
+    } else if (*it == ':') {
+      ++it;
+      it = handler.on_format_specs(it);
+      if (*it != '}') {
+        handler.on_error("unknown format specifier");
+        return;
+      }
+    } else {
+      handler.on_error("missing '}' in format string");
+      return;
+    }
+
+    start = ++it;
+  }
+  handler.on_text(start, it);
+}
+
+template <typename T, typename ParseContext>
+FMT_CONSTEXPR const typename ParseContext::char_type *
+    parse_format_specs(ParseContext &ctx) {
+  // GCC 7.2 requires initializer.
+  formatter<T, typename ParseContext::char_type> f{};
+  return f.parse(ctx);
+}
+
+template <typename Char, typename ErrorHandler, typename... Args>
+class format_string_checker {
+ public:
+  explicit FMT_CONSTEXPR format_string_checker(
+      basic_string_view<Char> format_str, ErrorHandler eh)
+    : arg_id_(-1), context_(format_str, eh),
+      parse_funcs_{&parse_format_specs<Args, parse_context_type>...} {}
+
+  FMT_CONSTEXPR void on_text(const Char *, const Char *) {}
+
+  FMT_CONSTEXPR void on_arg_id() {
+    arg_id_ = context_.next_arg_id();
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(unsigned id) {
+    arg_id_ = id;
+    context_.check_arg_id(id);
+    check_arg_id();
+  }
+  FMT_CONSTEXPR void on_arg_id(basic_string_view<Char>) {}
+
+  FMT_CONSTEXPR void on_replacement_field(const Char *) {}
+
+  FMT_CONSTEXPR const Char *on_format_specs(const Char *s) {
+    context_.advance_to(s);
+    return to_unsigned(arg_id_) < NUM_ARGS ?
+          parse_funcs_[arg_id_](context_) : s;
+  }
+
+  FMT_CONSTEXPR void on_error(const char *message) {
+    context_.on_error(message);
+  }
+
+ private:
+  typedef basic_parse_context<Char, ErrorHandler> parse_context_type;
+  enum { NUM_ARGS = sizeof...(Args) };
+
+  FMT_CONSTEXPR void check_arg_id() {
+    if (internal::to_unsigned(arg_id_) >= NUM_ARGS)
+      context_.on_error("argument index out of range");
+  }
+
+  // Format specifier parsing function.
+  typedef const Char *(*parse_func)(parse_context_type &);
+
+  int arg_id_;
+  parse_context_type context_;
+  parse_func parse_funcs_[NUM_ARGS > 0 ? NUM_ARGS : 1];
+};
+
+template <typename Char, typename ErrorHandler, typename... Args>
+FMT_CONSTEXPR bool check_format_string(
+    basic_string_view<Char> s, ErrorHandler eh = ErrorHandler()) {
+  format_string_checker<Char, ErrorHandler, Args...> checker(s, eh);
+  parse_format_string(s.begin(), checker);
+  return true;
+}
+
+template <typename... Args, typename String>
+void check_format_string(String format_str) {
+  FMT_CONSTEXPR_DECL bool invalid_format =
+      internal::check_format_string<char, internal::error_handler, Args...>(
+        string_view(format_str.data(), format_str.size()));
+  (void)invalid_format;
+}
+
+// Specifies whether to format T using the standard formatter.
+// It is not possible to use get_type in formatter specialization directly
+// because of a bug in MSVC.
+template <typename Context, typename T>
+struct format_type :
+  std::integral_constant<bool, get_type<Context, T>::value != custom_type> {};
+
+// Specifies whether to format enums.
+template <typename T, typename Enable = void>
+struct format_enum : std::integral_constant<bool, std::is_enum<T>::value> {};
+
+template <template <typename> class Handler, typename Spec, typename Context>
+void handle_dynamic_spec(
+    Spec &value, arg_ref<typename Context::char_type> ref, Context &ctx) {
+  typedef typename Context::char_type char_type;
+  switch (ref.kind) {
+  case arg_ref<char_type>::NONE:
+    break;
+  case arg_ref<char_type>::INDEX:
+    internal::set_dynamic_spec<Handler>(
+          value, ctx.get_arg(ref.index), ctx.error_handler());
+    break;
+  case arg_ref<char_type>::NAME:
+    internal::set_dynamic_spec<Handler>(
+          value, ctx.get_arg(ref.name), ctx.error_handler());
+    break;
+  }
+}
+}  // namespace internal
 
 /** The default argument formatter. */
-template<typename Char>
-class ArgFormatter : public BasicArgFormatter<ArgFormatter<Char>, Char, FormatSpec>
-{
-public:
-    /** Constructs an argument formatter object. */
-    ArgFormatter(BasicFormatter<Char> &formatter, FormatSpec &spec, const Char *fmt)
-        : BasicArgFormatter<ArgFormatter<Char>, Char, FormatSpec>(formatter, spec, fmt)
-    {
-    }
+template <typename Range>
+class arg_formatter:
+  public internal::function<
+    typename internal::arg_formatter_base<Range>::iterator>,
+  public internal::arg_formatter_base<Range> {
+ private:
+  typedef typename Range::value_type char_type;
+  typedef internal::arg_formatter_base<Range> base;
+  typedef basic_format_context<typename base::iterator, char_type> context_type;
+
+  context_type &ctx_;
+
+ public:
+  typedef Range range;
+  typedef typename base::iterator iterator;
+  typedef typename base::format_specs format_specs;
+
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *ctx* is a reference to the formatting context,
+    *spec* contains format specifier information for standard argument types.
+    \endrst
+   */
+  arg_formatter(context_type &ctx, format_specs &spec)
+  : base(Range(ctx.out()), spec), ctx_(ctx) {}
+
+  using base::operator();
+
+  /** Formats an argument of a user-defined type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(ctx_);
+    return this->out();
+  }
 };
-
-/** This template formats data and writes the output to a writer. */
-template<typename CharType, typename ArgFormatter>
-class BasicFormatter : private internal::FormatterBase
-{
-public:
-    /** The character type for the output. */
-    typedef CharType Char;
-
-private:
-    BasicWriter<Char> &writer_;
-    internal::ArgMap<Char> map_;
-
-    FMT_DISALLOW_COPY_AND_ASSIGN(BasicFormatter);
-
-    using internal::FormatterBase::get_arg;
-
-    // Checks if manual indexing is used and returns the argument with
-    // specified name.
-    internal::Arg get_arg(BasicStringRef<Char> arg_name, const char *&error);
-
-    // Parses argument index and returns corresponding argument.
-    internal::Arg parse_arg_index(const Char *&s);
-
-    // Parses argument name and returns corresponding argument.
-    internal::Arg parse_arg_name(const Char *&s);
-
-public:
-    /**
-     \rst
-     Constructs a ``BasicFormatter`` object. References to the arguments and
-     the writer are stored in the formatter object so make sure they have
-     appropriate lifetimes.
-     \endrst
-     */
-    BasicFormatter(const ArgList &args, BasicWriter<Char> &w)
-        : internal::FormatterBase(args)
-        , writer_(w)
-    {
-    }
-
-    /** Returns a reference to the writer associated with this formatter. */
-    BasicWriter<Char> &writer()
-    {
-        return writer_;
-    }
-
-    /** Formats stored arguments and writes the output to the writer. */
-    void format(BasicCStringRef<Char> format_str);
-
-    // Formats a single argument and advances format_str, a format string pointer.
-    const Char *format(const Char *&format_str, const internal::Arg &arg);
-};
-
-// Generates a comma-separated list with results of applying f to
-// numbers 0..n-1.
-#define FMT_GEN(n, f) FMT_GEN##n(f)
-#define FMT_GEN1(f) f(0)
-#define FMT_GEN2(f) FMT_GEN1(f), f(1)
-#define FMT_GEN3(f) FMT_GEN2(f), f(2)
-#define FMT_GEN4(f) FMT_GEN3(f), f(3)
-#define FMT_GEN5(f) FMT_GEN4(f), f(4)
-#define FMT_GEN6(f) FMT_GEN5(f), f(5)
-#define FMT_GEN7(f) FMT_GEN6(f), f(6)
-#define FMT_GEN8(f) FMT_GEN7(f), f(7)
-#define FMT_GEN9(f) FMT_GEN8(f), f(8)
-#define FMT_GEN10(f) FMT_GEN9(f), f(9)
-#define FMT_GEN11(f) FMT_GEN10(f), f(10)
-#define FMT_GEN12(f) FMT_GEN11(f), f(11)
-#define FMT_GEN13(f) FMT_GEN12(f), f(12)
-#define FMT_GEN14(f) FMT_GEN13(f), f(13)
-#define FMT_GEN15(f) FMT_GEN14(f), f(14)
-
-namespace internal {
-inline uint64_t make_type()
-{
-    return 0;
-}
-
-template<typename T>
-inline uint64_t make_type(const T &arg)
-{
-    return MakeValue<BasicFormatter<char>>::type(arg);
-}
-
-template<std::size_t N, bool /*IsPacked*/ = (N < ArgList::MAX_PACKED_ARGS)>
-struct ArgArray;
-
-template<std::size_t N>
-struct ArgArray<N, true /*IsPacked*/>
-{
-    // '+' is used to silence GCC -Wduplicated-branches warning.
-    typedef Value Type[N > 0 ? N : +1];
-
-    template<typename Formatter, typename T>
-    static Value make(const T &value)
-    {
-#ifdef __clang__
-        Value result = MakeValue<Formatter>(value);
-        // Workaround a bug in Apple LLVM version 4.2 (clang-425.0.28) of clang:
-        // https://github.com/fmtlib/fmt/issues/276
-        (void)result.custom.format;
-        return result;
-#else
-        return MakeValue<Formatter>(value);
-#endif
-    }
-};
-
-template<std::size_t N>
-struct ArgArray<N, false /*IsPacked*/>
-{
-    typedef Arg Type[N + 1]; // +1 for the list end Arg::NONE
-
-    template<typename Formatter, typename T>
-    static Arg make(const T &value)
-    {
-        return MakeArg<Formatter>(value);
-    }
-};
-
-#if FMT_USE_VARIADIC_TEMPLATES
-template<typename Arg, typename... Args>
-inline uint64_t make_type(const Arg &first, const Args &... tail)
-{
-    return make_type(first) | (make_type(tail...) << 4);
-}
-
-#else
-
-struct ArgType
-{
-    uint64_t type;
-
-    ArgType()
-        : type(0)
-    {
-    }
-
-    template<typename T>
-    ArgType(const T &arg)
-        : type(make_type(arg))
-    {
-    }
-};
-
-#define FMT_ARG_TYPE_DEFAULT(n) ArgType t##n = ArgType()
-
-inline uint64_t make_type(FMT_GEN15(FMT_ARG_TYPE_DEFAULT))
-{
-    return t0.type | (t1.type << 4) | (t2.type << 8) | (t3.type << 12) | (t4.type << 16) | (t5.type << 20) | (t6.type << 24) |
-           (t7.type << 28) | (t8.type << 32) | (t9.type << 36) | (t10.type << 40) | (t11.type << 44) | (t12.type << 48) | (t13.type << 52) |
-           (t14.type << 56);
-}
-#endif
-} // namespace internal
-
-#define FMT_MAKE_TEMPLATE_ARG(n) typename T##n
-#define FMT_MAKE_ARG_TYPE(n) T##n
-#define FMT_MAKE_ARG(n) const T##n &v##n
-#define FMT_ASSIGN_char(n) arr[n] = fmt::internal::MakeValue<fmt::BasicFormatter<char>>(v##n)
-#define FMT_ASSIGN_wchar_t(n) arr[n] = fmt::internal::MakeValue<fmt::BasicFormatter<wchar_t>>(v##n)
-
-#if FMT_USE_VARIADIC_TEMPLATES
-// Defines a variadic function returning void.
-#define FMT_VARIADIC_VOID(func, arg_type)                                                                                                  \
-    template<typename... Args>                                                                                                             \
-    void func(arg_type arg0, const Args &... args)                                                                                         \
-    {                                                                                                                                      \
-        typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                                                         \
-        typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...};                                        \
-        func(arg0, fmt::ArgList(fmt::internal::make_type(args...), array));                                                                \
-    }
-
-// Defines a variadic constructor.
-#define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type)                                                                                \
-    template<typename... Args>                                                                                                             \
-    ctor(arg0_type arg0, arg1_type arg1, const Args &... args)                                                                             \
-    {                                                                                                                                      \
-        typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                                                         \
-        typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...};                                        \
-        func(arg0, arg1, fmt::ArgList(fmt::internal::make_type(args...), array));                                                          \
-    }
-
-#else
-
-#define FMT_MAKE_REF(n) fmt::internal::MakeValue<fmt::BasicFormatter<Char>>(v##n)
-#define FMT_MAKE_REF2(n) v##n
-
-// Defines a wrapper for a function taking one argument of type arg_type
-// and n additional arguments of arbitrary types.
-#define FMT_WRAP1(func, arg_type, n)                                                                                                       \
-    template<FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)>                                                                                            \
-    inline void func(arg_type arg1, FMT_GEN(n, FMT_MAKE_ARG))                                                                              \
-    {                                                                                                                                      \
-        const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)};                                                         \
-        func(arg1, fmt::ArgList(fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array));                                              \
-    }
-
-// Emulates a variadic function returning void on a pre-C++11 compiler.
-#define FMT_VARIADIC_VOID(func, arg_type)                                                                                                  \
-    inline void func(arg_type arg)                                                                                                         \
-    {                                                                                                                                      \
-        func(arg, fmt::ArgList());                                                                                                         \
-    }                                                                                                                                      \
-    FMT_WRAP1(func, arg_type, 1)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 2)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 3)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 4)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 5)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 6)                                                                                                           \
-    FMT_WRAP1(func, arg_type, 7) FMT_WRAP1(func, arg_type, 8) FMT_WRAP1(func, arg_type, 9) FMT_WRAP1(func, arg_type, 10)
-
-#define FMT_CTOR(ctor, func, arg0_type, arg1_type, n)                                                                                      \
-    template<FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)>                                                                                            \
-    ctor(arg0_type arg0, arg1_type arg1, FMT_GEN(n, FMT_MAKE_ARG))                                                                         \
-    {                                                                                                                                      \
-        const fmt::internal::ArgArray<n>::Type array = {FMT_GEN(n, FMT_MAKE_REF)};                                                         \
-        func(arg0, arg1, fmt::ArgList(fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), array));                                        \
-    }
-
-// Emulates a variadic constructor on a pre-C++11 compiler.
-#define FMT_VARIADIC_CTOR(ctor, func, arg0_type, arg1_type)                                                                                \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 1)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 2)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 3)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 4)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 5)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 6)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 7)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 8)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 9)                                                                                          \
-    FMT_CTOR(ctor, func, arg0_type, arg1_type, 10)
-#endif
-
-// Generates a comma-separated list with results of applying f to pairs
-// (argument, index).
-#define FMT_FOR_EACH1(f, x0) f(x0, 0)
-#define FMT_FOR_EACH2(f, x0, x1) FMT_FOR_EACH1(f, x0), f(x1, 1)
-#define FMT_FOR_EACH3(f, x0, x1, x2) FMT_FOR_EACH2(f, x0, x1), f(x2, 2)
-#define FMT_FOR_EACH4(f, x0, x1, x2, x3) FMT_FOR_EACH3(f, x0, x1, x2), f(x3, 3)
-#define FMT_FOR_EACH5(f, x0, x1, x2, x3, x4) FMT_FOR_EACH4(f, x0, x1, x2, x3), f(x4, 4)
-#define FMT_FOR_EACH6(f, x0, x1, x2, x3, x4, x5) FMT_FOR_EACH5(f, x0, x1, x2, x3, x4), f(x5, 5)
-#define FMT_FOR_EACH7(f, x0, x1, x2, x3, x4, x5, x6) FMT_FOR_EACH6(f, x0, x1, x2, x3, x4, x5), f(x6, 6)
-#define FMT_FOR_EACH8(f, x0, x1, x2, x3, x4, x5, x6, x7) FMT_FOR_EACH7(f, x0, x1, x2, x3, x4, x5, x6), f(x7, 7)
-#define FMT_FOR_EACH9(f, x0, x1, x2, x3, x4, x5, x6, x7, x8) FMT_FOR_EACH8(f, x0, x1, x2, x3, x4, x5, x6, x7), f(x8, 8)
-#define FMT_FOR_EACH10(f, x0, x1, x2, x3, x4, x5, x6, x7, x8, x9) FMT_FOR_EACH9(f, x0, x1, x2, x3, x4, x5, x6, x7, x8), f(x9, 9)
 
 /**
  An error returned by an operating system or a language runtime,
  for example a file opening error.
 */
-class SystemError : public internal::RuntimeError
-{
-private:
-    FMT_API void init(int err_code, CStringRef format_str, ArgList args);
+class system_error : public std::runtime_error {
+ private:
+  FMT_API void init(int err_code, string_view format_str, format_args args);
 
-protected:
-    int error_code_;
+ protected:
+  int error_code_;
 
-    typedef char Char; // For FMT_VARIADIC_CTOR.
+  system_error() : std::runtime_error("") {}
 
-    SystemError() {}
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::system_error` object with a description
+   formatted with `fmt::format_system_error`. *message* and additional
+   arguments passed into the constructor are formatted similarly to
+   `fmt::format`.
 
-public:
-    /**
-     \rst
-     Constructs a :class:`fmt::SystemError` object with a description
-     formatted with `fmt::format_system_error`. *message* and additional
-     arguments passed into the constructor are formatted similarly to
-     `fmt::format`.
+   **Example**::
 
-     **Example**::
+     // This throws a system_error with the description
+     //   cannot open file 'madeup': No such file or directory
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     std::FILE *file = std::fopen(filename, "r");
+     if (!file)
+       throw fmt::system_error(errno, "cannot open file '{}'", filename);
+   \endrst
+  */
+  template <typename... Args>
+  system_error(int error_code, string_view message, const Args & ... args)
+    : std::runtime_error("") {
+    init(error_code, message, make_format_args(args...));
+  }
 
-       // This throws a SystemError with the description
-       //   cannot open file 'madeup': No such file or directory
-       // or similar (system message may vary).
-       const char *filename = "madeup";
-       std::FILE *file = std::fopen(filename, "r");
-       if (!file)
-         throw fmt::SystemError(errno, "cannot open file '{}'", filename);
-     \endrst
-    */
-    SystemError(int error_code, CStringRef message)
-    {
-        init(error_code, message, ArgList());
-    }
-    FMT_DEFAULTED_COPY_CTOR(SystemError)
-    FMT_VARIADIC_CTOR(SystemError, init, int, CStringRef)
+  FMT_API ~system_error() FMT_DTOR_NOEXCEPT;
 
-    FMT_API ~SystemError() FMT_DTOR_NOEXCEPT FMT_OVERRIDE;
-
-    int error_code() const
-    {
-        return error_code_;
-    }
+  int error_code() const { return error_code_; }
 };
 
 /**
@@ -3112,1756 +2329,1278 @@ public:
   may look like "Unknown error -1" and is platform-dependent.
   \endrst
  */
-FMT_API void format_system_error(fmt::Writer &out, int error_code, fmt::StringRef message) FMT_NOEXCEPT;
+FMT_API void format_system_error(internal::buffer &out, int error_code,
+                                 fmt::string_view message) FMT_NOEXCEPT;
 
 /**
-  \rst
-  This template provides operations for formatting and writing data into
-  a character stream. The output is stored in a buffer provided by a subclass
-  such as :class:`fmt::BasicMemoryWriter`.
-
-  You can use one of the following typedefs for common character types:
-
-  +---------+----------------------+
-  | Type    | Definition           |
-  +=========+======================+
-  | Writer  | BasicWriter<char>    |
-  +---------+----------------------+
-  | WWriter | BasicWriter<wchar_t> |
-  +---------+----------------------+
-
-  \endrst
+  This template provides operations for formatting and writing data into a
+  character range.
  */
-template<typename Char>
-class BasicWriter
-{
-private:
-    // Output buffer.
-    Buffer<Char> &buffer_;
+template <typename Range>
+class basic_writer {
+ public:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef basic_format_specs<char_type> format_specs;
 
-    FMT_DISALLOW_COPY_AND_ASSIGN(BasicWriter);
+ private:
+  // Output iterator.
+  iterator out_;
 
-    typedef typename internal::CharTraits<Char>::CharPtr CharPtr;
+  std::unique_ptr<locale_provider> locale_;
 
-#if FMT_SECURE_SCL
-    // Returns pointer value.
-    static Char *get(CharPtr p)
-    {
-        return p.base();
+  FMT_DISALLOW_COPY_AND_ASSIGN(basic_writer);
+
+  iterator out() const { return out_; }
+
+  // Attempts to reserve space for n extra characters in the output range.
+  // Returns a pointer to the reserved range or a reference to out_.
+  auto reserve(std::size_t n) -> decltype(internal::reserve(out_, n)) {
+    return internal::reserve(out_, n);
+  }
+
+  // Writes a value in the format
+  //   <left-padding><value><right-padding>
+  // where <value> is written by f(it).
+  template <typename F>
+  void write_padded(std::size_t size, const align_spec &spec, F f);
+
+  template <typename F>
+  struct padded_int_writer {
+    string_view prefix;
+    char_type fill;
+    std::size_t padding;
+    F f;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      if (prefix.size() != 0)
+        it = std::copy_n(prefix.data(), prefix.size(), it);
+      it = std::fill_n(it, padding, fill);
+      f(it);
     }
-#else
-    static Char *get(Char *p)
-    {
-        return p;
+  };
+
+  // Writes an integer in the format
+  //   <left-padding><prefix><numeric-padding><digits><right-padding>
+  // where <digits> are written by f(it).
+  template <typename Spec, typename F>
+  void write_int(unsigned num_digits, string_view prefix,
+                 const Spec &spec, F f) {
+    std::size_t size = prefix.size() + num_digits;
+    char_type fill = static_cast<char_type>(spec.fill());
+    std::size_t padding = 0;
+    if (spec.align() == ALIGN_NUMERIC) {
+      if (spec.width() > size) {
+        padding = spec.width() - size;
+        size = spec.width();
+      }
+    } else if (spec.precision() > static_cast<int>(num_digits)) {
+      size = prefix.size() + spec.precision();
+      padding = spec.precision() - num_digits;
+      fill = '0';
     }
-#endif
+    align_spec as = spec;
+    if (spec.align() == ALIGN_DEFAULT)
+      as.align_ = ALIGN_RIGHT;
+    write_padded(size, as, padded_int_writer<F>{prefix, fill, padding, f});
+  }
 
-    // Fills the padding around the content and returns the pointer to the
-    // content area.
-    static CharPtr fill_padding(CharPtr buffer, unsigned total_size, std::size_t content_size, wchar_t fill);
+  // Writes a decimal integer.
+  template <typename Int>
+  void write_decimal(Int value) {
+    typedef typename internal::int_traits<Int>::main_type main_type;
+    main_type abs_value = static_cast<main_type>(value);
+    bool is_negative = internal::is_negative(value);
+    if (is_negative)
+      abs_value = 0 - abs_value;
+    unsigned num_digits = internal::count_digits(abs_value);
+    auto &&it = reserve((is_negative ? 1 : 0) + num_digits);
+    if (is_negative)
+      *it++ = '-';
+    internal::format_decimal(it, abs_value, num_digits);
+  }
 
-    // Grows the buffer by n characters and returns a pointer to the newly
-    // allocated area.
-    CharPtr grow_buffer(std::size_t n)
-    {
-        std::size_t size = buffer_.size();
-        buffer_.resize(size + n);
-        return internal::make_ptr(&buffer_[size], n);
-    }
+  // The handle_int_type_spec handler that writes an integer.
+  template <typename Int, typename Spec>
+  struct int_writer {
+    typedef typename internal::int_traits<Int>::main_type unsigned_type;
 
-    // Writes an unsigned decimal integer.
-    template<typename UInt>
-    Char *write_unsigned_decimal(UInt value, unsigned prefix_size = 0)
-    {
-        unsigned num_digits = internal::count_digits(value);
-        Char *ptr = get(grow_buffer(prefix_size + num_digits));
-        internal::format_decimal(ptr + prefix_size, value, num_digits);
-        return ptr;
-    }
+    basic_writer<Range> &writer;
+    const Spec &spec;
+    unsigned_type abs_value;
+    char prefix[4];
+    unsigned prefix_size;
 
-    // Writes a decimal integer.
-    template<typename Int>
-    void write_decimal(Int value)
-    {
-        typedef typename internal::IntTraits<Int>::MainType MainType;
-        MainType abs_value = static_cast<MainType>(value);
-        if (internal::is_negative(value))
-        {
-            abs_value = 0 - abs_value;
-            *write_unsigned_decimal(abs_value, 1) = '-';
-        }
-        else
-        {
-            write_unsigned_decimal(abs_value, 0);
-        }
-    }
+    string_view get_prefix() const { return string_view(prefix, prefix_size); }
 
-    // Prepare a buffer for integer formatting.
-    CharPtr prepare_int_buffer(unsigned num_digits, const EmptySpec &, const char *prefix, unsigned prefix_size)
-    {
-        unsigned size = prefix_size + num_digits;
-        CharPtr p = grow_buffer(size);
-        std::uninitialized_copy(prefix, prefix + prefix_size, p);
-        return p + size - 1;
-    }
-
-    template<typename Spec>
-    CharPtr prepare_int_buffer(unsigned num_digits, const Spec &spec, const char *prefix, unsigned prefix_size);
-
-    // Formats an integer.
-    template<typename T, typename Spec>
-    void write_int(T value, Spec spec);
-
-    // Formats a floating-point number (double or long double).
-    template<typename T, typename Spec>
-    void write_double(T value, const Spec &spec);
-
-    // Writes a formatted string.
-    template<typename StrChar>
-    CharPtr write_str(const StrChar *s, std::size_t size, const AlignSpec &spec);
-
-    template<typename StrChar, typename Spec>
-    void write_str(const internal::Arg::StringValue<StrChar> &str, const Spec &spec);
-
-    // This following methods are private to disallow writing wide characters
-    // and strings to a char stream. If you want to print a wide string as a
-    // pointer as std::ostream does, cast it to const void*.
-    // Do not implement!
-    void operator<<(typename internal::WCharHelper<wchar_t, Char>::Unsupported);
-    void operator<<(typename internal::WCharHelper<const wchar_t *, Char>::Unsupported);
-
-    // Appends floating-point length specifier to the format string.
-    // The second argument is only used for overload resolution.
-    void append_float_length(Char *&format_ptr, long double)
-    {
-        *format_ptr++ = 'L';
-    }
-
-    template<typename T>
-    void append_float_length(Char *&, T)
-    {
-    }
-
-    template<typename Impl, typename Char_, typename Spec_>
-    friend class internal::ArgFormatterBase;
-
-    template<typename Impl, typename Char_, typename Spec_>
-    friend class BasicPrintfArgFormatter;
-
-protected:
-    /**
-      Constructs a ``BasicWriter`` object.
-     */
-    explicit BasicWriter(Buffer<Char> &b)
-        : buffer_(b)
-    {
+    // Counts the number of digits in abs_value. BITS = log2(radix).
+    template <unsigned BITS>
+    unsigned count_digits() const {
+      unsigned_type n = abs_value;
+      unsigned num_digits = 0;
+      do {
+        ++num_digits;
+      } while ((n >>= BITS) != 0);
+      return num_digits;
     }
 
-public:
-    /**
-      \rst
-      Destroys a ``BasicWriter`` object.
-      \endrst
-     */
-    virtual ~BasicWriter() {}
-
-    /**
-      Returns the total number of characters written.
-     */
-    std::size_t size() const
-    {
-        return buffer_.size();
-    }
-
-    /**
-      Returns a pointer to the output buffer content. No terminating null
-      character is appended.
-     */
-    const Char *data() const FMT_NOEXCEPT
-    {
-        return &buffer_[0];
-    }
-
-    /**
-      Returns a pointer to the output buffer content with terminating null
-      character appended.
-     */
-    const Char *c_str() const
-    {
-        std::size_t size = buffer_.size();
-        buffer_.reserve(size + 1);
-        buffer_[size] = '\0';
-        return &buffer_[0];
-    }
-
-    /**
-      \rst
-      Returns the content of the output buffer as an `std::string`.
-      \endrst
-     */
-    std::basic_string<Char> str() const
-    {
-        return std::basic_string<Char>(&buffer_[0], buffer_.size());
-    }
-
-    /**
-      \rst
-      Writes formatted data.
-
-      *args* is an argument list representing arbitrary arguments.
-
-      **Example**::
-
-         MemoryWriter out;
-         out.write("Current point:\n");
-         out.write("({:+f}, {:+f})", -3.14, 3.14);
-
-      This will write the following output to the ``out`` object:
-
-      .. code-block:: none
-
-         Current point:
-         (-3.140000, +3.140000)
-
-      The output can be accessed using :func:`data()`, :func:`c_str` or
-      :func:`str` methods.
-
-      See also :ref:`syntax`.
-      \endrst
-     */
-    void write(BasicCStringRef<Char> format, ArgList args)
-    {
-        BasicFormatter<Char>(args, *this).format(format);
-    }
-    FMT_VARIADIC_VOID(write, BasicCStringRef<Char>)
-
-    BasicWriter &operator<<(int value)
-    {
-        write_decimal(value);
-        return *this;
-    }
-    BasicWriter &operator<<(unsigned value)
-    {
-        return *this << IntFormatSpec<unsigned>(value);
-    }
-    BasicWriter &operator<<(long value)
-    {
-        write_decimal(value);
-        return *this;
-    }
-    BasicWriter &operator<<(unsigned long value)
-    {
-        return *this << IntFormatSpec<unsigned long>(value);
-    }
-    BasicWriter &operator<<(LongLong value)
-    {
-        write_decimal(value);
-        return *this;
-    }
-
-    /**
-      \rst
-      Formats *value* and writes it to the stream.
-      \endrst
-     */
-    BasicWriter &operator<<(ULongLong value)
-    {
-        return *this << IntFormatSpec<ULongLong>(value);
-    }
-
-    BasicWriter &operator<<(double value)
-    {
-        write_double(value, FormatSpec());
-        return *this;
-    }
-
-    /**
-      \rst
-      Formats *value* using the general format for floating-point numbers
-      (``'g'``) and writes it to the stream.
-      \endrst
-     */
-    BasicWriter &operator<<(long double value)
-    {
-        write_double(value, FormatSpec());
-        return *this;
-    }
-
-    /**
-      Writes a character to the stream.
-     */
-    BasicWriter &operator<<(char value)
-    {
-        buffer_.push_back(value);
-        return *this;
-    }
-
-    BasicWriter &operator<<(typename internal::WCharHelper<wchar_t, Char>::Supported value)
-    {
-        buffer_.push_back(value);
-        return *this;
-    }
-
-    /**
-      \rst
-      Writes *value* to the stream.
-      \endrst
-     */
-    BasicWriter &operator<<(fmt::BasicStringRef<Char> value)
-    {
-        const Char *str = value.data();
-        buffer_.append(str, str + value.size());
-        return *this;
-    }
-
-    BasicWriter &operator<<(typename internal::WCharHelper<StringRef, Char>::Supported value)
-    {
-        const char *str = value.data();
-        buffer_.append(str, str + value.size());
-        return *this;
-    }
-
-    template<typename T, typename Spec, typename FillChar>
-    BasicWriter &operator<<(IntFormatSpec<T, Spec, FillChar> spec)
-    {
-        internal::CharTraits<Char>::convert(FillChar());
-        write_int(spec.value(), spec);
-        return *this;
-    }
-
-    template<typename StrChar>
-    BasicWriter &operator<<(const StrFormatSpec<StrChar> &spec)
-    {
-        const StrChar *s = spec.str();
-        write_str(s, std::char_traits<Char>::length(s), spec);
-        return *this;
-    }
-
-    void clear() FMT_NOEXCEPT
-    {
-        buffer_.clear();
-    }
-
-    Buffer<Char> &buffer() FMT_NOEXCEPT
-    {
-        return buffer_;
-    }
-};
-
-template<typename Char>
-template<typename StrChar>
-typename BasicWriter<Char>::CharPtr BasicWriter<Char>::write_str(const StrChar *s, std::size_t size, const AlignSpec &spec)
-{
-    CharPtr out = CharPtr();
-    if (spec.width() > size)
-    {
-        out = grow_buffer(spec.width());
-        Char fill = internal::CharTraits<Char>::cast(spec.fill());
-        if (spec.align() == ALIGN_RIGHT)
-        {
-            std::uninitialized_fill_n(out, spec.width() - size, fill);
-            out += spec.width() - size;
-        }
-        else if (spec.align() == ALIGN_CENTER)
-        {
-            out = fill_padding(out, spec.width(), size, fill);
-        }
-        else
-        {
-            std::uninitialized_fill_n(out + size, spec.width() - size, fill);
-        }
-    }
-    else
-    {
-        out = grow_buffer(size);
-    }
-    std::uninitialized_copy(s, s + size, out);
-    return out;
-}
-
-template<typename Char>
-template<typename StrChar, typename Spec>
-void BasicWriter<Char>::write_str(const internal::Arg::StringValue<StrChar> &s, const Spec &spec)
-{
-    // Check if StrChar is convertible to Char.
-    internal::CharTraits<Char>::convert(StrChar());
-    if (spec.type_ && spec.type_ != 's')
-        internal::report_unknown_type(spec.type_, "string");
-    const StrChar *str_value = s.value;
-    std::size_t str_size = s.size;
-    if (str_size == 0)
-    {
-        if (!str_value)
-        {
-            FMT_THROW(FormatError("string pointer is null"));
-        }
-    }
-    std::size_t precision = static_cast<std::size_t>(spec.precision_);
-    if (spec.precision_ >= 0 && precision < str_size)
-        str_size = precision;
-    write_str(str_value, str_size, spec);
-}
-
-template<typename Char>
-typename BasicWriter<Char>::CharPtr BasicWriter<Char>::fill_padding(
-    CharPtr buffer, unsigned total_size, std::size_t content_size, wchar_t fill)
-{
-    std::size_t padding = total_size - content_size;
-    std::size_t left_padding = padding / 2;
-    Char fill_char = internal::CharTraits<Char>::cast(fill);
-    std::uninitialized_fill_n(buffer, left_padding, fill_char);
-    buffer += left_padding;
-    CharPtr content = buffer;
-    std::uninitialized_fill_n(buffer + content_size, padding - left_padding, fill_char);
-    return content;
-}
-
-template<typename Char>
-template<typename Spec>
-typename BasicWriter<Char>::CharPtr BasicWriter<Char>::prepare_int_buffer(
-    unsigned num_digits, const Spec &spec, const char *prefix, unsigned prefix_size)
-{
-    unsigned width = spec.width();
-    Alignment align = spec.align();
-    Char fill = internal::CharTraits<Char>::cast(spec.fill());
-    if (spec.precision() > static_cast<int>(num_digits))
-    {
-        // Octal prefix '0' is counted as a digit, so ignore it if precision
-        // is specified.
-        if (prefix_size > 0 && prefix[prefix_size - 1] == '0')
-            --prefix_size;
-        unsigned number_size = prefix_size + internal::to_unsigned(spec.precision());
-        AlignSpec subspec(number_size, '0', ALIGN_NUMERIC);
-        if (number_size >= width)
-            return prepare_int_buffer(num_digits, subspec, prefix, prefix_size);
-        buffer_.reserve(width);
-        unsigned fill_size = width - number_size;
-        if (align != ALIGN_LEFT)
-        {
-            CharPtr p = grow_buffer(fill_size);
-            std::uninitialized_fill(p, p + fill_size, fill);
-        }
-        CharPtr result = prepare_int_buffer(num_digits, subspec, prefix, prefix_size);
-        if (align == ALIGN_LEFT)
-        {
-            CharPtr p = grow_buffer(fill_size);
-            std::uninitialized_fill(p, p + fill_size, fill);
-        }
-        return result;
-    }
-    unsigned size = prefix_size + num_digits;
-    if (width <= size)
-    {
-        CharPtr p = grow_buffer(size);
-        std::uninitialized_copy(prefix, prefix + prefix_size, p);
-        return p + size - 1;
-    }
-    CharPtr p = grow_buffer(width);
-    CharPtr end = p + width;
-    if (align == ALIGN_LEFT)
-    {
-        std::uninitialized_copy(prefix, prefix + prefix_size, p);
-        p += size;
-        std::uninitialized_fill(p, end, fill);
-    }
-    else if (align == ALIGN_CENTER)
-    {
-        p = fill_padding(p, width, size, fill);
-        std::uninitialized_copy(prefix, prefix + prefix_size, p);
-        p += size;
-    }
-    else
-    {
-        if (align == ALIGN_NUMERIC)
-        {
-            if (prefix_size != 0)
-            {
-                p = std::uninitialized_copy(prefix, prefix + prefix_size, p);
-                size -= prefix_size;
-            }
-        }
-        else
-        {
-            std::uninitialized_copy(prefix, prefix + prefix_size, end - size);
-        }
-        std::uninitialized_fill(p, end - size, fill);
-        p = end;
-    }
-    return p - 1;
-}
-
-template<typename Char>
-template<typename T, typename Spec>
-void BasicWriter<Char>::write_int(T value, Spec spec)
-{
-    unsigned prefix_size = 0;
-    typedef typename internal::IntTraits<T>::MainType UnsignedType;
-    UnsignedType abs_value = static_cast<UnsignedType>(value);
-    char prefix[4] = "";
-    if (internal::is_negative(value))
-    {
+    int_writer(basic_writer<Range> &w, Int value, const Spec &s)
+      : writer(w), spec(s), abs_value(static_cast<unsigned_type>(value)),
+        prefix_size(0) {
+      if (internal::is_negative(value)) {
         prefix[0] = '-';
         ++prefix_size;
         abs_value = 0 - abs_value;
-    }
-    else if (spec.flag(SIGN_FLAG))
-    {
+      } else if (spec.flag(SIGN_FLAG)) {
         prefix[0] = spec.flag(PLUS_FLAG) ? '+' : ' ';
         ++prefix_size;
+      }
     }
-    switch (spec.type())
-    {
-    case 0:
-    case 'd':
-    {
-        unsigned num_digits = internal::count_digits(abs_value);
-        CharPtr p = prepare_int_buffer(num_digits, spec, prefix, prefix_size) + 1;
-        internal::format_decimal(get(p), abs_value, 0);
-        break;
+
+    struct dec_writer {
+      unsigned_type abs_value;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_decimal(it, abs_value, num_digits);
+      }
+    };
+
+    void on_dec() {
+      unsigned num_digits = internal::count_digits(abs_value);
+      writer.write_int(num_digits, get_prefix(), spec,
+                       dec_writer{abs_value, num_digits});
     }
-    case 'x':
-    case 'X':
-    {
-        UnsignedType n = abs_value;
-        if (spec.flag(HASH_FLAG))
-        {
-            prefix[prefix_size++] = '0';
-            prefix[prefix_size++] = spec.type_prefix();
-        }
-        unsigned num_digits = 0;
-        do
-        {
-            ++num_digits;
-        } while ((n >>= 4) != 0);
-        Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
-        n = abs_value;
-        const char *digits = spec.type() == 'x' ? "0123456789abcdef" : "0123456789ABCDEF";
-        do
-        {
-            *p-- = digits[n & 0xf];
-        } while ((n >>= 4) != 0);
-        break;
+
+    struct hex_writer {
+      int_writer &self;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_uint<4>(it, self.abs_value, num_digits,
+                                      self.spec.type() != 'x');
+      }
+    };
+
+    void on_hex() {
+      if (spec.flag(HASH_FLAG)) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = static_cast<char>(spec.type());
+      }
+      unsigned num_digits = count_digits<4>();
+      writer.write_int(num_digits, get_prefix(), spec,
+                       hex_writer{*this, num_digits});
     }
-    case 'b':
-    case 'B':
-    {
-        UnsignedType n = abs_value;
-        if (spec.flag(HASH_FLAG))
-        {
-            prefix[prefix_size++] = '0';
-            prefix[prefix_size++] = spec.type_prefix();
-        }
-        unsigned num_digits = 0;
-        do
-        {
-            ++num_digits;
-        } while ((n >>= 1) != 0);
-        Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
-        n = abs_value;
-        do
-        {
-            *p-- = static_cast<Char>('0' + (n & 1));
-        } while ((n >>= 1) != 0);
-        break;
+
+    template <int BITS>
+    struct bin_writer {
+      unsigned_type abs_value;
+      unsigned num_digits;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        it = internal::format_uint<BITS>(it, abs_value, num_digits);
+      }
+    };
+
+    void on_bin() {
+      if (spec.flag(HASH_FLAG)) {
+        prefix[prefix_size++] = '0';
+        prefix[prefix_size++] = static_cast<char>(spec.type());
+      }
+      unsigned num_digits = count_digits<1>();
+      writer.write_int(num_digits, get_prefix(), spec,
+                       bin_writer<1>{abs_value, num_digits});
     }
-    case 'o':
-    {
-        UnsignedType n = abs_value;
-        if (spec.flag(HASH_FLAG))
-            prefix[prefix_size++] = '0';
-        unsigned num_digits = 0;
-        do
-        {
-            ++num_digits;
-        } while ((n >>= 3) != 0);
-        Char *p = get(prepare_int_buffer(num_digits, spec, prefix, prefix_size));
-        n = abs_value;
-        do
-        {
-            *p-- = static_cast<Char>('0' + (n & 7));
-        } while ((n >>= 3) != 0);
-        break;
+
+    void on_oct() {
+      unsigned num_digits = count_digits<3>();
+      if (spec.flag(HASH_FLAG) &&
+          spec.precision() <= static_cast<int>(num_digits)) {
+        // Octal prefix '0' is counted as a digit, so only add it if precision
+        // is not greater than the number of digits.
+        prefix[prefix_size++] = '0';
+      }
+      writer.write_int(num_digits, get_prefix(), spec,
+                       bin_writer<3>{abs_value, num_digits});
     }
-    case 'n':
-    {
-        unsigned num_digits = internal::count_digits(abs_value);
-        fmt::StringRef sep = "";
-#if !(defined(ANDROID) || defined(__ANDROID__))
-        sep = internal::thousands_sep(std::localeconv());
-#endif
-        unsigned size = static_cast<unsigned>(num_digits + sep.size() * ((num_digits - 1) / 3));
-        CharPtr p = prepare_int_buffer(size, spec, prefix, prefix_size) + 1;
-        internal::format_decimal(get(p), abs_value, 0, internal::ThousandsSep(sep));
-        break;
+
+    enum { SEP_SIZE = 1 };
+
+    struct num_writer {
+      unsigned_type abs_value;
+      unsigned size;
+      char_type sep;
+
+      template <typename It>
+      void operator()(It &&it) const {
+        basic_string_view<char_type> s(&sep, SEP_SIZE);
+        it = format_decimal(it, abs_value, size,
+                            internal::add_thousands_sep<char_type>(s));
+      }
+    };
+
+    void on_num() {
+      unsigned num_digits = internal::count_digits(abs_value);
+      char_type sep = internal::thousands_sep<char_type>(writer.locale_.get());
+      unsigned size = num_digits + SEP_SIZE * ((num_digits - 1) / 3);
+      writer.write_int(size, get_prefix(), spec,
+                       num_writer{abs_value, size, sep});
     }
-    default:
-        internal::report_unknown_type(spec.type(), spec.flag(CHAR_FLAG) ? "char" : "integer");
-        break;
+
+    void on_error() {
+      FMT_THROW(format_error("invalid type specifier"));
     }
+  };
+
+  // Writes a formatted integer.
+  template <typename T, typename Spec>
+  void write_int(T value, const Spec &spec) {
+    internal::handle_int_type_spec(spec.type(),
+                                   int_writer<T, Spec>(*this, value, spec));
+  }
+
+  enum {INF_SIZE = 3}; // This is an enum to workaround a bug in MSVC.
+
+  struct inf_or_nan_writer {
+    char sign;
+    const char *str;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      if (sign)
+        *it++ = sign;
+      it = std::copy_n(str, static_cast<std::size_t>(INF_SIZE), it);
+    }
+  };
+
+  struct double_writer {
+    unsigned n;
+    char sign;
+    basic_memory_buffer<char_type> &buffer;
+
+    template <typename It>
+    void operator()(It &&it) {
+      if (sign) {
+        *it++ = sign;
+        --n;
+      }
+      it = std::copy_n(buffer.begin(), n, it);
+    }
+  };
+
+  // Formats a floating-point number (double or long double).
+  template <typename T>
+  void write_double(T value, const format_specs &spec);
+
+  template <typename Char>
+  struct str_writer {
+    const Char *s;
+    std::size_t size;
+
+    template <typename It>
+    void operator()(It &&it) const {
+      it = std::copy_n(s, size, it);
+    }
+  };
+
+  // Writes a formatted string.
+  template <typename Char>
+  void write_str(const Char *s, std::size_t size, const align_spec &spec) {
+    write_padded(size, spec, str_writer<Char>{s, size});
+  }
+
+  template <typename Char>
+  void write_str(basic_string_view<Char> str, const format_specs &spec);
+
+  // Appends floating-point length specifier to the format string.
+  // The second argument is only used for overload resolution.
+  void append_float_length(char_type *&format_ptr, long double) {
+    *format_ptr++ = 'L';
+  }
+
+  template<typename T>
+  void append_float_length(char_type *&, T) {}
+
+  template <typename Char>
+  friend class internal::arg_formatter_base;
+
+ public:
+  /** Constructs a ``basic_writer`` object. */
+  explicit basic_writer(Range out): out_(out.begin()) {}
+
+  void write(int value) { write_decimal(value); }
+  void write(long value) { write_decimal(value); }
+  void write(long long value) { write_decimal(value); }
+
+  void write(unsigned value) { write_decimal(value); }
+  void write(unsigned long value) { write_decimal(value); }
+  void write(unsigned long long value) { write_decimal(value); }
+
+  /**
+    \rst
+    Formats *value* and writes it to the buffer.
+    \endrst
+   */
+  template <typename T, typename FormatSpec, typename... FormatSpecs>
+  typename std::enable_if<std::is_integral<T>::value, void>::type
+      write(T value, FormatSpec spec, FormatSpecs... specs) {
+    format_specs s(spec, specs...);
+    s.align_ = ALIGN_RIGHT;
+    write_int(value, s);
+  }
+
+  void write(double value) {
+    write_double(value, format_specs());
+  }
+
+  /**
+    \rst
+    Formats *value* using the general format for floating-point numbers
+    (``'g'``) and writes it to the buffer.
+    \endrst
+   */
+  void write(long double value) {
+    write_double(value, format_specs());
+  }
+
+  /** Writes a character to the buffer. */
+  void write(char value) {
+    *reserve(1) = value;
+  }
+
+  void write(wchar_t value) {
+    internal::require_wchar<char_type>();
+    *reserve(1) = value;
+  }
+
+  /**
+    \rst
+    Writes *value* to the buffer.
+    \endrst
+   */
+  void write(string_view value) {
+    auto &&it = reserve(value.size());
+    it = std::copy(value.begin(), value.end(), it);
+  }
+
+  void write(wstring_view value) {
+    internal::require_wchar<char_type>();
+    auto &&it = reserve(value.size());
+    it = std::uninitialized_copy(value.begin(), value.end(), it);
+  }
+
+  template <typename... FormatSpecs>
+  void write(basic_string_view<char_type> str, FormatSpecs... specs) {
+    write_str(str, format_specs(specs...));
+  }
+
+  template <typename T>
+  typename std::enable_if<std::is_same<T, void>::value>::type write(const T* p) {
+    format_specs specs;
+    specs.flags_ = HASH_FLAG;
+    specs.type_ = 'x';
+    write_int(reinterpret_cast<uintptr_t>(p), specs);
+  }
+};
+
+template <typename Range>
+template <typename F>
+void basic_writer<Range>::write_padded(
+    std::size_t size, const align_spec &spec, F f) {
+  unsigned width = spec.width();
+  if (width <= size)
+    return f(reserve(size));
+  auto &&it = reserve(width);
+  char_type fill = static_cast<char_type>(spec.fill());
+  std::size_t padding = width - size;
+  if (spec.align() == ALIGN_RIGHT) {
+    it = std::fill_n(it, padding, fill);
+    f(it);
+  } else if (spec.align() == ALIGN_CENTER) {
+    std::size_t left_padding = padding / 2;
+    it = std::fill_n(it, left_padding, fill);
+    f(it);
+    it = std::fill_n(it, padding - left_padding, fill);
+  } else {
+    f(it);
+    it = std::fill_n(it, padding, fill);
+  }
 }
 
-template<typename Char>
-template<typename T, typename Spec>
-void BasicWriter<Char>::write_double(T value, const Spec &spec)
-{
-    // Check type.
-    char type = spec.type();
-    bool upper = false;
-    switch (type)
-    {
-    case 0:
-        type = 'g';
-        break;
-    case 'e':
-    case 'f':
-    case 'g':
-    case 'a':
-        break;
-    case 'F':
-#if FMT_MSC_VER
-        // MSVC's printf doesn't support 'F'.
-        type = 'f';
-#endif
-    // Fall through.
-    case 'E':
-    case 'G':
-    case 'A':
-        upper = true;
-        break;
-    default:
-        internal::report_unknown_type(type, "double");
-        break;
-    }
+template <typename Range>
+template <typename Char>
+void basic_writer<Range>::write_str(
+    basic_string_view<Char> s, const format_specs &spec) {
+  const Char *data = s.data();
+  std::size_t size = s.size();
+  std::size_t precision = static_cast<std::size_t>(spec.precision_);
+  if (spec.precision_ >= 0 && precision < size)
+    size = precision;
+  write_str(data, size, spec);
+}
 
-    char sign = 0;
-    // Use isnegative instead of value < 0 because the latter is always
-    // false for NaN.
-    if (internal::FPUtil::isnegative(static_cast<double>(value)))
-    {
-        sign = '-';
-        value = -value;
-    }
-    else if (spec.flag(SIGN_FLAG))
-    {
-        sign = spec.flag(PLUS_FLAG) ? '+' : ' ';
-    }
+template <typename Char>
+struct float_spec_handler {
+  Char type;
+  bool upper;
 
-    if (internal::FPUtil::isnotanumber(value))
-    {
-        // Format NaN ourselves because sprintf's output is not consistent
-        // across platforms.
-        std::size_t nan_size = 4;
-        const char *nan = upper ? " NAN" : " nan";
-        if (!sign)
-        {
-            --nan_size;
-            ++nan;
-        }
-        CharPtr out = write_str(nan, nan_size, spec);
-        if (sign)
-            *out = sign;
-        return;
-    }
+  explicit float_spec_handler(Char t) : type(t), upper(false) {}
 
-    if (internal::FPUtil::isinfinity(value))
-    {
-        // Format infinity ourselves because sprintf's output is not consistent
-        // across platforms.
-        std::size_t inf_size = 4;
-        const char *inf = upper ? " INF" : " inf";
-        if (!sign)
-        {
-            --inf_size;
-            ++inf;
-        }
-        CharPtr out = write_str(inf, inf_size, spec);
-        if (sign)
-            *out = sign;
-        return;
-    }
-
-    std::size_t offset = buffer_.size();
-    unsigned width = spec.width();
-    if (sign)
-    {
-        buffer_.reserve(buffer_.size() + (width > 1u ? width : 1u));
-        if (width > 0)
-            --width;
-        ++offset;
-    }
-
-    // Build format string.
-    enum
-    {
-        MAX_FORMAT_SIZE = 10
-    }; // longest format: %#-*.*Lg
-    Char format[MAX_FORMAT_SIZE];
-    Char *format_ptr = format;
-    *format_ptr++ = '%';
-    unsigned width_for_sprintf = width;
-    if (spec.flag(HASH_FLAG))
-        *format_ptr++ = '#';
-    if (spec.align() == ALIGN_CENTER)
-    {
-        width_for_sprintf = 0;
-    }
+  void on_general() {
+    if (type == 'G')
+      upper = true;
     else
-    {
-        if (spec.align() == ALIGN_LEFT)
-            *format_ptr++ = '-';
-        if (width != 0)
-            *format_ptr++ = '*';
-    }
-    if (spec.precision() >= 0)
-    {
-        *format_ptr++ = '.';
-        *format_ptr++ = '*';
-    }
+      type = 'g';
+  }
 
-    append_float_length(format_ptr, value);
-    *format_ptr++ = type;
-    *format_ptr = '\0';
+  void on_exp() {
+    if (type == 'E')
+      upper = true;
+  }
 
-    // Format using snprintf.
-    Char fill = internal::CharTraits<Char>::cast(spec.fill());
-    unsigned n = 0;
-    Char *start = FMT_NULL;
-    for (;;)
-    {
-        std::size_t buffer_size = buffer_.capacity() - offset;
+  void on_fixed() {
+    if (type == 'F') {
+      upper = true;
 #if FMT_MSC_VER
-        // MSVC's vsnprintf_s doesn't work with zero size, so reserve
-        // space for at least one extra character to make the size non-zero.
-        // Note that the buffer's capacity will increase by more than 1.
-        if (buffer_size == 0)
-        {
-            buffer_.reserve(offset + 1);
-            buffer_size = buffer_.capacity() - offset;
-        }
+      // MSVC's printf doesn't support 'F'.
+      type = 'f';
 #endif
-        start = &buffer_[offset];
-        int result = internal::CharTraits<Char>::format_float(start, buffer_size, format, width_for_sprintf, spec.precision(), value);
-        if (result >= 0)
-        {
-            n = internal::to_unsigned(result);
-            if (offset + n < buffer_.capacity())
-                break; // The buffer is large enough - continue with formatting.
-            buffer_.reserve(offset + n + 1);
-        }
-        else
-        {
-            // If result is negative we ask to increase the capacity by at least 1,
-            // but as std::vector, the buffer grows exponentially.
-            buffer_.reserve(buffer_.capacity() + 1);
-        }
     }
+  }
+
+  void on_hex() {
+    if (type == 'A')
+      upper = true;
+  }
+
+  void on_error() {
+    FMT_THROW(format_error("invalid type specifier"));
+  }
+};
+
+template <typename Range>
+template <typename T>
+void basic_writer<Range>::write_double(T value, const format_specs &spec) {
+  // Check type.
+  float_spec_handler<char_type> handler(spec.type());
+  internal::handle_float_type_spec(spec.type(), handler);
+
+  char sign = 0;
+  // Use isnegative instead of value < 0 because the latter is always
+  // false for NaN.
+  if (internal::fputil::isnegative(static_cast<double>(value))) {
+    sign = '-';
+    value = -value;
+  } else if (spec.flag(SIGN_FLAG)) {
+    sign = spec.flag(PLUS_FLAG) ? '+' : ' ';
+  }
+
+  struct write_inf_or_nan_t {
+    basic_writer &writer;
+    format_specs spec;
+    char sign;
+    void operator()(const char *str) const {
+      writer.write_padded(INF_SIZE + (sign ? 1 : 0), spec,
+                          inf_or_nan_writer{sign, str});
+    }
+  } write_inf_or_nan = {*this, spec, sign};
+
+  // Format NaN and ininity ourselves because sprintf's output is not consistent
+  // across platforms.
+  if (internal::fputil::isnotanumber(value))
+    return write_inf_or_nan(handler.upper ? "NAN" : "nan");
+  if (internal::fputil::isinfinity(value))
+    return write_inf_or_nan(handler.upper ? "INF" : "inf");
+
+  basic_memory_buffer<char_type> buffer;
+
+  unsigned width = spec.width();
+  if (sign) {
+    buffer.reserve(width > 1u ? width : 1u);
+    if (width > 0)
+      --width;
+  }
+
+  // Build format string.
+  enum { MAX_FORMAT_SIZE = 10}; // longest format: %#-*.*Lg
+  char_type format[MAX_FORMAT_SIZE];
+  char_type *format_ptr = format;
+  *format_ptr++ = '%';
+  unsigned width_for_sprintf = width;
+  if (spec.flag(HASH_FLAG))
+    *format_ptr++ = '#';
+  width_for_sprintf = 0;
+  if (spec.precision() >= 0) {
+    *format_ptr++ = '.';
+    *format_ptr++ = '*';
+  }
+
+  append_float_length(format_ptr, value);
+  *format_ptr++ = handler.type;
+  *format_ptr = '\0';
+
+  // Format using snprintf.
+  unsigned n = 0;
+  char_type *start = FMT_NULL;
+  for (;;) {
+    std::size_t buffer_size = buffer.capacity();
+#if FMT_MSC_VER
+    // MSVC's vsnprintf_s doesn't work with zero size, so reserve
+    // space for at least one extra character to make the size non-zero.
+    // Note that the buffer's capacity may increase by more than 1.
+    if (buffer_size == 0) {
+      buffer.reserve(1);
+      buffer_size = buffer.capacity();
+    }
+#endif
+    start = &buffer[0];
+    int result = internal::char_traits<char_type>::format_float(
+        start, buffer_size, format, width_for_sprintf, spec.precision(), value);
+    if (result >= 0) {
+      n = internal::to_unsigned(result);
+      if (n < buffer.capacity())
+        break;  // The buffer is large enough - continue with formatting.
+      buffer.reserve(n + 1);
+    } else {
+      // If result is negative we ask to increase the capacity by at least 1,
+      // but as std::vector, the buffer grows exponentially.
+      buffer.reserve(buffer.capacity() + 1);
+    }
+  }
+  align_spec as = spec;
+  if (spec.align() == ALIGN_NUMERIC) {
+    if (sign) {
+      *reserve(1) = sign;
+      sign = 0;
+      if (as.width_)
+        --as.width_;
+    }
+    as.align_ = ALIGN_RIGHT;
+  } else {
+    if (spec.align() == ALIGN_DEFAULT)
+      as.align_ = ALIGN_RIGHT;
     if (sign)
-    {
-        if ((spec.align() != ALIGN_RIGHT && spec.align() != ALIGN_DEFAULT) || *start != ' ')
-        {
-            *(start - 1) = sign;
-            sign = 0;
-        }
-        else
-        {
-            *(start - 1) = fill;
-        }
-        ++n;
-    }
-    if (spec.align() == ALIGN_CENTER && spec.width() > n)
-    {
-        width = spec.width();
-        CharPtr p = grow_buffer(width);
-        std::memmove(get(p) + (width - n) / 2, get(p), n * sizeof(Char));
-        fill_padding(p, spec.width(), n, fill);
-        return;
-    }
-    if (spec.fill() != ' ' || sign)
-    {
-        while (*start == ' ')
-            *start++ = fill;
-        if (sign)
-            *(start - 1) = sign;
-    }
-    grow_buffer(n);
+      ++n;
+  }
+  write_padded(n, as, double_writer{n, sign, buffer});
 }
 
-/**
-  \rst
-  This class template provides operations for formatting and writing data
-  into a character stream. The output is stored in a memory buffer that grows
-  dynamically.
+template <typename OutputIt, typename T = typename OutputIt::value_type>
+class output_range {
+ private:
+  OutputIt it_;
 
-  You can use one of the following typedefs for common character types
-  and the standard allocator:
+  // Unused yet.
+  typedef void sentinel;
+  sentinel end() const;
 
-  +---------------+-----------------------------------------------------+
-  | Type          | Definition                                          |
-  +===============+=====================================================+
-  | MemoryWriter  | BasicMemoryWriter<char, std::allocator<char>>       |
-  +---------------+-----------------------------------------------------+
-  | WMemoryWriter | BasicMemoryWriter<wchar_t, std::allocator<wchar_t>> |
-  +---------------+-----------------------------------------------------+
+ public:
+  typedef OutputIt iterator;
+  typedef T value_type;
 
-  **Example**::
-
-     MemoryWriter out;
-     out << "The answer is " << 42 << "\n";
-     out.write("({:+f}, {:+f})", -3.14, 3.14);
-
-  This will write the following output to the ``out`` object:
-
-  .. code-block:: none
-
-     The answer is 42
-     (-3.140000, +3.140000)
-
-  The output can be converted to an ``std::string`` with ``out.str()`` or
-  accessed as a C string with ``out.c_str()``.
-  \endrst
- */
-template<typename Char, typename Allocator = std::allocator<Char>>
-class BasicMemoryWriter : public BasicWriter<Char>
-{
-private:
-    internal::MemoryBuffer<Char, internal::INLINE_BUFFER_SIZE, Allocator> buffer_;
-
-public:
-    explicit BasicMemoryWriter(const Allocator &alloc = Allocator())
-        : BasicWriter<Char>(buffer_)
-        , buffer_(alloc)
-    {
-    }
-
-#if FMT_USE_RVALUE_REFERENCES
-    /**
-      \rst
-      Constructs a :class:`fmt::BasicMemoryWriter` object moving the content
-      of the other object to it.
-      \endrst
-     */
-    BasicMemoryWriter(BasicMemoryWriter &&other)
-        : BasicWriter<Char>(buffer_)
-        , buffer_(std::move(other.buffer_))
-    {
-    }
-
-    /**
-      \rst
-      Moves the content of the other ``BasicMemoryWriter`` object to this one.
-      \endrst
-     */
-    BasicMemoryWriter &operator=(BasicMemoryWriter &&other)
-    {
-        buffer_ = std::move(other.buffer_);
-        return *this;
-    }
-#endif
+  explicit output_range(OutputIt it): it_(it) {}
+  OutputIt begin() const { return it_; }
 };
 
-typedef BasicMemoryWriter<char> MemoryWriter;
-typedef BasicMemoryWriter<wchar_t> WMemoryWriter;
+// A range where begin() returns back_insert_iterator.
+template <typename Container>
+class back_insert_range:
+    public output_range<std::back_insert_iterator<Container>> {
+  typedef output_range<std::back_insert_iterator<Container>> base;
+ public:
+  typedef typename Container::value_type value_type;
 
-/**
-  \rst
-  This class template provides operations for formatting and writing data
-  into a fixed-size array. For writing into a dynamically growing buffer
-  use :class:`fmt::BasicMemoryWriter`.
-
-  Any write method will throw ``std::runtime_error`` if the output doesn't fit
-  into the array.
-
-  You can use one of the following typedefs for common character types:
-
-  +--------------+---------------------------+
-  | Type         | Definition                |
-  +==============+===========================+
-  | ArrayWriter  | BasicArrayWriter<char>    |
-  +--------------+---------------------------+
-  | WArrayWriter | BasicArrayWriter<wchar_t> |
-  +--------------+---------------------------+
-  \endrst
- */
-template<typename Char>
-class BasicArrayWriter : public BasicWriter<Char>
-{
-private:
-    internal::FixedBuffer<Char> buffer_;
-
-public:
-    /**
-     \rst
-     Constructs a :class:`fmt::BasicArrayWriter` object for *array* of the
-     given size.
-     \endrst
-     */
-    BasicArrayWriter(Char *array, std::size_t size)
-        : BasicWriter<Char>(buffer_)
-        , buffer_(array, size)
-    {
-    }
-
-    /**
-     \rst
-     Constructs a :class:`fmt::BasicArrayWriter` object for *array* of the
-     size known at compile time.
-     \endrst
-     */
-    template<std::size_t SIZE>
-    explicit BasicArrayWriter(Char (&array)[SIZE])
-        : BasicWriter<Char>(buffer_)
-        , buffer_(array, SIZE)
-    {
-    }
+  back_insert_range(Container &c): base(std::back_inserter(c)) {}
+  back_insert_range(typename base::iterator it): base(it) {}
 };
 
-typedef BasicArrayWriter<char> ArrayWriter;
-typedef BasicArrayWriter<wchar_t> WArrayWriter;
+typedef basic_writer<back_insert_range<internal::buffer>> writer;
+typedef basic_writer<back_insert_range<internal::wbuffer>> wwriter;
 
 // Reports a system error without throwing an exception.
 // Can be used to report errors from destructors.
-FMT_API void report_system_error(int error_code, StringRef message) FMT_NOEXCEPT;
+FMT_API void report_system_error(int error_code,
+                                 string_view message) FMT_NOEXCEPT;
 
 #if FMT_USE_WINDOWS_H
 
 /** A Windows error. */
-class WindowsError : public SystemError
-{
-private:
-    FMT_API void init(int error_code, CStringRef format_str, ArgList args);
+class windows_error : public system_error {
+ private:
+  FMT_API void init(int error_code, string_view format_str, format_args args);
 
-public:
-    /**
-     \rst
-     Constructs a :class:`fmt::WindowsError` object with the description
-     of the form
+ public:
+  /**
+   \rst
+   Constructs a :class:`fmt::windows_error` object with the description
+   of the form
 
-     .. parsed-literal::
-       *<message>*: *<system-message>*
+   .. parsed-literal::
+     *<message>*: *<system-message>*
 
-     where *<message>* is the formatted message and *<system-message>* is the
-     system message corresponding to the error code.
-     *error_code* is a Windows error code as given by ``GetLastError``.
-     If *error_code* is not a valid error code such as -1, the system message
-     will look like "error -1".
+   where *<message>* is the formatted message and *<system-message>* is the
+   system message corresponding to the error code.
+   *error_code* is a Windows error code as given by ``GetLastError``.
+   If *error_code* is not a valid error code such as -1, the system message
+   will look like "error -1".
 
-     **Example**::
+   **Example**::
 
-       // This throws a WindowsError with the description
-       //   cannot open file 'madeup': The system cannot find the file specified.
-       // or similar (system message may vary).
-       const char *filename = "madeup";
-       LPOFSTRUCT of = LPOFSTRUCT();
-       HFILE file = OpenFile(filename, &of, OF_READ);
-       if (file == HFILE_ERROR) {
-         throw fmt::WindowsError(GetLastError(),
-                                 "cannot open file '{}'", filename);
-       }
-     \endrst
-    */
-    WindowsError(int error_code, CStringRef message)
-    {
-        init(error_code, message, ArgList());
-    }
-    FMT_VARIADIC_CTOR(WindowsError, init, int, CStringRef)
+     // This throws a windows_error with the description
+     //   cannot open file 'madeup': The system cannot find the file specified.
+     // or similar (system message may vary).
+     const char *filename = "madeup";
+     LPOFSTRUCT of = LPOFSTRUCT();
+     HFILE file = OpenFile(filename, &of, OF_READ);
+     if (file == HFILE_ERROR) {
+       throw fmt::windows_error(GetLastError(),
+                                "cannot open file '{}'", filename);
+     }
+   \endrst
+  */
+  template <typename... Args>
+  windows_error(int error_code, string_view message, const Args & ... args) {
+    init(error_code, message, make_format_args(args...));
+  }
 };
 
 // Reports a Windows error without throwing an exception.
 // Can be used to report errors from destructors.
-FMT_API void report_windows_error(int error_code, StringRef message) FMT_NOEXCEPT;
+FMT_API void report_windows_error(int error_code,
+                                  string_view message) FMT_NOEXCEPT;
 
 #endif
 
-enum Color
-{
-    BLACK,
-    RED,
-    GREEN,
-    YELLOW,
-    BLUE,
-    MAGENTA,
-    CYAN,
-    WHITE
-};
+/** Fast integer formatter. */
+class format_int {
+ private:
+  // Buffer should be large enough to hold all digits (digits10 + 1),
+  // a sign and a null character.
+  enum {BUFFER_SIZE = std::numeric_limits<unsigned long long>::digits10 + 3};
+  mutable char buffer_[BUFFER_SIZE];
+  char *str_;
 
-/**
-  Formats a string and prints it to stdout using ANSI escape sequences
-  to specify color (experimental).
-  Example:
-    print_colored(fmt::RED, "Elapsed time: {0:.2f} seconds", 1.23);
- */
-FMT_API void print_colored(Color c, CStringRef format, ArgList args);
-
-/**
-  \rst
-  Formats arguments and returns the result as a string.
-
-  **Example**::
-
-    std::string message = format("The answer is {}", 42);
-  \endrst
-*/
-inline std::string format(CStringRef format_str, ArgList args)
-{
-    MemoryWriter w;
-    w.write(format_str, args);
-    return w.str();
-}
-
-inline std::wstring format(WCStringRef format_str, ArgList args)
-{
-    WMemoryWriter w;
-    w.write(format_str, args);
-    return w.str();
-}
-
-/**
-  \rst
-  Prints formatted data to the file *f*.
-
-  **Example**::
-
-    print(stderr, "Don't {}!", "panic");
-  \endrst
- */
-FMT_API void print(std::FILE *f, CStringRef format_str, ArgList args);
-
-/**
-  \rst
-  Prints formatted data to ``stdout``.
-
-  **Example**::
-
-    print("Elapsed time: {0:.2f} seconds", 1.23);
-  \endrst
- */
-FMT_API void print(CStringRef format_str, ArgList args);
-
-/**
-  Fast integer formatter.
- */
-class FormatInt
-{
-private:
-    // Buffer should be large enough to hold all digits (digits10 + 1),
-    // a sign and a null character.
-    enum
-    {
-        BUFFER_SIZE = std::numeric_limits<ULongLong>::digits10 + 3
-    };
-    mutable char buffer_[BUFFER_SIZE];
-    char *str_;
-
-    // Formats value in reverse and returns the number of digits.
-    char *format_decimal(ULongLong value)
-    {
-        char *buffer_end = buffer_ + BUFFER_SIZE - 1;
-        while (value >= 100)
-        {
-            // Integer division is slow so do it for a group of two digits instead
-            // of for every digit. The idea comes from the talk by Alexandrescu
-            // "Three Optimization Tips for C++". See speed-test for a comparison.
-            unsigned index = static_cast<unsigned>((value % 100) * 2);
-            value /= 100;
-            *--buffer_end = internal::Data::DIGITS[index + 1];
-            *--buffer_end = internal::Data::DIGITS[index];
-        }
-        if (value < 10)
-        {
-            *--buffer_end = static_cast<char>('0' + value);
-            return buffer_end;
-        }
-        unsigned index = static_cast<unsigned>(value * 2);
-        *--buffer_end = internal::Data::DIGITS[index + 1];
-        *--buffer_end = internal::Data::DIGITS[index];
-        return buffer_end;
+  // Formats value in reverse and returns a pointer to the beginning.
+  char *format_decimal(unsigned long long value) {
+    char *ptr = buffer_ + BUFFER_SIZE - 1;
+    while (value >= 100) {
+      // Integer division is slow so do it for a group of two digits instead
+      // of for every digit. The idea comes from the talk by Alexandrescu
+      // "Three Optimization Tips for C++". See speed-test for a comparison.
+      unsigned index = static_cast<unsigned>((value % 100) * 2);
+      value /= 100;
+      *--ptr = internal::data::DIGITS[index + 1];
+      *--ptr = internal::data::DIGITS[index];
     }
+    if (value < 10) {
+      *--ptr = static_cast<char>('0' + value);
+      return ptr;
+    }
+    unsigned index = static_cast<unsigned>(value * 2);
+    *--ptr = internal::data::DIGITS[index + 1];
+    *--ptr = internal::data::DIGITS[index];
+    return ptr;
+  }
 
-    void FormatSigned(LongLong value)
-    {
-        ULongLong abs_value = static_cast<ULongLong>(value);
-        bool negative = value < 0;
-        if (negative)
-            abs_value = 0 - abs_value;
-        str_ = format_decimal(abs_value);
-        if (negative)
-            *--str_ = '-';
-    }
+  void format_signed(long long value) {
+    unsigned long long abs_value = static_cast<unsigned long long>(value);
+    bool negative = value < 0;
+    if (negative)
+      abs_value = 0 - abs_value;
+    str_ = format_decimal(abs_value);
+    if (negative)
+      *--str_ = '-';
+  }
 
-public:
-    explicit FormatInt(int value)
-    {
-        FormatSigned(value);
-    }
-    explicit FormatInt(long value)
-    {
-        FormatSigned(value);
-    }
-    explicit FormatInt(LongLong value)
-    {
-        FormatSigned(value);
-    }
-    explicit FormatInt(unsigned value)
-        : str_(format_decimal(value))
-    {
-    }
-    explicit FormatInt(unsigned long value)
-        : str_(format_decimal(value))
-    {
-    }
-    explicit FormatInt(ULongLong value)
-        : str_(format_decimal(value))
-    {
-    }
+ public:
+  explicit format_int(int value) { format_signed(value); }
+  explicit format_int(long value) { format_signed(value); }
+  explicit format_int(long long value) { format_signed(value); }
+  explicit format_int(unsigned value) : str_(format_decimal(value)) {}
+  explicit format_int(unsigned long value) : str_(format_decimal(value)) {}
+  explicit format_int(unsigned long long value) : str_(format_decimal(value)) {}
 
-    /** Returns the number of characters written to the output buffer. */
-    std::size_t size() const
-    {
-        return internal::to_unsigned(buffer_ - str_ + BUFFER_SIZE - 1);
-    }
+  /** Returns the number of characters written to the output buffer. */
+  std::size_t size() const {
+    return internal::to_unsigned(buffer_ - str_ + BUFFER_SIZE - 1);
+  }
 
-    /**
-      Returns a pointer to the output buffer content. No terminating null
-      character is appended.
-     */
-    const char *data() const
-    {
-        return str_;
-    }
+  /**
+    Returns a pointer to the output buffer content. No terminating null
+    character is appended.
+   */
+  const char *data() const { return str_; }
 
-    /**
-      Returns a pointer to the output buffer content with terminating null
-      character appended.
-     */
-    const char *c_str() const
-    {
-        buffer_[BUFFER_SIZE - 1] = '\0';
-        return str_;
-    }
+  /**
+    Returns a pointer to the output buffer content with terminating null
+    character appended.
+   */
+  const char *c_str() const {
+    buffer_[BUFFER_SIZE - 1] = '\0';
+    return str_;
+  }
 
-    /**
-      \rst
-      Returns the content of the output buffer as an ``std::string``.
-      \endrst
-     */
-    std::string str() const
-    {
-        return std::string(str_, size());
-    }
+  /**
+    \rst
+    Returns the content of the output buffer as an ``std::string``.
+    \endrst
+   */
+  std::string str() const { return std::string(str_, size()); }
 };
 
 // Formats a decimal integer value writing into buffer and returns
 // a pointer to the end of the formatted string. This function doesn't
 // write a terminating null character.
-template<typename T>
-inline void format_decimal(char *&buffer, T value)
-{
-    typedef typename internal::IntTraits<T>::MainType MainType;
-    MainType abs_value = static_cast<MainType>(value);
-    if (internal::is_negative(value))
-    {
-        *buffer++ = '-';
-        abs_value = 0 - abs_value;
+template <typename T>
+inline void format_decimal(char *&buffer, T value) {
+  typedef typename internal::int_traits<T>::main_type main_type;
+  main_type abs_value = static_cast<main_type>(value);
+  if (internal::is_negative(value)) {
+    *buffer++ = '-';
+    abs_value = 0 - abs_value;
+  }
+  if (abs_value < 100) {
+    if (abs_value < 10) {
+      *buffer++ = static_cast<char>('0' + abs_value);
+      return;
     }
-    if (abs_value < 100)
-    {
-        if (abs_value < 10)
-        {
-            *buffer++ = static_cast<char>('0' + abs_value);
-            return;
-        }
-        unsigned index = static_cast<unsigned>(abs_value * 2);
-        *buffer++ = internal::Data::DIGITS[index];
-        *buffer++ = internal::Data::DIGITS[index + 1];
-        return;
-    }
-    unsigned num_digits = internal::count_digits(abs_value);
-    internal::format_decimal(buffer, abs_value, num_digits);
-    buffer += num_digits;
+    unsigned index = static_cast<unsigned>(abs_value * 2);
+    *buffer++ = internal::data::DIGITS[index];
+    *buffer++ = internal::data::DIGITS[index + 1];
+    return;
+  }
+  unsigned num_digits = internal::count_digits(abs_value);
+  internal::format_decimal(buffer, abs_value, num_digits);
+  buffer += num_digits;
 }
 
-/**
-  \rst
-  Returns a named argument for formatting functions.
+// Formatter of objects of type T.
+template <typename T, typename Char>
+struct formatter<
+    T, Char,
+    typename std::enable_if<internal::format_type<
+        typename buffer_context<Char>::type, T>::value>::type> {
 
-  **Example**::
-
-    print("Elapsed time: {s:.2f} seconds", arg("s", 1.23));
-
-  \endrst
- */
-template<typename T>
-inline internal::NamedArgWithType<char, T> arg(StringRef name, const T &arg)
-{
-    return internal::NamedArgWithType<char, T>(name, arg);
-}
-
-template<typename T>
-inline internal::NamedArgWithType<wchar_t, T> arg(WStringRef name, const T &arg)
-{
-    return internal::NamedArgWithType<wchar_t, T>(name, arg);
-}
-
-// The following two functions are deleted intentionally to disable
-// nested named arguments as in ``format("{}", arg("a", arg("b", 42)))``.
-template<typename Char>
-void arg(StringRef, const internal::NamedArg<Char> &) FMT_DELETED_OR_UNDEFINED;
-template<typename Char>
-void arg(WStringRef, const internal::NamedArg<Char> &) FMT_DELETED_OR_UNDEFINED;
-} // namespace fmt
-
-#if FMT_GCC_VERSION
-// Use the system_header pragma to suppress warnings about variadic macros
-// because suppressing -Wvariadic-macros with the diagnostic pragma doesn't
-// work. It is used at the end because we want to suppress as little warnings
-// as possible.
-#pragma GCC system_header
-#endif
-
-// This is used to work around VC++ bugs in handling variadic macros.
-#define FMT_EXPAND(args) args
-
-// Returns the number of arguments.
-// Based on https://groups.google.com/forum/#!topic/comp.std.c/d-6Mj5Lko_s.
-#define FMT_NARG(...) FMT_NARG_(__VA_ARGS__, FMT_RSEQ_N())
-#define FMT_NARG_(...) FMT_EXPAND(FMT_ARG_N(__VA_ARGS__))
-#define FMT_ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
-#define FMT_RSEQ_N() 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
-
-#define FMT_FOR_EACH_(N, f, ...) FMT_EXPAND(FMT_CONCAT(FMT_FOR_EACH, N)(f, __VA_ARGS__))
-#define FMT_FOR_EACH(f, ...) FMT_EXPAND(FMT_FOR_EACH_(FMT_NARG(__VA_ARGS__), f, __VA_ARGS__))
-
-#define FMT_ADD_ARG_NAME(type, index) type arg##index
-#define FMT_GET_ARG_NAME(type, index) arg##index
-
-#if FMT_USE_VARIADIC_TEMPLATES
-#define FMT_VARIADIC_(Const, Char, ReturnType, func, call, ...)                                                                            \
-    template<typename... Args>                                                                                                             \
-    ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), const Args &... args) Const                                               \
-    {                                                                                                                                      \
-        typedef fmt::internal::ArgArray<sizeof...(Args)> ArgArray;                                                                         \
-        typename ArgArray::Type array{ArgArray::template make<fmt::BasicFormatter<Char>>(args)...};                                        \
-        call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList(fmt::internal::make_type(args...), array));                         \
+  // Parses format specifiers stopping either at the end of the range or at the
+  // terminating '}'.
+  template <typename ParseContext>
+  FMT_CONSTEXPR typename ParseContext::iterator parse(ParseContext &ctx) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    typedef internal::dynamic_specs_handler<ParseContext> handler_type;
+    auto type = internal::get_type<
+      typename buffer_context<Char>::type, T>::value;
+    internal::specs_checker<handler_type>
+        handler(handler_type(specs_, ctx), type);
+    it = parse_format_specs(it, handler);
+    auto type_spec = specs_.type();
+    auto eh = ctx.error_handler();
+    switch (type) {
+    case internal::none_type:
+    case internal::name_arg_type:
+      FMT_ASSERT(false, "invalid argument type");
+      break;
+    case internal::int_type:
+    case internal::uint_type:
+    case internal::long_long_type:
+    case internal::ulong_long_type:
+    case internal::bool_type:
+      handle_int_type_spec(
+            type_spec, internal::int_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::char_type:
+      handle_char_specs(
+          specs_,
+          internal::char_specs_checker<decltype(eh), decltype(type_spec)>(
+              type_spec, eh));
+      break;
+    case internal::double_type:
+    case internal::long_double_type:
+      handle_float_type_spec(
+            type_spec, internal::float_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::cstring_type:
+      internal::handle_cstring_type_spec(
+            type_spec, internal::cstring_type_checker<decltype(eh)>(eh));
+      break;
+    case internal::string_type:
+      internal::check_string_type_spec(type_spec, eh);
+      break;
+    case internal::pointer_type:
+      internal::check_pointer_type_spec(type_spec, eh);
+      break;
+    case internal::custom_type:
+      // Custom format specifiers should be checked in parse functions of
+      // formatter specializations.
+      break;
     }
-#else
-// Defines a wrapper for a function taking __VA_ARGS__ arguments
-// and n additional arguments of arbitrary types.
-#define FMT_WRAP(Const, Char, ReturnType, func, call, n, ...)                                                                              \
-    template<FMT_GEN(n, FMT_MAKE_TEMPLATE_ARG)>                                                                                            \
-    inline ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__), FMT_GEN(n, FMT_MAKE_ARG)) Const                                    \
-    {                                                                                                                                      \
-        fmt::internal::ArgArray<n>::Type arr;                                                                                              \
-        FMT_GEN(n, FMT_ASSIGN_##Char);                                                                                                     \
-        call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList(fmt::internal::make_type(FMT_GEN(n, FMT_MAKE_REF2)), arr));         \
-    }
+    return pointer_from(it);
+  }
 
-#define FMT_VARIADIC_(Const, Char, ReturnType, func, call, ...)                                                                            \
-    inline ReturnType func(FMT_FOR_EACH(FMT_ADD_ARG_NAME, __VA_ARGS__)) Const                                                              \
-    {                                                                                                                                      \
-        call(FMT_FOR_EACH(FMT_GET_ARG_NAME, __VA_ARGS__), fmt::ArgList());                                                                 \
-    }                                                                                                                                      \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 1, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 2, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 3, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 4, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 5, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 6, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 7, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 8, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 9, __VA_ARGS__)                                                                          \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 10, __VA_ARGS__)                                                                         \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 11, __VA_ARGS__)                                                                         \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 12, __VA_ARGS__)                                                                         \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 13, __VA_ARGS__)                                                                         \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 14, __VA_ARGS__)                                                                         \
-    FMT_WRAP(Const, Char, ReturnType, func, call, 15, __VA_ARGS__)
-#endif // FMT_USE_VARIADIC_TEMPLATES
+  template <typename FormatContext>
+  auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+      specs_.width_, specs_.width_ref, ctx);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+      specs_.precision_, specs_.precision_ref, ctx);
+    typedef output_range<typename FormatContext::iterator,
+                         typename FormatContext::char_type> range;
+    visit(arg_formatter<range>(ctx, specs_),
+          internal::make_arg<FormatContext>(val));
+    return ctx.out();
+  }
 
-/**
-  \rst
-  Defines a variadic function with the specified return type, function name
-  and argument types passed as variable arguments to this macro.
-
-  **Example**::
-
-    void print_error(const char *file, int line, const char *format,
-                     fmt::ArgList args) {
-      fmt::print("{}: {}: ", file, line);
-      fmt::print(format, args);
-    }
-    FMT_VARIADIC(void, print_error, const char *, int, const char *)
-
-  ``FMT_VARIADIC`` is used for compatibility with legacy C++ compilers that
-  don't implement variadic templates. You don't have to use this macro if
-  you don't need legacy compiler support and can use variadic templates
-  directly::
-
-    template <typename... Args>
-    void print_error(const char *file, int line, const char *format,
-                     const Args & ... args) {
-      fmt::print("{}: {}: ", file, line);
-      fmt::print(format, args...);
-    }
-  \endrst
- */
-#define FMT_VARIADIC(ReturnType, func, ...) FMT_VARIADIC_(, char, ReturnType, func, return func, __VA_ARGS__)
-
-#define FMT_VARIADIC_CONST(ReturnType, func, ...) FMT_VARIADIC_(const, char, ReturnType, func, return func, __VA_ARGS__)
-
-#define FMT_VARIADIC_W(ReturnType, func, ...) FMT_VARIADIC_(, wchar_t, ReturnType, func, return func, __VA_ARGS__)
-
-#define FMT_VARIADIC_CONST_W(ReturnType, func, ...) FMT_VARIADIC_(const, wchar_t, ReturnType, func, return func, __VA_ARGS__)
-
-#define FMT_CAPTURE_ARG_(id, index) ::fmt::arg(#id, id)
-
-#define FMT_CAPTURE_ARG_W_(id, index) ::fmt::arg(L## #id, id)
-
-/**
-  \rst
-  Convenient macro to capture the arguments' names and values into several
-  ``fmt::arg(name, value)``.
-
-  **Example**::
-
-    int x = 1, y = 2;
-    print("point: ({x}, {y})", FMT_CAPTURE(x, y));
-    // same as:
-    // print("point: ({x}, {y})", arg("x", x), arg("y", y));
-
-  \endrst
- */
-#define FMT_CAPTURE(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_, __VA_ARGS__)
-
-#define FMT_CAPTURE_W(...) FMT_FOR_EACH(FMT_CAPTURE_ARG_W_, __VA_ARGS__)
-
-namespace fmt {
-FMT_VARIADIC(std::string, format, CStringRef)
-FMT_VARIADIC_W(std::wstring, format, WCStringRef)
-FMT_VARIADIC(void, print, CStringRef)
-FMT_VARIADIC(void, print, std::FILE *, CStringRef)
-FMT_VARIADIC(void, print_colored, Color, CStringRef)
-
-namespace internal {
-template<typename Char>
-inline bool is_name_start(Char c)
-{
-    return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || '_' == c;
-}
-
-// Parses an unsigned integer advancing s to the end of the parsed input.
-// This function assumes that the first character of s is a digit.
-template<typename Char>
-unsigned parse_nonnegative_int(const Char *&s)
-{
-    assert('0' <= *s && *s <= '9');
-    unsigned value = 0;
-    // Convert to unsigned to prevent a warning.
-    unsigned max_int = (std::numeric_limits<int>::max)();
-    unsigned big = max_int / 10;
-    do
-    {
-        // Check for overflow.
-        if (value > big)
-        {
-            value = max_int + 1;
-            break;
-        }
-        value = value * 10 + (*s - '0');
-        ++s;
-    } while ('0' <= *s && *s <= '9');
-    // Convert to unsigned to prevent a warning.
-    if (value > max_int)
-        FMT_THROW(FormatError("number is too big"));
-    return value;
-}
-
-inline void require_numeric_argument(const Arg &arg, char spec)
-{
-    if (arg.type > Arg::LAST_NUMERIC_TYPE)
-    {
-        std::string message = fmt::format("format specifier '{}' requires numeric argument", spec);
-        FMT_THROW(fmt::FormatError(message));
-    }
-}
-
-template<typename Char>
-void check_sign(const Char *&s, const Arg &arg)
-{
-    char sign = static_cast<char>(*s);
-    require_numeric_argument(arg, sign);
-    if (arg.type == Arg::UINT || arg.type == Arg::ULONG_LONG)
-    {
-        FMT_THROW(FormatError(fmt::format("format specifier '{}' requires signed argument", sign)));
-    }
-    ++s;
-}
-} // namespace internal
-
-template<typename Char, typename AF>
-inline internal::Arg BasicFormatter<Char, AF>::get_arg(BasicStringRef<Char> arg_name, const char *&error)
-{
-    if (check_no_auto_index(error))
-    {
-        map_.init(args());
-        const internal::Arg *arg = map_.find(arg_name);
-        if (arg)
-            return *arg;
-        error = "argument not found";
-    }
-    return internal::Arg();
-}
-
-template<typename Char, typename AF>
-inline internal::Arg BasicFormatter<Char, AF>::parse_arg_index(const Char *&s)
-{
-    const char *error = FMT_NULL;
-    internal::Arg arg = *s < '0' || *s > '9' ? next_arg(error) : get_arg(internal::parse_nonnegative_int(s), error);
-    if (error)
-    {
-        FMT_THROW(FormatError(*s != '}' && *s != ':' ? "invalid format string" : error));
-    }
-    return arg;
-}
-
-template<typename Char, typename AF>
-inline internal::Arg BasicFormatter<Char, AF>::parse_arg_name(const Char *&s)
-{
-    assert(internal::is_name_start(*s));
-    const Char *start = s;
-    Char c;
-    do
-    {
-        c = *++s;
-    } while (internal::is_name_start(c) || ('0' <= c && c <= '9'));
-    const char *error = FMT_NULL;
-    internal::Arg arg = get_arg(BasicStringRef<Char>(start, s - start), error);
-    if (error)
-        FMT_THROW(FormatError(error));
-    return arg;
-}
-
-template<typename Char, typename ArgFormatter>
-const Char *BasicFormatter<Char, ArgFormatter>::format(const Char *&format_str, const internal::Arg &arg)
-{
-    using internal::Arg;
-    const Char *s = format_str;
-    typename ArgFormatter::SpecType spec;
-    if (*s == ':')
-    {
-        if (arg.type == Arg::CUSTOM)
-        {
-            arg.custom.format(this, arg.custom.value, &s);
-            return s;
-        }
-        ++s;
-        // Parse fill and alignment.
-        if (Char c = *s)
-        {
-            const Char *p = s + 1;
-            spec.align_ = ALIGN_DEFAULT;
-            do
-            {
-                switch (*p)
-                {
-                case '<':
-                    spec.align_ = ALIGN_LEFT;
-                    break;
-                case '>':
-                    spec.align_ = ALIGN_RIGHT;
-                    break;
-                case '=':
-                    spec.align_ = ALIGN_NUMERIC;
-                    break;
-                case '^':
-                    spec.align_ = ALIGN_CENTER;
-                    break;
-                }
-                if (spec.align_ != ALIGN_DEFAULT)
-                {
-                    if (p != s)
-                    {
-                        if (c == '}')
-                            break;
-                        if (c == '{')
-                            FMT_THROW(FormatError("invalid fill character '{'"));
-                        s += 2;
-                        spec.fill_ = c;
-                    }
-                    else
-                        ++s;
-                    if (spec.align_ == ALIGN_NUMERIC)
-                        require_numeric_argument(arg, '=');
-                    break;
-                }
-            } while (--p >= s);
-        }
-
-        // Parse sign.
-        switch (*s)
-        {
-        case '+':
-            check_sign(s, arg);
-            spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
-            break;
-        case '-':
-            check_sign(s, arg);
-            spec.flags_ |= MINUS_FLAG;
-            break;
-        case ' ':
-            check_sign(s, arg);
-            spec.flags_ |= SIGN_FLAG;
-            break;
-        }
-
-        if (*s == '#')
-        {
-            require_numeric_argument(arg, '#');
-            spec.flags_ |= HASH_FLAG;
-            ++s;
-        }
-
-        // Parse zero flag.
-        if (*s == '0')
-        {
-            require_numeric_argument(arg, '0');
-            spec.align_ = ALIGN_NUMERIC;
-            spec.fill_ = '0';
-            ++s;
-        }
-
-        // Parse width.
-        if ('0' <= *s && *s <= '9')
-        {
-            spec.width_ = internal::parse_nonnegative_int(s);
-        }
-        else if (*s == '{')
-        {
-            ++s;
-            Arg width_arg = internal::is_name_start(*s) ? parse_arg_name(s) : parse_arg_index(s);
-            if (*s++ != '}')
-                FMT_THROW(FormatError("invalid format string"));
-            ULongLong value = 0;
-            switch (width_arg.type)
-            {
-            case Arg::INT:
-                if (width_arg.int_value < 0)
-                    FMT_THROW(FormatError("negative width"));
-                value = width_arg.int_value;
-                break;
-            case Arg::UINT:
-                value = width_arg.uint_value;
-                break;
-            case Arg::LONG_LONG:
-                if (width_arg.long_long_value < 0)
-                    FMT_THROW(FormatError("negative width"));
-                value = width_arg.long_long_value;
-                break;
-            case Arg::ULONG_LONG:
-                value = width_arg.ulong_long_value;
-                break;
-            default:
-                FMT_THROW(FormatError("width is not integer"));
-            }
-            unsigned max_int = (std::numeric_limits<int>::max)();
-            if (value > max_int)
-                FMT_THROW(FormatError("number is too big"));
-            spec.width_ = static_cast<int>(value);
-        }
-
-        // Parse precision.
-        if (*s == '.')
-        {
-            ++s;
-            spec.precision_ = 0;
-            if ('0' <= *s && *s <= '9')
-            {
-                spec.precision_ = internal::parse_nonnegative_int(s);
-            }
-            else if (*s == '{')
-            {
-                ++s;
-                Arg precision_arg = internal::is_name_start(*s) ? parse_arg_name(s) : parse_arg_index(s);
-                if (*s++ != '}')
-                    FMT_THROW(FormatError("invalid format string"));
-                ULongLong value = 0;
-                switch (precision_arg.type)
-                {
-                case Arg::INT:
-                    if (precision_arg.int_value < 0)
-                        FMT_THROW(FormatError("negative precision"));
-                    value = precision_arg.int_value;
-                    break;
-                case Arg::UINT:
-                    value = precision_arg.uint_value;
-                    break;
-                case Arg::LONG_LONG:
-                    if (precision_arg.long_long_value < 0)
-                        FMT_THROW(FormatError("negative precision"));
-                    value = precision_arg.long_long_value;
-                    break;
-                case Arg::ULONG_LONG:
-                    value = precision_arg.ulong_long_value;
-                    break;
-                default:
-                    FMT_THROW(FormatError("precision is not integer"));
-                }
-                unsigned max_int = (std::numeric_limits<int>::max)();
-                if (value > max_int)
-                    FMT_THROW(FormatError("number is too big"));
-                spec.precision_ = static_cast<int>(value);
-            }
-            else
-            {
-                FMT_THROW(FormatError("missing precision specifier"));
-            }
-            if (arg.type <= Arg::LAST_INTEGER_TYPE || arg.type == Arg::POINTER)
-            {
-                FMT_THROW(FormatError(
-                    fmt::format("precision not allowed in {} format specifier", arg.type == Arg::POINTER ? "pointer" : "integer")));
-            }
-        }
-
-        // Parse type.
-        if (*s != '}' && *s)
-            spec.type_ = static_cast<char>(*s++);
-    }
-
-    if (*s++ != '}')
-        FMT_THROW(FormatError("missing '}' in format string"));
-
-    // Format argument.
-    ArgFormatter(*this, spec, s - 1).visit(arg);
-    return s;
-}
-
-template<typename Char, typename AF>
-void BasicFormatter<Char, AF>::format(BasicCStringRef<Char> format_str)
-{
-    const Char *s = format_str.c_str();
-    const Char *start = s;
-    while (*s)
-    {
-        Char c = *s++;
-        if (c != '{' && c != '}')
-            continue;
-        if (*s == c)
-        {
-            write(writer_, start, s);
-            start = ++s;
-            continue;
-        }
-        if (c == '}')
-            FMT_THROW(FormatError("unmatched '}' in format string"));
-        write(writer_, start, s - 1);
-        internal::Arg arg = internal::is_name_start(*s) ? parse_arg_name(s) : parse_arg_index(s);
-        start = s = format(s, arg);
-    }
-    write(writer_, start, s);
-}
-
-template<typename Char, typename It>
-struct ArgJoin
-{
-    It first;
-    It last;
-    BasicCStringRef<Char> sep;
-
-    ArgJoin(It first, It last, const BasicCStringRef<Char> &sep)
-        : first(first)
-        , last(last)
-        , sep(sep)
-    {
-    }
+ private:
+  internal::dynamic_format_specs<Char> specs_;
 };
 
-template<typename It>
-ArgJoin<char, It> join(It first, It last, const BasicCStringRef<char> &sep)
-{
-    return ArgJoin<char, It>(first, last, sep);
+template <typename T, typename Char>
+struct formatter<T, Char,
+    typename std::enable_if<internal::format_enum<T>::value>::type>
+    : public formatter<int, Char> {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+};
+
+// A formatter for types known only at run time such as variant alternatives.
+//
+// Usage:
+//   typedef std::variant<int, std::string> variant;
+//   template <>
+//   struct formatter<variant>: dynamic_formatter<> {
+//     void format(buffer &buf, const variant &v, context &ctx) {
+//       visit([&](const auto &val) { format(buf, val, ctx); }, v);
+//     }
+//   };
+template <typename Char = char>
+class dynamic_formatter {
+ private:
+  struct null_handler: internal::error_handler {
+    void on_align(alignment) {}
+    void on_plus() {}
+    void on_minus() {}
+    void on_space() {}
+    void on_hash() {}
+  };
+
+ public:
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    // Checks are deferred to formatting time when the argument type is known.
+    internal::dynamic_specs_handler<ParseContext> handler(specs_, ctx);
+    it = parse_format_specs(it, handler);
+    return pointer_from(it);
+  }
+
+  template <typename T, typename FormatContext>
+  auto format(const T &val, FormatContext &ctx) -> decltype(ctx.out()) {
+    handle_specs(ctx);
+    internal::specs_checker<null_handler>
+        checker(null_handler(), internal::get_type<FormatContext, T>::value);
+    checker.on_align(specs_.align());
+    if (specs_.flags_ == 0) {
+      // Do nothing.
+    } else if (specs_.flag(SIGN_FLAG)) {
+      if (specs_.flag(PLUS_FLAG))
+        checker.on_plus();
+      else
+        checker.on_space();
+    } else if (specs_.flag(MINUS_FLAG)) {
+      checker.on_minus();
+    } else if (specs_.flag(HASH_FLAG)) {
+      checker.on_hash();
+    }
+    if (specs_.precision_ != -1)
+      checker.end_precision();
+    typedef output_range<typename FormatContext::iterator,
+                         typename FormatContext::char_type> range;
+    visit(arg_formatter<range>(ctx, specs_),
+          internal::make_arg<FormatContext>(val));
+    return ctx.out();
+  }
+
+ private:
+  template <typename Context>
+  void handle_specs(Context &ctx) {
+    internal::handle_dynamic_spec<internal::width_checker>(
+      specs_.width_, specs_.width_ref, ctx);
+    internal::handle_dynamic_spec<internal::precision_checker>(
+      specs_.precision_, specs_.precision_ref, ctx);
+  }
+
+  internal::dynamic_format_specs<Char> specs_;
+};
+
+template <typename Range, typename Char>
+typename basic_format_context<Range, Char>::format_arg
+  basic_format_context<Range, Char>::get_arg(basic_string_view<char_type> name) {
+  map_.init(this->args());
+  format_arg arg = map_.find(name);
+  if (arg.type() == internal::none_type)
+    this->on_error("argument not found");
+  return arg;
 }
 
-template<typename It>
-ArgJoin<wchar_t, It> join(It first, It last, const BasicCStringRef<wchar_t> &sep)
-{
-    return ArgJoin<wchar_t, It>(first, last, sep);
+template <typename ArgFormatter, typename Char, typename Context>
+struct format_handler : internal::error_handler {
+  typedef internal::null_terminating_iterator<Char> iterator;
+  typedef typename ArgFormatter::range range;
+
+  format_handler(range r, basic_string_view<Char> str,
+                 basic_format_args<Context> format_args)
+    : context(r.begin(), str, format_args) {}
+
+  void on_text(iterator begin, iterator end) {
+    size_t size = end - begin;
+    auto out = context.out();
+    auto &&it = internal::reserve(out, size);
+    it = std::copy_n(begin, size, it);
+    context.advance_to(out);
+  }
+
+  void on_arg_id() { arg = context.next_arg(); }
+  void on_arg_id(unsigned id) {
+    context.parse_context().check_arg_id(id);
+    arg = context.get_arg(id);
+  }
+  void on_arg_id(basic_string_view<Char> id) {
+    arg = context.get_arg(id);
+  }
+
+  void on_replacement_field(iterator it) {
+    context.parse_context().advance_to(pointer_from(it));
+    if (visit(internal::custom_formatter<Char, Context>(context), arg))
+      return;
+    basic_format_specs<Char> specs;
+    context.advance_to(visit(ArgFormatter(context, specs), arg));
+  }
+
+  iterator on_format_specs(iterator it) {
+    auto& parse_ctx = context.parse_context();
+    parse_ctx.advance_to(pointer_from(it));
+    if (visit(internal::custom_formatter<Char, Context>(context), arg))
+      return iterator(parse_ctx);
+    basic_format_specs<Char> specs;
+    using internal::specs_handler;
+    internal::specs_checker<specs_handler<Context>>
+        handler(specs_handler<Context>(specs, context), arg.type());
+    it = parse_format_specs(it, handler);
+    if (*it != '}')
+      on_error("missing '}' in format string");
+    parse_ctx.advance_to(pointer_from(it));
+    context.advance_to(visit(ArgFormatter(context, specs), arg));
+    return it;
+  }
+
+  Context context;
+  basic_format_arg<Context> arg;
+};
+
+/** Formats arguments and writes the output to the range. */
+template <typename ArgFormatter, typename Char, typename Context>
+typename Context::iterator vformat_to(typename ArgFormatter::range out,
+                                      basic_string_view<Char> format_str,
+                                      basic_format_args<Context> args) {
+  typedef internal::null_terminating_iterator<Char> iterator;
+  format_handler<ArgFormatter, Char, Context> h(out, format_str, args);
+  parse_format_string(iterator(format_str.begin(), format_str.end()), h);
+  return h.context.out();
 }
 
-#if FMT_HAS_GXX_CXX11
-template<typename Range>
-auto join(const Range &range, const BasicCStringRef<char> &sep) -> ArgJoin<char, decltype(std::begin(range))>
-{
-    return join(std::begin(range), std::end(range), sep);
+// Casts ``p`` to ``const void*`` for pointer formatting.
+// Example:
+//   auto s = format("{}", ptr(p));
+template <typename T>
+inline const void *ptr(const T *p) { return p; }
+
+template <typename It, typename Char>
+struct arg_join {
+  It begin;
+  It end;
+  basic_string_view<Char> sep;
+
+  arg_join(It begin, It end, basic_string_view<Char> sep)
+    : begin(begin), end(end), sep(sep) {}
+};
+
+template <typename It, typename Char>
+struct formatter<arg_join<It, Char>, Char>:
+    formatter<typename std::iterator_traits<It>::value_type, Char> {
+  template <typename FormatContext>
+  auto format(const arg_join<It, Char> &value, FormatContext &ctx)
+      -> decltype(ctx.out()) {
+    typedef formatter<typename std::iterator_traits<It>::value_type, Char> base;
+    auto it = value.begin;
+    auto out = ctx.out();
+    if (it != value.end) {
+      out = base::format(*it++, ctx);
+      while (it != value.end) {
+        out = std::copy(value.sep.begin(), value.sep.end(), out);
+        ctx.advance_to(out);
+        out = base::format(*it++, ctx);
+      }
+    }
+    return out;
+  }
+};
+
+template <typename It>
+arg_join<It, char> join(It begin, It end, string_view sep) {
+  return arg_join<It, char>(begin, end, sep);
 }
 
-template<typename Range>
-auto join(const Range &range, const BasicCStringRef<wchar_t> &sep) -> ArgJoin<wchar_t, decltype(std::begin(range))>
-{
-    return join(std::begin(range), std::end(range), sep);
+template <typename It>
+arg_join<It, wchar_t> join(It begin, It end, wstring_view sep) {
+  return arg_join<It, wchar_t>(begin, end, sep);
+}
+
+// The following causes ICE in gcc 4.4.
+#if FMT_USE_TRAILING_RETURN && (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 405)
+template <typename Range>
+auto join(const Range &range, string_view sep)
+    -> arg_join<decltype(internal::begin(range)), char> {
+  return join(internal::begin(range), internal::end(range), sep);
+}
+
+template <typename Range>
+auto join(const Range &range, wstring_view sep)
+    -> arg_join<decltype(internal::begin(range)), wchar_t> {
+  return join(internal::begin(range), internal::end(range), sep);
 }
 #endif
 
-template<typename ArgFormatter, typename Char, typename It>
-void format_arg(fmt::BasicFormatter<Char, ArgFormatter> &f, const Char *&format_str, const ArgJoin<Char, It> &e)
-{
-    const Char *end = format_str;
-    if (*end == ':')
-        ++end;
-    while (*end && *end != '}')
-        ++end;
-    if (*end != '}')
-        FMT_THROW(FormatError("missing '}' in format string"));
+/**
+  \rst
+  Converts *value* to ``std::string`` using the default format for type *T*.
 
-    It it = e.first;
-    if (it != e.last)
-    {
-        const Char *save = format_str;
-        f.format(format_str, internal::MakeArg<fmt::BasicFormatter<Char, ArgFormatter>>(*it++));
-        while (it != e.last)
-        {
-            f.writer().write(e.sep);
-            format_str = save;
-            f.format(format_str, internal::MakeArg<fmt::BasicFormatter<Char, ArgFormatter>>(*it++));
-        }
-    }
-    format_str = end + 1;
+  **Example**::
+
+    #include <fmt/format.h>
+
+    std::string answer = fmt::to_string(42);
+  \endrst
+ */
+template <typename T>
+std::string to_string(const T &value) {
+  std::string str;
+  internal::container_buffer<std::string> buf(str);
+  writer(buf).write(value);
+  return str;
 }
-} // namespace fmt
+
+/**
+  Converts *value* to ``std::wstring`` using the default format for type *T*.
+ */
+template <typename T>
+std::wstring to_wstring(const T &value) {
+  std::wstring str;
+  internal::container_buffer<std::wstring> buf(str);
+  wwriter(buf).write(value);
+  return str;
+}
+
+template <typename Char>
+std::basic_string<Char> to_string(const basic_memory_buffer<Char> &buffer) {
+  return std::basic_string<Char>(buffer.data(), buffer.size());
+}
+
+inline format_context::iterator vformat_to(
+    internal::buffer &buf, string_view format_str, format_args args) {
+  typedef back_insert_range<internal::buffer> range;
+  return vformat_to<arg_formatter<range>>(buf, format_str, args);
+}
+
+inline wformat_context::iterator vformat_to(
+    internal::wbuffer &buf, wstring_view format_str, wformat_args args) {
+  typedef back_insert_range<internal::wbuffer> range;
+  return vformat_to<arg_formatter<range>>(buf, format_str, args);
+}
+
+template <typename... Args>
+inline format_context::iterator format_to(
+    memory_buffer &buf, string_view format_str, const Args & ... args) {
+  return vformat_to(buf, format_str, make_format_args(args...));
+}
+
+template <typename... Args>
+inline wformat_context::iterator format_to(
+    wmemory_buffer &buf, wstring_view format_str, const Args & ... args) {
+  return vformat_to(buf, format_str, make_format_args<wformat_context>(args...));
+}
+
+template <typename OutputIt, typename Char = char>
+//using format_context_t = basic_format_context<OutputIt, Char>;
+struct format_context_t { typedef basic_format_context<OutputIt, Char> type; };
+
+template <typename OutputIt, typename Char = char>
+//using format_args_t = basic_format_args<format_context_t<OutputIt, Char>>;
+struct format_args_t {
+  typedef basic_format_args<
+    typename format_context_t<OutputIt, Char>::type> type;
+};
+
+template <typename OutputIt, typename... Args>
+inline OutputIt vformat_to(OutputIt out, string_view format_str,
+                           typename format_args_t<OutputIt>::type args) {
+  typedef output_range<OutputIt, char> range;
+  return vformat_to<arg_formatter<range>>(range(out), format_str, args);
+}
+
+/**
+ \rst
+ Formats arguments, writes the result to the output iterator ``out`` and returns
+ the iterator past the end of the output range.
+
+ **Example**::
+
+   std::vector<char> out;
+   fmt::format_to(std::back_inserter(out), "{}", 42);
+ \endrst
+ */
+template <typename OutputIt, typename... Args>
+inline OutputIt format_to(OutputIt out, string_view format_str,
+                          const Args & ... args) {
+  return vformat_to(out, format_str,
+      make_format_args<typename format_context_t<OutputIt>::type>(args...));
+}
+
+template <typename Container, typename... Args>
+inline typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    format_to(std::back_insert_iterator<Container> out,
+              string_view format_str, const Args & ... args) {
+  return vformat_to(out, format_str, make_format_args<format_context>(args...));
+}
+
+template <typename Container, typename... Args>
+inline typename std::enable_if<
+  is_contiguous<Container>::value, std::back_insert_iterator<Container>>::type
+    format_to(std::back_insert_iterator<Container> out,
+              wstring_view format_str, const Args & ... args) {
+  return vformat_to(out, format_str, make_format_args<wformat_context>(args...));
+}
+
+template <typename OutputIt>
+struct format_to_n_result {
+  /** Iterator past the end of the output range. */
+  OutputIt out;
+  /** Total (not truncated) output size. */
+  std::size_t size;
+};
+
+/**
+ \rst
+ Formats arguments, writes up to ``n`` characters of the result to the output
+ iterator ``out`` and returns the total output size and the iterator past the end
+ of the output range.
+ \endrst
+ */
+template <typename OutputIt, typename... Args>
+inline format_to_n_result<OutputIt> format_to_n(
+    OutputIt out, std::size_t n, string_view format_str, const Args & ... args) {
+  typedef internal::truncating_iterator<OutputIt> It;
+  auto it = vformat_to(It(out, n), format_str,
+      make_format_args<typename format_context_t<It>::type>(args...));
+  return {it.base(), it.count()};
+}
+
+inline std::string vformat(string_view format_str, format_args args) {
+  memory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  return fmt::to_string(buffer);
+}
+
+inline std::wstring vformat(wstring_view format_str, wformat_args args) {
+  wmemory_buffer buffer;
+  vformat_to(buffer, format_str, args);
+  return to_string(buffer);
+}
+
+template <typename String, typename... Args>
+inline typename std::enable_if<
+  internal::is_format_string<String>::value, std::string>::type
+    format(String format_str, const Args & ... args) {
+  internal::check_format_string<Args...>(format_str);
+  return vformat(format_str.data(), make_format_args(args...));
+}
+
+template <typename String, typename... Args>
+inline typename std::enable_if<internal::is_format_string<String>::value>::type
+    print(String format_str, const Args & ... args) {
+  internal::check_format_string<Args...>(format_str);
+  return vprint(format_str.data(), make_format_args(args...));
+}
+
+/**
+ Returns the number of characters in the output of
+ ``format(format_str, args...)``.
+ */
+template <typename... Args>
+inline std::size_t formatted_size(string_view format_str,
+                                  const Args & ... args) {
+  auto it = format_to(internal::counting_iterator<char>(), format_str, args...);
+  return it.count();
+}
 
 #if FMT_USE_USER_DEFINED_LITERALS
-namespace fmt {
 namespace internal {
 
-template<typename Char>
-struct UdlFormat
-{
-    const Char *str;
-
-    template<typename... Args>
-    auto operator()(Args &&... args) const -> decltype(format(str, std::forward<Args>(args)...))
-    {
-        return format(str, std::forward<Args>(args)...);
-    }
+# if FMT_UDL_TEMPLATE
+template <typename Char, Char... CHARS>
+class udl_formatter {
+ public:
+  template <typename... Args>
+  std::basic_string<Char> operator()(const Args &... args) const {
+    FMT_CONSTEXPR_DECL Char s[] = {CHARS..., '\0'};
+    FMT_CONSTEXPR_DECL bool invalid_format =
+        check_format_string<Char, error_handler, Args...>(
+          basic_string_view<Char>(s, sizeof...(CHARS)));
+    (void)invalid_format;
+    return format(s, args...);
+  }
 };
+# else
+template <typename Char>
+struct udl_formatter {
+  const Char *str;
 
-template<typename Char>
-struct UdlArg
-{
-    const Char *str;
+  template <typename... Args>
+  auto operator()(Args && ... args) const
+                  -> decltype(format(str, std::forward<Args>(args)...)) {
+    return format(str, std::forward<Args>(args)...);
+  }
+};
+# endif // FMT_UDL_TEMPLATE
 
-    template<typename T>
-    NamedArgWithType<Char, T> operator=(T &&value) const
-    {
-        return {str, std::forward<T>(value)};
-    }
+template <typename Char>
+struct udl_arg {
+  const Char *str;
+
+  template <typename T>
+  named_arg<T, Char> operator=(T &&value) const {
+    return {str, std::forward<T>(value)};
+  }
 };
 
 } // namespace internal
 
 inline namespace literals {
 
+# if FMT_UDL_TEMPLATE
+template <typename Char, Char... CHARS>
+FMT_CONSTEXPR internal::udl_formatter<Char, CHARS...> operator""_format() {
+  return {};
+}
+# else
 /**
   \rst
-  C++11 literal equivalent of :func:`fmt::format`.
+  User-defined literal equivalent of :func:`fmt::format`.
 
   **Example**::
 
@@ -4869,52 +3608,67 @@ inline namespace literals {
     std::string message = "The answer is {}"_format(42);
   \endrst
  */
-inline internal::UdlFormat<char> operator"" _format(const char *s, std::size_t)
-{
-    return {s};
-}
-inline internal::UdlFormat<wchar_t> operator"" _format(const wchar_t *s, std::size_t)
-{
-    return {s};
-}
+inline internal::udl_formatter<char>
+operator"" _format(const char *s, std::size_t) { return {s}; }
+inline internal::udl_formatter<wchar_t>
+operator"" _format(const wchar_t *s, std::size_t) { return {s}; }
+# endif // FMT_UDL_TEMPLATE
 
 /**
   \rst
-  C++11 literal equivalent of :func:`fmt::arg`.
+  User-defined literal equivalent of :func:`fmt::arg`.
 
   **Example**::
 
     using namespace fmt::literals;
-    print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
+    fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-inline internal::UdlArg<char> operator"" _a(const char *s, std::size_t)
-{
-    return {s};
-}
-inline internal::UdlArg<wchar_t> operator"" _a(const wchar_t *s, std::size_t)
-{
-    return {s};
-}
-
-} // namespace literals
-} // namespace fmt
+inline internal::udl_arg<char>
+operator"" _a(const char *s, std::size_t) { return {s}; }
+inline internal::udl_arg<wchar_t>
+operator"" _a(const wchar_t *s, std::size_t) { return {s}; }
+} // inline namespace literals
 #endif // FMT_USE_USER_DEFINED_LITERALS
+FMT_END_NAMESPACE
 
-// Restore warnings.
-#if FMT_GCC_VERSION >= 406
-#pragma GCC diagnostic pop
-#endif
+#define FMT_STRING(s) [] { \
+    struct S : fmt::format_string { \
+      static FMT_CONSTEXPR auto data() { return s; } \
+      static FMT_CONSTEXPR size_t size() { return sizeof(s); } \
+    }; \
+    return S{}; \
+  }()
 
-#if defined(__clang__) && !defined(FMT_ICC_VERSION)
-#pragma clang diagnostic pop
+#ifndef FMT_NO_FMT_STRING_ALIAS
+/**
+  \rst
+  Constructs a compile-time format string.
+
+  **Example**::
+
+    #include <fmt/format.h>
+    // A compile-time error because 'd' is an invalid specifier for strings.
+    std::string s = format(fmt("{:d}"), "foo");
+  \endrst
+ */
+# define fmt(s) FMT_STRING(s)
 #endif
 
 #ifdef FMT_HEADER_ONLY
-#define FMT_FUNC inline
-#include "format.cc"
+# define FMT_FUNC inline
+# include "format-inl.h"
 #else
-#define FMT_FUNC
+# define FMT_FUNC
 #endif
 
-#endif // FMT_FORMAT_H_
+// Restore warnings.
+#if FMT_GCC_VERSION >= 406
+# pragma GCC diagnostic pop
+#endif
+
+#if defined(__clang__) && !defined(FMT_ICC_VERSION)
+# pragma clang diagnostic pop
+#endif
+
+#endif  // FMT_FORMAT_H_

--- a/include/spdlog/fmt/bundled/ostream.h
+++ b/include/spdlog/fmt/bundled/ostream.h
@@ -1,11 +1,9 @@
-/*
- Formatting library for C++ - std::ostream support
-
- Copyright (c) 2012 - 2016, Victor Zverovich
- All rights reserved.
-
- For the license information refer to format.h.
- */
+// Formatting library for C++ - std::ostream support
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
 
 #ifndef FMT_OSTREAM_H_
 #define FMT_OSTREAM_H_
@@ -13,105 +11,151 @@
 #include "format.h"
 #include <ostream>
 
-namespace fmt {
-
+FMT_BEGIN_NAMESPACE
 namespace internal {
 
-template<class Char>
-class FormatBuf : public std::basic_streambuf<Char>
-{
-private:
-    typedef typename std::basic_streambuf<Char>::int_type int_type;
-    typedef typename std::basic_streambuf<Char>::traits_type traits_type;
+template <class Char>
+class formatbuf : public std::basic_streambuf<Char> {
+ private:
+  typedef typename std::basic_streambuf<Char>::int_type int_type;
+  typedef typename std::basic_streambuf<Char>::traits_type traits_type;
 
-    Buffer<Char> &buffer_;
+  basic_buffer<Char> &buffer_;
 
-public:
-    FormatBuf(Buffer<Char> &buffer)
-        : buffer_(buffer)
-    {
-    }
+ public:
+  formatbuf(basic_buffer<Char> &buffer) : buffer_(buffer) {}
 
-protected:
-    // The put-area is actually always empty. This makes the implementation
-    // simpler and has the advantage that the streambuf and the buffer are always
-    // in sync and sputc never writes into uninitialized memory. The obvious
-    // disadvantage is that each call to sputc always results in a (virtual) call
-    // to overflow. There is no disadvantage here for sputn since this always
-    // results in a call to xsputn.
+ protected:
+  // The put-area is actually always empty. This makes the implementation
+  // simpler and has the advantage that the streambuf and the buffer are always
+  // in sync and sputc never writes into uninitialized memory. The obvious
+  // disadvantage is that each call to sputc always results in a (virtual) call
+  // to overflow. There is no disadvantage here for sputn since this always
+  // results in a call to xsputn.
 
-    int_type overflow(int_type ch = traits_type::eof()) FMT_OVERRIDE
-    {
-        if (!traits_type::eq_int_type(ch, traits_type::eof()))
-            buffer_.push_back(static_cast<Char>(ch));
-        return ch;
-    }
+  int_type overflow(int_type ch = traits_type::eof()) FMT_OVERRIDE {
+    if (!traits_type::eq_int_type(ch, traits_type::eof()))
+      buffer_.push_back(static_cast<Char>(ch));
+    return ch;
+  }
 
-    std::streamsize xsputn(const Char *s, std::streamsize count) FMT_OVERRIDE
-    {
-        buffer_.append(s, s + count);
-        return count;
-    }
+  std::streamsize xsputn(const Char *s, std::streamsize count) FMT_OVERRIDE {
+    buffer_.append(s, s + count);
+    return count;
+  }
 };
 
-Yes &convert(std::ostream &);
-
-struct DummyStream : std::ostream
-{
-    DummyStream(); // Suppress a bogus warning in MSVC.
-
-    // Hide all operator<< overloads from std::ostream.
-    template<typename T>
-    typename EnableIf<sizeof(T) == 0>::type operator<<(const T &);
+template <typename Char>
+struct test_stream : std::basic_ostream<Char> {
+ private:
+  struct null;
+  // Hide all operator<< from std::basic_ostream<Char>.
+  void operator<<(null);
 };
 
-No &operator<<(std::ostream &, int);
+// Checks if T has an overloaded operator<< which is a free function (not a
+// member of std::ostream).
+template <typename T, typename Char>
+class is_streamable {
+ private:
+  template <typename U>
+  static decltype(
+    internal::declval<test_stream<Char>&>()
+      << internal::declval<U>(), std::true_type()) test(int);
 
-template<typename T>
-struct ConvertToIntImpl<T, true>
-{
-    // Convert to int only if T doesn't have an overloaded operator<<.
-    enum
-    {
-        value = sizeof(convert(get<DummyStream>() << get<T>())) == sizeof(No)
-    };
+  template <typename>
+  static std::false_type test(...);
+
+  typedef decltype(test<T>(0)) result;
+
+ public:
+  static const bool value = result::value;
 };
 
-// Write the content of w to os.
-FMT_API void write(std::ostream &os, Writer &w);
-} // namespace internal
+// Disable conversion to int if T has an overloaded operator<< which is a free
+// function (not a member of std::ostream).
+template <typename T, typename Char>
+class convert_to_int<T, Char, true> {
+ public:
+  static const bool value =
+    convert_to_int<T, Char, false>::value && !is_streamable<T, Char>::value;
+};
 
-// Formats a value.
-template<typename Char, typename ArgFormatter_, typename T>
-void format_arg(BasicFormatter<Char, ArgFormatter_> &f, const Char *&format_str, const T &value)
-{
-    internal::MemoryBuffer<Char, internal::INLINE_BUFFER_SIZE> buffer;
-
-    internal::FormatBuf<Char> format_buf(buffer);
-    std::basic_ostream<Char> output(&format_buf);
-    output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-    output << value;
-
-    BasicStringRef<Char> str(&buffer[0], buffer.size());
-    typedef internal::MakeArg<BasicFormatter<Char>> MakeArg;
-    format_str = f.format(format_str, MakeArg(str));
+// Write the content of buf to os.
+template <typename Char>
+void write(std::basic_ostream<Char> &os, basic_buffer<Char> &buf) {
+  const Char *data = buf.data();
+  typedef std::make_unsigned<std::streamsize>::type UnsignedStreamSize;
+  UnsignedStreamSize size = buf.size();
+  UnsignedStreamSize max_size =
+      internal::to_unsigned((std::numeric_limits<std::streamsize>::max)());
+  do {
+    UnsignedStreamSize n = size <= max_size ? size : max_size;
+    os.write(data, static_cast<std::streamsize>(n));
+    data += n;
+    size -= n;
+  } while (size != 0);
 }
 
+template <typename Char, typename T>
+void format_value(basic_buffer<Char> &buffer, const T &value) {
+  internal::formatbuf<Char> format_buf(buffer);
+  std::basic_ostream<Char> output(&format_buf);
+  output.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+  output << value;
+  buffer.resize(buffer.size());
+}
+
+// Disable builtin formatting of enums and use operator<< instead.
+template <typename T>
+struct format_enum<T,
+    typename std::enable_if<std::is_enum<T>::value>::type> : std::false_type {};
+}  // namespace internal
+
+// Formats an object of type T that has an overloaded ostream operator<<.
+template <typename T, typename Char>
+struct formatter<T, Char,
+    typename std::enable_if<internal::is_streamable<T, Char>::value>::type>
+    : formatter<basic_string_view<Char>, Char> {
+
+  template <typename Context>
+  auto format(const T &value, Context &ctx) -> decltype(ctx.out()) {
+    basic_memory_buffer<Char> buffer;
+    internal::format_value(buffer, value);
+    basic_string_view<Char> str(buffer.data(), buffer.size());
+    formatter<basic_string_view<Char>, Char>::format(str, ctx);
+    return ctx.out();
+  }
+};
+
+template <typename Char>
+inline void vprint(std::basic_ostream<Char> &os,
+                   basic_string_view<Char> format_str,
+                   basic_format_args<typename buffer_context<Char>::type> args) {
+  basic_memory_buffer<Char> buffer;
+  vformat_to(buffer, format_str, args);
+  internal::write(os, buffer);
+}
 /**
   \rst
   Prints formatted data to the stream *os*.
 
   **Example**::
 
-    print(cerr, "Don't {}!", "panic");
+    fmt::print(cerr, "Don't {}!", "panic");
   \endrst
  */
-FMT_API void print(std::ostream &os, CStringRef format_str, ArgList args);
-FMT_VARIADIC(void, print, std::ostream &, CStringRef)
-} // namespace fmt
+template <typename... Args>
+inline void print(std::ostream &os, string_view format_str,
+                  const Args & ... args) {
+  vprint<char>(os, format_str, make_format_args<format_context>(args...));
+}
 
-#ifdef FMT_HEADER_ONLY
-#include "ostream.cc"
-#endif
+template <typename... Args>
+inline void print(std::wostream &os, wstring_view format_str,
+                  const Args & ... args) {
+  vprint<wchar_t>(os, format_str, make_format_args<wformat_context>(args...));
+}
+FMT_END_NAMESPACE
 
-#endif // FMT_OSTREAM_H_
+#endif  // FMT_OSTREAM_H_

--- a/include/spdlog/fmt/bundled/posix.h
+++ b/include/spdlog/fmt/bundled/posix.h
@@ -1,423 +1,417 @@
-/*
- A C++ interface to POSIX functions.
-
- Copyright (c) 2012 - 2016, Victor Zverovich
- All rights reserved.
-
- For the license information refer to format.h.
- */
+// A C++ interface to POSIX functions.
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
 
 #ifndef FMT_POSIX_H_
 #define FMT_POSIX_H_
 
 #if defined(__MINGW32__) || defined(__CYGWIN__)
 // Workaround MinGW bug https://sourceforge.net/p/mingw/bugs/2024/.
-#undef __STRICT_ANSI__
+# undef __STRICT_ANSI__
 #endif
 
 #include <errno.h>
-#include <fcntl.h>  // for O_RDONLY
-#include <locale.h> // for locale_t
+#include <fcntl.h>   // for O_RDONLY
+#include <locale.h>  // for locale_t
 #include <stdio.h>
-#include <stdlib.h> // for strtod_l
+#include <stdlib.h>  // for strtod_l
 
 #include <cstddef>
 
 #if defined __APPLE__ || defined(__FreeBSD__)
-#include <xlocale.h> // for LC_NUMERIC_MASK on OS X
+# include <xlocale.h>  // for LC_NUMERIC_MASK on OS X
 #endif
 
 #include "format.h"
 
 #ifndef FMT_POSIX
-#if defined(_WIN32) && !defined(__MINGW32__)
+# if defined(_WIN32) && !defined(__MINGW32__)
 // Fix warnings about deprecated symbols.
-#define FMT_POSIX(call) _##call
-#else
-#define FMT_POSIX(call) call
-#endif
+#  define FMT_POSIX(call) _##call
+# else
+#  define FMT_POSIX(call) call
+# endif
 #endif
 
 // Calls to system functions are wrapped in FMT_SYSTEM for testability.
 #ifdef FMT_SYSTEM
-#define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
+# define FMT_POSIX_CALL(call) FMT_SYSTEM(call)
 #else
-#define FMT_SYSTEM(call) call
-#ifdef _WIN32
+# define FMT_SYSTEM(call) call
+# ifdef _WIN32
 // Fix warnings about deprecated symbols.
-#define FMT_POSIX_CALL(call) ::_##call
-#else
-#define FMT_POSIX_CALL(call) ::call
-#endif
+#  define FMT_POSIX_CALL(call) ::_##call
+# else
+#  define FMT_POSIX_CALL(call) ::call
+# endif
 #endif
 
 // Retries the expression while it evaluates to error_result and errno
 // equals to EINTR.
 #ifndef _WIN32
-#define FMT_RETRY_VAL(result, expression, error_result)                                                                                    \
-    do                                                                                                                                     \
-    {                                                                                                                                      \
-        result = (expression);                                                                                                             \
-    } while (result == error_result && errno == EINTR)
+# define FMT_RETRY_VAL(result, expression, error_result) \
+  do { \
+    result = (expression); \
+  } while (result == error_result && errno == EINTR)
 #else
-#define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
+# define FMT_RETRY_VAL(result, expression, error_result) result = (expression)
 #endif
 
 #define FMT_RETRY(result, expression) FMT_RETRY_VAL(result, expression, -1)
 
-namespace fmt {
+FMT_BEGIN_NAMESPACE
+
+/**
+  \rst
+  A reference to a null-terminated string. It can be constructed from a C
+  string or ``std::string``.
+
+  You can use one of the following typedefs for common character types:
+
+  +---------------+-----------------------------+
+  | Type          | Definition                  |
+  +===============+=============================+
+  | cstring_view  | basic_cstring_view<char>    |
+  +---------------+-----------------------------+
+  | wcstring_view | basic_cstring_view<wchar_t> |
+  +---------------+-----------------------------+
+
+  This class is most useful as a parameter type to allow passing
+  different types of strings to a function, for example::
+
+    template <typename... Args>
+    std::string format(cstring_view format_str, const Args & ... args);
+
+    format("{}", 42);
+    format(std::string("{}"), 42);
+  \endrst
+ */
+template <typename Char>
+class basic_cstring_view {
+ private:
+  const Char *data_;
+
+ public:
+  /** Constructs a string reference object from a C string. */
+  basic_cstring_view(const Char *s) : data_(s) {}
+
+  /**
+    \rst
+    Constructs a string reference from an ``std::string`` object.
+    \endrst
+   */
+  basic_cstring_view(const std::basic_string<Char> &s) : data_(s.c_str()) {}
+
+  /** Returns the pointer to a C string. */
+  const Char *c_str() const { return data_; }
+};
+
+typedef basic_cstring_view<char> cstring_view;
+typedef basic_cstring_view<wchar_t> wcstring_view;
 
 // An error code.
-class ErrorCode
-{
-private:
-    int value_;
+class error_code {
+ private:
+  int value_;
 
-public:
-    explicit ErrorCode(int value = 0) FMT_NOEXCEPT : value_(value) {}
+ public:
+  explicit error_code(int value = 0) FMT_NOEXCEPT : value_(value) {}
 
-    int get() const FMT_NOEXCEPT
-    {
-        return value_;
-    }
+  int get() const FMT_NOEXCEPT { return value_; }
 };
 
 // A buffered file.
-class BufferedFile
-{
-private:
-    FILE *file_;
+class buffered_file {
+ private:
+  FILE *file_;
 
-    friend class File;
+  friend class file;
 
-    explicit BufferedFile(FILE *f)
-        : file_(f)
-    {
-    }
+  explicit buffered_file(FILE *f) : file_(f) {}
 
-public:
-    // Constructs a BufferedFile object which doesn't represent any file.
-    BufferedFile() FMT_NOEXCEPT : file_(FMT_NULL) {}
+ public:
+  // Constructs a buffered_file object which doesn't represent any file.
+  buffered_file() FMT_NOEXCEPT : file_(FMT_NULL) {}
 
-    // Destroys the object closing the file it represents if any.
-    FMT_API ~BufferedFile() FMT_NOEXCEPT;
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~buffered_file() FMT_DTOR_NOEXCEPT;
 
 #if !FMT_USE_RVALUE_REFERENCES
-    // Emulate a move constructor and a move assignment operator if rvalue
-    // references are not supported.
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
 
-private:
-    // A proxy object to emulate a move constructor.
-    // It is private to make it impossible call operator Proxy directly.
-    struct Proxy
-    {
-        FILE *file;
-    };
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    FILE *file;
+  };
 
 public:
-    // A "move constructor" for moving from a temporary.
-    BufferedFile(Proxy p) FMT_NOEXCEPT : file_(p.file) {}
+  // A "move constructor" for moving from a temporary.
+  buffered_file(Proxy p) FMT_NOEXCEPT : file_(p.file) {}
 
-    // A "move constructor" for moving from an lvalue.
-    BufferedFile(BufferedFile &f) FMT_NOEXCEPT : file_(f.file_)
-    {
-        f.file_ = FMT_NULL;
-    }
+  // A "move constructor" for moving from an lvalue.
+  buffered_file(buffered_file &f) FMT_NOEXCEPT : file_(f.file_) {
+    f.file_ = FMT_NULL;
+  }
 
-    // A "move assignment operator" for moving from a temporary.
-    BufferedFile &operator=(Proxy p)
-    {
-        close();
-        file_ = p.file;
-        return *this;
-    }
+  // A "move assignment operator" for moving from a temporary.
+  buffered_file &operator=(Proxy p) {
+    close();
+    file_ = p.file;
+    return *this;
+  }
 
-    // A "move assignment operator" for moving from an lvalue.
-    BufferedFile &operator=(BufferedFile &other)
-    {
-        close();
-        file_ = other.file_;
-        other.file_ = FMT_NULL;
-        return *this;
-    }
+  // A "move assignment operator" for moving from an lvalue.
+  buffered_file &operator=(buffered_file &other) {
+    close();
+    file_ = other.file_;
+    other.file_ = FMT_NULL;
+    return *this;
+  }
 
-    // Returns a proxy object for moving from a temporary:
-    //   BufferedFile file = BufferedFile(...);
-    operator Proxy() FMT_NOEXCEPT
-    {
-        Proxy p = {file_};
-        file_ = FMT_NULL;
-        return p;
-    }
+  // Returns a proxy object for moving from a temporary:
+  //   buffered_file file = buffered_file(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {file_};
+    file_ = FMT_NULL;
+    return p;
+  }
 
 #else
-private:
-    FMT_DISALLOW_COPY_AND_ASSIGN(BufferedFile);
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(buffered_file);
 
-public:
-    BufferedFile(BufferedFile &&other) FMT_NOEXCEPT : file_(other.file_)
-    {
-        other.file_ = FMT_NULL;
-    }
+ public:
+  buffered_file(buffered_file &&other) FMT_NOEXCEPT : file_(other.file_) {
+    other.file_ = FMT_NULL;
+  }
 
-    BufferedFile &operator=(BufferedFile &&other)
-    {
-        close();
-        file_ = other.file_;
-        other.file_ = FMT_NULL;
-        return *this;
-    }
+  buffered_file& operator=(buffered_file &&other) {
+    close();
+    file_ = other.file_;
+    other.file_ = FMT_NULL;
+    return *this;
+  }
 #endif
 
-    // Opens a file.
-    FMT_API BufferedFile(CStringRef filename, CStringRef mode);
+  // Opens a file.
+  FMT_API buffered_file(cstring_view filename, cstring_view mode);
 
-    // Closes the file.
-    FMT_API void close();
+  // Closes the file.
+  FMT_API void close();
 
-    // Returns the pointer to a FILE object representing this file.
-    FILE *get() const FMT_NOEXCEPT
-    {
-        return file_;
-    }
+  // Returns the pointer to a FILE object representing this file.
+  FILE *get() const FMT_NOEXCEPT { return file_; }
 
-    // We place parentheses around fileno to workaround a bug in some versions
-    // of MinGW that define fileno as a macro.
-    FMT_API int(fileno)() const;
+  // We place parentheses around fileno to workaround a bug in some versions
+  // of MinGW that define fileno as a macro.
+  FMT_API int (fileno)() const;
 
-    void print(CStringRef format_str, const ArgList &args)
-    {
-        fmt::print(file_, format_str, args);
-    }
-    FMT_VARIADIC(void, print, CStringRef)
+  void vprint(string_view format_str, format_args args) {
+    fmt::vprint(file_, format_str, args);
+  }
+
+  template <typename... Args>
+  inline void print(string_view format_str, const Args & ... args) {
+    vprint(format_str, make_format_args(args...));
+  }
 };
 
-// A file. Closed file is represented by a File object with descriptor -1.
+// A file. Closed file is represented by a file object with descriptor -1.
 // Methods that are not declared with FMT_NOEXCEPT may throw
-// fmt::SystemError in case of failure. Note that some errors such as
+// fmt::system_error in case of failure. Note that some errors such as
 // closing the file multiple times will cause a crash on Windows rather
 // than an exception. You can get standard behavior by overriding the
 // invalid parameter handler with _set_invalid_parameter_handler.
-class File
-{
-private:
-    int fd_; // File descriptor.
+class file {
+ private:
+  int fd_;  // File descriptor.
 
-    // Constructs a File object with a given descriptor.
-    explicit File(int fd)
-        : fd_(fd)
-    {
-    }
+  // Constructs a file object with a given descriptor.
+  explicit file(int fd) : fd_(fd) {}
 
-public:
-    // Possible values for the oflag argument to the constructor.
-    enum
-    {
-        RDONLY = FMT_POSIX(O_RDONLY), // Open for reading only.
-        WRONLY = FMT_POSIX(O_WRONLY), // Open for writing only.
-        RDWR = FMT_POSIX(O_RDWR)      // Open for reading and writing.
-    };
+ public:
+  // Possible values for the oflag argument to the constructor.
+  enum {
+    RDONLY = FMT_POSIX(O_RDONLY), // Open for reading only.
+    WRONLY = FMT_POSIX(O_WRONLY), // Open for writing only.
+    RDWR   = FMT_POSIX(O_RDWR)    // Open for reading and writing.
+  };
 
-    // Constructs a File object which doesn't represent any file.
-    File() FMT_NOEXCEPT : fd_(-1) {}
+  // Constructs a file object which doesn't represent any file.
+  file() FMT_NOEXCEPT : fd_(-1) {}
 
-    // Opens a file and constructs a File object representing this file.
-    FMT_API File(CStringRef path, int oflag);
+  // Opens a file and constructs a file object representing this file.
+  FMT_API file(cstring_view path, int oflag);
 
 #if !FMT_USE_RVALUE_REFERENCES
-    // Emulate a move constructor and a move assignment operator if rvalue
-    // references are not supported.
+  // Emulate a move constructor and a move assignment operator if rvalue
+  // references are not supported.
 
-private:
-    // A proxy object to emulate a move constructor.
-    // It is private to make it impossible call operator Proxy directly.
-    struct Proxy
-    {
-        int fd;
-    };
+ private:
+  // A proxy object to emulate a move constructor.
+  // It is private to make it impossible call operator Proxy directly.
+  struct Proxy {
+    int fd;
+  };
 
-public:
-    // A "move constructor" for moving from a temporary.
-    File(Proxy p) FMT_NOEXCEPT : fd_(p.fd) {}
+ public:
+  // A "move constructor" for moving from a temporary.
+  file(Proxy p) FMT_NOEXCEPT : fd_(p.fd) {}
 
-    // A "move constructor" for moving from an lvalue.
-    File(File &other) FMT_NOEXCEPT : fd_(other.fd_)
-    {
-        other.fd_ = -1;
-    }
+  // A "move constructor" for moving from an lvalue.
+  file(file &other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
 
-    // A "move assignment operator" for moving from a temporary.
-    File &operator=(Proxy p)
-    {
-        close();
-        fd_ = p.fd;
-        return *this;
-    }
+  // A "move assignment operator" for moving from a temporary.
+  file &operator=(Proxy p) {
+    close();
+    fd_ = p.fd;
+    return *this;
+  }
 
-    // A "move assignment operator" for moving from an lvalue.
-    File &operator=(File &other)
-    {
-        close();
-        fd_ = other.fd_;
-        other.fd_ = -1;
-        return *this;
-    }
+  // A "move assignment operator" for moving from an lvalue.
+  file &operator=(file &other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
 
-    // Returns a proxy object for moving from a temporary:
-    //   File file = File(...);
-    operator Proxy() FMT_NOEXCEPT
-    {
-        Proxy p = {fd_};
-        fd_ = -1;
-        return p;
-    }
+  // Returns a proxy object for moving from a temporary:
+  //   file f = file(...);
+  operator Proxy() FMT_NOEXCEPT {
+    Proxy p = {fd_};
+    fd_ = -1;
+    return p;
+  }
 
 #else
-private:
-    FMT_DISALLOW_COPY_AND_ASSIGN(File);
+ private:
+  FMT_DISALLOW_COPY_AND_ASSIGN(file);
 
-public:
-    File(File &&other) FMT_NOEXCEPT : fd_(other.fd_)
-    {
-        other.fd_ = -1;
-    }
+ public:
+  file(file &&other) FMT_NOEXCEPT : fd_(other.fd_) {
+    other.fd_ = -1;
+  }
 
-    File &operator=(File &&other)
-    {
-        close();
-        fd_ = other.fd_;
-        other.fd_ = -1;
-        return *this;
-    }
+  file& operator=(file &&other) {
+    close();
+    fd_ = other.fd_;
+    other.fd_ = -1;
+    return *this;
+  }
 #endif
 
-    // Destroys the object closing the file it represents if any.
-    FMT_API ~File() FMT_NOEXCEPT;
+  // Destroys the object closing the file it represents if any.
+  FMT_API ~file() FMT_DTOR_NOEXCEPT;
 
-    // Returns the file descriptor.
-    int descriptor() const FMT_NOEXCEPT
-    {
-        return fd_;
-    }
+  // Returns the file descriptor.
+  int descriptor() const FMT_NOEXCEPT { return fd_; }
 
-    // Closes the file.
-    FMT_API void close();
+  // Closes the file.
+  FMT_API void close();
 
-    // Returns the file size. The size has signed type for consistency with
-    // stat::st_size.
-    FMT_API LongLong size() const;
+  // Returns the file size. The size has signed type for consistency with
+  // stat::st_size.
+  FMT_API long long size() const;
 
-    // Attempts to read count bytes from the file into the specified buffer.
-    FMT_API std::size_t read(void *buffer, std::size_t count);
+  // Attempts to read count bytes from the file into the specified buffer.
+  FMT_API std::size_t read(void *buffer, std::size_t count);
 
-    // Attempts to write count bytes from the specified buffer to the file.
-    FMT_API std::size_t write(const void *buffer, std::size_t count);
+  // Attempts to write count bytes from the specified buffer to the file.
+  FMT_API std::size_t write(const void *buffer, std::size_t count);
 
-    // Duplicates a file descriptor with the dup function and returns
-    // the duplicate as a file object.
-    FMT_API static File dup(int fd);
+  // Duplicates a file descriptor with the dup function and returns
+  // the duplicate as a file object.
+  FMT_API static file dup(int fd);
 
-    // Makes fd be the copy of this file descriptor, closing fd first if
-    // necessary.
-    FMT_API void dup2(int fd);
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd);
 
-    // Makes fd be the copy of this file descriptor, closing fd first if
-    // necessary.
-    FMT_API void dup2(int fd, ErrorCode &ec) FMT_NOEXCEPT;
+  // Makes fd be the copy of this file descriptor, closing fd first if
+  // necessary.
+  FMT_API void dup2(int fd, error_code &ec) FMT_NOEXCEPT;
 
-    // Creates a pipe setting up read_end and write_end file objects for reading
-    // and writing respectively.
-    FMT_API static void pipe(File &read_end, File &write_end);
+  // Creates a pipe setting up read_end and write_end file objects for reading
+  // and writing respectively.
+  FMT_API static void pipe(file &read_end, file &write_end);
 
-    // Creates a BufferedFile object associated with this file and detaches
-    // this File object from the file.
-    FMT_API BufferedFile fdopen(const char *mode);
+  // Creates a buffered_file object associated with this file and detaches
+  // this file object from the file.
+  FMT_API buffered_file fdopen(const char *mode);
 };
 
 // Returns the memory page size.
 long getpagesize();
 
-#if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && !defined(__ANDROID__) && !defined(__CYGWIN__)
-#define FMT_LOCALE
+#if (defined(LC_NUMERIC_MASK) || defined(_MSC_VER)) && \
+    !defined(__ANDROID__) && !defined(__CYGWIN__) && !defined(__OpenBSD__)
+# define FMT_LOCALE
 #endif
 
 #ifdef FMT_LOCALE
 // A "C" numeric locale.
-class Locale
-{
-private:
-#ifdef _MSC_VER
-    typedef _locale_t locale_t;
+class Locale {
+ private:
+# ifdef _MSC_VER
+  typedef _locale_t locale_t;
 
-    enum
-    {
-        LC_NUMERIC_MASK = LC_NUMERIC
-    };
+  enum { LC_NUMERIC_MASK = LC_NUMERIC };
 
-    static locale_t newlocale(int category_mask, const char *locale, locale_t)
-    {
-        return _create_locale(category_mask, locale);
-    }
+  static locale_t newlocale(int category_mask, const char *locale, locale_t) {
+    return _create_locale(category_mask, locale);
+  }
 
-    static void freelocale(locale_t locale)
-    {
-        _free_locale(locale);
-    }
+  static void freelocale(locale_t locale) {
+    _free_locale(locale);
+  }
 
-    static double strtod_l(const char *nptr, char **endptr, _locale_t locale)
-    {
-        return _strtod_l(nptr, endptr, locale);
-    }
-#endif
+  static double strtod_l(const char *nptr, char **endptr, _locale_t locale) {
+    return _strtod_l(nptr, endptr, locale);
+  }
+# endif
 
-    locale_t locale_;
+  locale_t locale_;
 
-    FMT_DISALLOW_COPY_AND_ASSIGN(Locale);
+  FMT_DISALLOW_COPY_AND_ASSIGN(Locale);
 
-public:
-    typedef locale_t Type;
+ public:
+  typedef locale_t Type;
 
-    Locale()
-        : locale_(newlocale(LC_NUMERIC_MASK, "C", FMT_NULL))
-    {
-        if (!locale_)
-            FMT_THROW(fmt::SystemError(errno, "cannot create locale"));
-    }
-    ~Locale()
-    {
-        freelocale(locale_);
-    }
+  Locale() : locale_(newlocale(LC_NUMERIC_MASK, "C", FMT_NULL)) {
+    if (!locale_)
+      FMT_THROW(system_error(errno, "cannot create locale"));
+  }
+  ~Locale() { freelocale(locale_); }
 
-    Type get() const
-    {
-        return locale_;
-    }
+  Type get() const { return locale_; }
 
-    // Converts string to floating-point number and advances str past the end
-    // of the parsed input.
-    double strtod(const char *&str) const
-    {
-        char *end = FMT_NULL;
-        double result = strtod_l(str, &end, locale_);
-        str = end;
-        return result;
-    }
+  // Converts string to floating-point number and advances str past the end
+  // of the parsed input.
+  double strtod(const char *&str) const {
+    char *end = FMT_NULL;
+    double result = strtod_l(str, &end, locale_);
+    str = end;
+    return result;
+  }
 };
-#endif // FMT_LOCALE
-} // namespace fmt
+#endif  // FMT_LOCALE
+FMT_END_NAMESPACE
 
 #if !FMT_USE_RVALUE_REFERENCES
 namespace std {
 // For compatibility with C++98.
-inline fmt::BufferedFile &move(fmt::BufferedFile &f)
-{
-    return f;
+inline fmt::buffered_file &move(fmt::buffered_file &f) { return f; }
+inline fmt::file &move(fmt::file &f) { return f; }
 }
-inline fmt::File &move(fmt::File &f)
-{
-    return f;
-}
-} // namespace std
 #endif
 
-#endif // FMT_POSIX_H_
+#endif  // FMT_POSIX_H_

--- a/include/spdlog/fmt/bundled/printf.h
+++ b/include/spdlog/fmt/bundled/printf.h
@@ -1,649 +1,582 @@
-/*
- Formatting library for C++
-
- Copyright (c) 2012 - 2016, Victor Zverovich
- All rights reserved.
-
- For the license information refer to format.h.
- */
+// Formatting library for C++
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
 
 #ifndef FMT_PRINTF_H_
 #define FMT_PRINTF_H_
 
-#include <algorithm> // std::fill_n
-#include <limits>    // std::numeric_limits
+#include <algorithm>  // std::fill_n
+#include <limits>     // std::numeric_limits
 
 #include "ostream.h"
 
-namespace fmt {
+FMT_BEGIN_NAMESPACE
 namespace internal {
 
 // Checks if a value fits in int - used to avoid warnings about comparing
 // signed and unsigned integers.
-template<bool IsSigned>
-struct IntChecker
-{
-    template<typename T>
-    static bool fits_in_int(T value)
-    {
-        unsigned max = std::numeric_limits<int>::max();
-        return value <= max;
-    }
-    static bool fits_in_int(bool)
-    {
-        return true;
-    }
+template <bool IsSigned>
+struct int_checker {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    unsigned max = std::numeric_limits<int>::max();
+    return value <= max;
+  }
+  static bool fits_in_int(bool) { return true; }
 };
 
-template<>
-struct IntChecker<true>
-{
-    template<typename T>
-    static bool fits_in_int(T value)
-    {
-        return value >= std::numeric_limits<int>::min() && value <= std::numeric_limits<int>::max();
-    }
-    static bool fits_in_int(int)
-    {
-        return true;
-    }
+template <>
+struct int_checker<true> {
+  template <typename T>
+  static bool fits_in_int(T value) {
+    return value >= std::numeric_limits<int>::min() &&
+           value <= std::numeric_limits<int>::max();
+  }
+  static bool fits_in_int(int) { return true; }
 };
 
-class PrecisionHandler : public ArgVisitor<PrecisionHandler, int>
-{
-public:
-    void report_unhandled_arg()
-    {
-        FMT_THROW(FormatError("precision is not integer"));
-    }
+class printf_precision_handler: public function<int> {
+ public:
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, int>::type
+      operator()(T value) {
+    if (!int_checker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
+      FMT_THROW(format_error("number is too big"));
+    return static_cast<int>(value);
+  }
 
-    template<typename T>
-    int visit_any_int(T value)
-    {
-        if (!IntChecker<std::numeric_limits<T>::is_signed>::fits_in_int(value))
-            FMT_THROW(FormatError("number is too big"));
-        return static_cast<int>(value);
-    }
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, int>::type
+      operator()(T) {
+    FMT_THROW(format_error("precision is not integer"));
+    return 0;
+  }
 };
 
-// IsZeroInt::visit(arg) returns true iff arg is a zero integer.
-class IsZeroInt : public ArgVisitor<IsZeroInt, bool>
-{
-public:
-    template<typename T>
-    bool visit_any_int(T value)
-    {
-        return value == 0;
-    }
+// An argument visitor that returns true iff arg is a zero integer.
+class is_zero_int: public function<bool> {
+ public:
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, bool>::type
+      operator()(T value) { return value == 0; }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, bool>::type
+      operator()(T) { return false; }
 };
 
-// returns the default type for format specific "%s"
-class DefaultType : public ArgVisitor<DefaultType, char>
-{
-public:
-    char visit_char(int)
-    {
-        return 'c';
-    }
+template <typename T>
+struct make_unsigned_or_bool : std::make_unsigned<T> {};
 
-    char visit_bool(bool)
-    {
-        return 's';
-    }
-
-    char visit_pointer(const void *)
-    {
-        return 'p';
-    }
-
-    template<typename T>
-    char visit_any_int(T)
-    {
-        return 'd';
-    }
-
-    template<typename T>
-    char visit_any_double(T)
-    {
-        return 'g';
-    }
-
-    char visit_unhandled_arg()
-    {
-        return 's';
-    }
+template <>
+struct make_unsigned_or_bool<bool> {
+  typedef bool type;
 };
 
-template<typename T, typename U>
-struct is_same
-{
-    enum
-    {
-        value = 0
-    };
+template <typename T, typename Context>
+class arg_converter: public function<void> {
+ private:
+  typedef typename Context::char_type Char;
+
+  basic_format_arg<Context> &arg_;
+  typename Context::char_type type_;
+
+ public:
+  arg_converter(basic_format_arg<Context> &arg, Char type)
+    : arg_(arg), type_(type) {}
+
+  void operator()(bool value) {
+    if (type_ != 's')
+      operator()<bool>(value);
+  }
+
+  template <typename U>
+  typename std::enable_if<std::is_integral<U>::value>::type
+      operator()(U value) {
+    bool is_signed = type_ == 'd' || type_ == 'i';
+    typedef typename std::conditional<
+        std::is_same<T, void>::value, U, T>::type TargetType;
+    if (const_check(sizeof(TargetType) <= sizeof(int))) {
+      // Extra casts are used to silence warnings.
+      if (is_signed) {
+        arg_ = internal::make_arg<Context>(
+          static_cast<int>(static_cast<TargetType>(value)));
+      } else {
+        typedef typename make_unsigned_or_bool<TargetType>::type Unsigned;
+        arg_ = internal::make_arg<Context>(
+          static_cast<unsigned>(static_cast<Unsigned>(value)));
+      }
+    } else {
+      if (is_signed) {
+        // glibc's printf doesn't sign extend arguments of smaller types:
+        //   std::printf("%lld", -42);  // prints "4294967254"
+        // but we don't have to do the same because it's a UB.
+        arg_ = internal::make_arg<Context>(static_cast<long long>(value));
+      } else {
+        arg_ = internal::make_arg<Context>(
+          static_cast<typename make_unsigned_or_bool<U>::type>(value));
+      }
+    }
+  }
+
+  template <typename U>
+  typename std::enable_if<!std::is_integral<U>::value>::type operator()(U) {
+    // No coversion needed for non-integral types.
+  }
 };
 
-template<typename T>
-struct is_same<T, T>
-{
-    enum
-    {
-        value = 1
-    };
-};
-
-// An argument visitor that converts an integer argument to T for printf,
-// if T is an integral type. If T is void, the argument is converted to
-// corresponding signed or unsigned type depending on the type specifier:
-// 'd' and 'i' - signed, other - unsigned)
-template<typename T = void>
-class ArgConverter : public ArgVisitor<ArgConverter<T>, void>
-{
-private:
-    internal::Arg &arg_;
-    wchar_t type_;
-
-    FMT_DISALLOW_COPY_AND_ASSIGN(ArgConverter);
-
-public:
-    ArgConverter(internal::Arg &arg, wchar_t type)
-        : arg_(arg)
-        , type_(type)
-    {
-    }
-
-    void visit_bool(bool value)
-    {
-        if (type_ != 's')
-            visit_any_int(value);
-    }
-
-    void visit_char(int value)
-    {
-        if (type_ != 's')
-            visit_any_int(value);
-    }
-
-    template<typename U>
-    void visit_any_int(U value)
-    {
-        bool is_signed = type_ == 'd' || type_ == 'i';
-        if (type_ == 's')
-        {
-            is_signed = std::numeric_limits<U>::is_signed;
-        }
-
-        using internal::Arg;
-        typedef typename internal::Conditional<is_same<T, void>::value, U, T>::type TargetType;
-        if (const_check(sizeof(TargetType) <= sizeof(int)))
-        {
-            // Extra casts are used to silence warnings.
-            if (is_signed)
-            {
-                arg_.type = Arg::INT;
-                arg_.int_value = static_cast<int>(static_cast<TargetType>(value));
-            }
-            else
-            {
-                arg_.type = Arg::UINT;
-                typedef typename internal::MakeUnsigned<TargetType>::Type Unsigned;
-                arg_.uint_value = static_cast<unsigned>(static_cast<Unsigned>(value));
-            }
-        }
-        else
-        {
-            if (is_signed)
-            {
-                arg_.type = Arg::LONG_LONG;
-                // glibc's printf doesn't sign extend arguments of smaller types:
-                //   std::printf("%lld", -42);  // prints "4294967254"
-                // but we don't have to do the same because it's a UB.
-                arg_.long_long_value = static_cast<LongLong>(value);
-            }
-            else
-            {
-                arg_.type = Arg::ULONG_LONG;
-                arg_.ulong_long_value = static_cast<typename internal::MakeUnsigned<U>::Type>(value);
-            }
-        }
-    }
-};
+// Converts an integer argument to T for printf, if T is an integral type.
+// If T is void, the argument is converted to corresponding signed or unsigned
+// type depending on the type specifier: 'd' and 'i' - signed, other -
+// unsigned).
+template <typename T, typename Context, typename Char>
+void convert_arg(basic_format_arg<Context> &arg, Char type) {
+  visit(arg_converter<T, Context>(arg, type), arg);
+}
 
 // Converts an integer argument to char for printf.
-class CharConverter : public ArgVisitor<CharConverter, void>
-{
-private:
-    internal::Arg &arg_;
+template <typename Context>
+class char_converter: public function<void> {
+ private:
+  basic_format_arg<Context> &arg_;
 
-    FMT_DISALLOW_COPY_AND_ASSIGN(CharConverter);
+  FMT_DISALLOW_COPY_AND_ASSIGN(char_converter);
 
-public:
-    explicit CharConverter(internal::Arg &arg)
-        : arg_(arg)
-    {
-    }
+ public:
+  explicit char_converter(basic_format_arg<Context> &arg) : arg_(arg) {}
 
-    template<typename T>
-    void visit_any_int(T value)
-    {
-        arg_.type = internal::Arg::CHAR;
-        arg_.int_value = static_cast<char>(value);
-    }
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value>::type
+      operator()(T value) {
+    typedef typename Context::char_type Char;
+    arg_ = internal::make_arg<Context>(static_cast<Char>(value));
+  }
+
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value>::type operator()(T) {
+    // No coversion needed for non-integral types.
+  }
 };
 
 // Checks if an argument is a valid printf width specifier and sets
 // left alignment if it is negative.
-class WidthHandler : public ArgVisitor<WidthHandler, unsigned>
-{
-private:
-    FormatSpec &spec_;
+template <typename Char>
+class printf_width_handler: public function<unsigned> {
+ private:
+  typedef basic_format_specs<Char> format_specs;
 
-    FMT_DISALLOW_COPY_AND_ASSIGN(WidthHandler);
+  format_specs &spec_;
 
-public:
-    explicit WidthHandler(FormatSpec &spec)
-        : spec_(spec)
-    {
+  FMT_DISALLOW_COPY_AND_ASSIGN(printf_width_handler);
+
+ public:
+  explicit printf_width_handler(format_specs &spec) : spec_(spec) {}
+
+  template <typename T>
+  typename std::enable_if<std::is_integral<T>::value, unsigned>::type
+      operator()(T value) {
+    typedef typename internal::int_traits<T>::main_type UnsignedType;
+    UnsignedType width = static_cast<UnsignedType>(value);
+    if (internal::is_negative(value)) {
+      spec_.align_ = ALIGN_LEFT;
+      width = 0 - width;
     }
+    unsigned int_max = std::numeric_limits<int>::max();
+    if (width > int_max)
+      FMT_THROW(format_error("number is too big"));
+    return static_cast<unsigned>(width);
+  }
 
-    void report_unhandled_arg()
-    {
-        FMT_THROW(FormatError("width is not integer"));
-    }
-
-    template<typename T>
-    unsigned visit_any_int(T value)
-    {
-        typedef typename internal::IntTraits<T>::MainType UnsignedType;
-        UnsignedType width = static_cast<UnsignedType>(value);
-        if (internal::is_negative(value))
-        {
-            spec_.align_ = ALIGN_LEFT;
-            width = 0 - width;
-        }
-        unsigned int_max = std::numeric_limits<int>::max();
-        if (width > int_max)
-            FMT_THROW(FormatError("number is too big"));
-        return static_cast<unsigned>(width);
-    }
+  template <typename T>
+  typename std::enable_if<!std::is_integral<T>::value, unsigned>::type
+      operator()(T) {
+    FMT_THROW(format_error("width is not integer"));
+    return 0;
+  }
 };
-} // namespace internal
+}  // namespace internal
+
+template <typename Range>
+class printf_arg_formatter;
+
+template <
+    typename OutputIt, typename Char,
+    typename ArgFormatter =
+      printf_arg_formatter<back_insert_range<internal::basic_buffer<Char>>>>
+class basic_printf_context;
 
 /**
   \rst
-  A ``printf`` argument formatter based on the `curiously recurring template
-  pattern <http://en.wikipedia.org/wiki/Curiously_recurring_template_pattern>`_.
-
-  To use `~fmt::BasicPrintfArgFormatter` define a subclass that implements some
-  or all of the visit methods with the same signatures as the methods in
-  `~fmt::ArgVisitor`, for example, `~fmt::ArgVisitor::visit_int()`.
-  Pass the subclass as the *Impl* template parameter. When a formatting
-  function processes an argument, it will dispatch to a visit method
-  specific to the argument type. For example, if the argument type is
-  ``double`` then the `~fmt::ArgVisitor::visit_double()` method of a subclass
-  will be called. If the subclass doesn't contain a method with this signature,
-  then a corresponding method of `~fmt::BasicPrintfArgFormatter` or its
-  superclass will be called.
+  The ``printf`` argument formatter.
   \endrst
  */
-template<typename Impl, typename Char, typename Spec>
-class BasicPrintfArgFormatter : public internal::ArgFormatterBase<Impl, Char, Spec>
-{
-private:
-    void write_null_pointer()
-    {
-        this->spec().type_ = 0;
-        this->write("(nil)");
-    }
+template <typename Range>
+class printf_arg_formatter:
+  public internal::function<
+    typename internal::arg_formatter_base<Range>::iterator>,
+  public internal::arg_formatter_base<Range> {
+ private:
+  typedef typename Range::value_type char_type;
+  typedef decltype(internal::declval<Range>().begin()) iterator;
+  typedef internal::arg_formatter_base<Range> base;
+  typedef basic_printf_context<iterator, char_type> context_type;
 
-    typedef internal::ArgFormatterBase<Impl, Char, Spec> Base;
+  context_type &context_;
 
-public:
-    /**
-      \rst
-      Constructs an argument formatter object.
-      *writer* is a reference to the output writer and *spec* contains format
-      specifier information for standard argument types.
-      \endrst
-     */
-    BasicPrintfArgFormatter(BasicWriter<Char> &w, Spec &s)
-        : internal::ArgFormatterBase<Impl, Char, Spec>(w, s)
-    {
-    }
+  void write_null_pointer(char) {
+    this->spec().type_ = 0;
+    this->write("(nil)");
+  }
 
-    /** Formats an argument of type ``bool``. */
-    void visit_bool(bool value)
-    {
-        Spec &fmt_spec = this->spec();
-        if (fmt_spec.type_ != 's')
-            return this->visit_any_int(value);
-        fmt_spec.type_ = 0;
-        this->write(value);
-    }
+  void write_null_pointer(wchar_t) {
+    this->spec().type_ = 0;
+    this->write(L"(nil)");
+  }
 
-    /** Formats a character. */
-    void visit_char(int value)
-    {
-        const Spec &fmt_spec = this->spec();
-        BasicWriter<Char> &w = this->writer();
-        if (fmt_spec.type_ && fmt_spec.type_ != 'c')
-            w.write_int(value, fmt_spec);
-        typedef typename BasicWriter<Char>::CharPtr CharPtr;
-        CharPtr out = CharPtr();
-        if (fmt_spec.width_ > 1)
-        {
-            Char fill = ' ';
-            out = w.grow_buffer(fmt_spec.width_);
-            if (fmt_spec.align_ != ALIGN_LEFT)
-            {
-                std::fill_n(out, fmt_spec.width_ - 1, fill);
-                out += fmt_spec.width_ - 1;
-            }
-            else
-            {
-                std::fill_n(out + 1, fmt_spec.width_ - 1, fill);
-            }
-        }
-        else
-        {
-            out = w.grow_buffer(1);
-        }
-        *out = static_cast<Char>(value);
-    }
+ public:
+  typedef typename base::format_specs format_specs;
 
-    /** Formats a null-terminated C string. */
-    void visit_cstring(const char *value)
-    {
-        if (value)
-            Base::visit_cstring(value);
-        else if (this->spec().type_ == 'p')
-            write_null_pointer();
-        else
-            this->write("(null)");
-    }
+  /**
+    \rst
+    Constructs an argument formatter object.
+    *buffer* is a reference to the output buffer and *spec* contains format
+    specifier information for standard argument types.
+    \endrst
+   */
+  printf_arg_formatter(internal::basic_buffer<char_type> &buffer,
+                       format_specs &spec, context_type &ctx)
+    : base(back_insert_range<internal::basic_buffer<char_type>>(buffer), spec),
+      context_(ctx) {}
 
-    /** Formats a pointer. */
-    void visit_pointer(const void *value)
-    {
-        if (value)
-            return Base::visit_pointer(value);
-        this->spec().type_ = 0;
-        write_null_pointer();
-    }
+  using base::operator();
 
-    /** Formats an argument of a custom (user-defined) type. */
-    void visit_custom(internal::Arg::CustomValue c)
-    {
-        BasicFormatter<Char> formatter(ArgList(), this->writer());
-        const Char format_str[] = {'}', 0};
-        const Char *format = format_str;
-        c.format(&formatter, c.value, &format);
-    }
+  /** Formats an argument of type ``bool``. */
+  iterator operator()(bool value) {
+    format_specs &fmt_spec = this->spec();
+    if (fmt_spec.type_ != 's')
+      return (*this)(value ? 1 : 0);
+    fmt_spec.type_ = 0;
+    this->write(value);
+    return this->out();
+  }
+
+  /** Formats a character. */
+  iterator operator()(char_type value) {
+    format_specs &fmt_spec = this->spec();
+    if (fmt_spec.type_ && fmt_spec.type_ != 'c')
+      return (*this)(static_cast<int>(value));
+    fmt_spec.flags_ = 0;
+    fmt_spec.align_ = ALIGN_RIGHT;
+    return base::operator()(value);
+  }
+
+  /** Formats a null-terminated C string. */
+  iterator operator()(const char *value) {
+    if (value)
+      base::operator()(value);
+    else if (this->spec().type_ == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write("(null)");
+    return this->out();
+  }
+
+  /** Formats a null-terminated wide C string. */
+  iterator operator()(const wchar_t *value) {
+    if (value)
+      base::operator()(value);
+    else if (this->spec().type_ == 'p')
+      write_null_pointer(char_type());
+    else
+      this->write(L"(null)");
+    return this->out();
+  }
+
+  /** Formats a pointer. */
+  iterator operator()(const void *value) {
+    if (value)
+      return base::operator()(value);
+    this->spec().type_ = 0;
+    write_null_pointer(char_type());
+    return this->out();
+  }
+
+  /** Formats an argument of a custom (user-defined) type. */
+  iterator operator()(typename basic_format_arg<context_type>::handle handle) {
+    handle.format(context_);
+    return this->out();
+  }
 };
 
-/** The default printf argument formatter. */
-template<typename Char>
-class PrintfArgFormatter : public BasicPrintfArgFormatter<PrintfArgFormatter<Char>, Char, FormatSpec>
-{
-public:
-    /** Constructs an argument formatter object. */
-    PrintfArgFormatter(BasicWriter<Char> &w, FormatSpec &s)
-        : BasicPrintfArgFormatter<PrintfArgFormatter<Char>, Char, FormatSpec>(w, s)
-    {
-    }
+template <typename T>
+struct printf_formatter {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const T &value, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::format_value(internal::get_container(ctx.out()), value);
+    return ctx.out();
+  }
 };
 
 /** This template formats data and writes the output to a writer. */
-template<typename Char, typename ArgFormatter = PrintfArgFormatter<Char>>
-class PrintfFormatter : private internal::FormatterBase
-{
-private:
-    BasicWriter<Char> &writer_;
+template <typename OutputIt, typename Char, typename ArgFormatter>
+class basic_printf_context :
+  private internal::context_base<
+    OutputIt, basic_printf_context<OutputIt, Char, ArgFormatter>, Char> {
+ public:
+  /** The character type for the output. */
+  typedef Char char_type;
 
-    void parse_flags(FormatSpec &spec, const Char *&s);
+  template <typename T>
+  struct formatter_type { typedef printf_formatter<T> type; };
 
-    // Returns the argument with specified index or, if arg_index is equal
-    // to the maximum unsigned value, the next argument.
-    internal::Arg get_arg(const Char *s, unsigned arg_index = (std::numeric_limits<unsigned>::max)());
+ private:
+  typedef internal::context_base<OutputIt, basic_printf_context, Char> base;
+  typedef typename base::format_arg format_arg;
+  typedef basic_format_specs<char_type> format_specs;
+  typedef internal::null_terminating_iterator<char_type> iterator;
 
-    // Parses argument index, flags and width and returns the argument index.
-    unsigned parse_header(const Char *&s, FormatSpec &spec);
+  void parse_flags(format_specs &spec, iterator &it);
 
-public:
-    /**
-     \rst
-     Constructs a ``PrintfFormatter`` object. References to the arguments and
-     the writer are stored in the formatter object so make sure they have
-     appropriate lifetimes.
-     \endrst
-     */
-    explicit PrintfFormatter(const ArgList &al, BasicWriter<Char> &w)
-        : FormatterBase(al)
-        , writer_(w)
-    {
-    }
+  // Returns the argument with specified index or, if arg_index is equal
+  // to the maximum unsigned value, the next argument.
+  format_arg get_arg(
+      iterator it,
+      unsigned arg_index = (std::numeric_limits<unsigned>::max)());
 
-    /** Formats stored arguments and writes the output to the writer. */
-    void format(BasicCStringRef<Char> format_str);
+  // Parses argument index, flags and width and returns the argument index.
+  unsigned parse_header(iterator &it, format_specs &spec);
+
+ public:
+  /**
+   \rst
+   Constructs a ``printf_context`` object. References to the arguments and
+   the writer are stored in the context object so make sure they have
+   appropriate lifetimes.
+   \endrst
+   */
+  basic_printf_context(OutputIt out, basic_string_view<char_type> format_str,
+                       basic_format_args<basic_printf_context> args)
+    : base(out, format_str, args) {}
+
+  using base::parse_context;
+  using base::out;
+  using base::advance_to;
+
+  /** Formats stored arguments and writes the output to the range. */
+  void format();
 };
 
-template<typename Char, typename AF>
-void PrintfFormatter<Char, AF>::parse_flags(FormatSpec &spec, const Char *&s)
-{
-    for (;;)
-    {
-        switch (*s++)
-        {
-        case '-':
-            spec.align_ = ALIGN_LEFT;
-            break;
-        case '+':
-            spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
-            break;
-        case '0':
-            spec.fill_ = '0';
-            break;
-        case ' ':
-            spec.flags_ |= SIGN_FLAG;
-            break;
-        case '#':
-            spec.flags_ |= HASH_FLAG;
-            break;
-        default:
-            --s;
-            return;
-        }
+template <typename OutputIt, typename Char, typename AF>
+void basic_printf_context<OutputIt, Char, AF>::parse_flags(
+    format_specs &spec, iterator &it) {
+  for (;;) {
+    switch (*it++) {
+      case '-':
+        spec.align_ = ALIGN_LEFT;
+        break;
+      case '+':
+        spec.flags_ |= SIGN_FLAG | PLUS_FLAG;
+        break;
+      case '0':
+        spec.fill_ = '0';
+        break;
+      case ' ':
+        spec.flags_ |= SIGN_FLAG;
+        break;
+      case '#':
+        spec.flags_ |= HASH_FLAG;
+        break;
+      default:
+        --it;
+        return;
     }
+  }
 }
 
-template<typename Char, typename AF>
-internal::Arg PrintfFormatter<Char, AF>::get_arg(const Char *s, unsigned arg_index)
-{
-    (void)s;
-    const char *error = FMT_NULL;
-    internal::Arg arg = arg_index == std::numeric_limits<unsigned>::max() ? next_arg(error) : FormatterBase::get_arg(arg_index - 1, error);
-    if (error)
-        FMT_THROW(FormatError(!*s ? "invalid format string" : error));
-    return arg;
+template <typename OutputIt, typename Char, typename AF>
+typename basic_printf_context<OutputIt, Char, AF>::format_arg
+  basic_printf_context<OutputIt, Char, AF>::get_arg(
+    iterator it, unsigned arg_index) {
+  (void)it;
+  if (arg_index == std::numeric_limits<unsigned>::max())
+    return this->do_get_arg(this->parse_context().next_arg_id());
+  return base::get_arg(arg_index - 1);
 }
 
-template<typename Char, typename AF>
-unsigned PrintfFormatter<Char, AF>::parse_header(const Char *&s, FormatSpec &spec)
-{
-    unsigned arg_index = std::numeric_limits<unsigned>::max();
-    Char c = *s;
-    if (c >= '0' && c <= '9')
-    {
-        // Parse an argument index (if followed by '$') or a width possibly
-        // preceded with '0' flag(s).
-        unsigned value = internal::parse_nonnegative_int(s);
-        if (*s == '$') // value is an argument index
-        {
-            ++s;
-            arg_index = value;
-        }
-        else
-        {
-            if (c == '0')
-                spec.fill_ = '0';
-            if (value != 0)
-            {
-                // Nonzero value means that we parsed width and don't need to
-                // parse it or flags again, so return now.
-                spec.width_ = value;
-                return arg_index;
-            }
-        }
+template <typename OutputIt, typename Char, typename AF>
+unsigned basic_printf_context<OutputIt, Char, AF>::parse_header(
+  iterator &it, format_specs &spec) {
+  unsigned arg_index = std::numeric_limits<unsigned>::max();
+  char_type c = *it;
+  if (c >= '0' && c <= '9') {
+    // Parse an argument index (if followed by '$') or a width possibly
+    // preceded with '0' flag(s).
+    internal::error_handler eh;
+    unsigned value = parse_nonnegative_int(it, eh);
+    if (*it == '$') {  // value is an argument index
+      ++it;
+      arg_index = value;
+    } else {
+      if (c == '0')
+        spec.fill_ = '0';
+      if (value != 0) {
+        // Nonzero value means that we parsed width and don't need to
+        // parse it or flags again, so return now.
+        spec.width_ = value;
+        return arg_index;
+      }
     }
-    parse_flags(spec, s);
-    // Parse width.
-    if (*s >= '0' && *s <= '9')
-    {
-        spec.width_ = internal::parse_nonnegative_int(s);
+  }
+  parse_flags(spec, it);
+  // Parse width.
+  if (*it >= '0' && *it <= '9') {
+    internal::error_handler eh;
+    spec.width_ = parse_nonnegative_int(it, eh);
+  } else if (*it == '*') {
+    ++it;
+    spec.width_ =
+        visit(internal::printf_width_handler<char_type>(spec), get_arg(it));
+  }
+  return arg_index;
+}
+
+template <typename OutputIt, typename Char, typename AF>
+void basic_printf_context<OutputIt, Char, AF>::format() {
+  auto &buffer = internal::get_container(this->out());
+  auto start = iterator(this->parse_context());
+  auto it = start;
+  using internal::pointer_from;
+  while (*it) {
+    char_type c = *it++;
+    if (c != '%') continue;
+    if (*it == c) {
+      buffer.append(pointer_from(start), pointer_from(it));
+      start = ++it;
+      continue;
     }
-    else if (*s == '*')
-    {
-        ++s;
-        spec.width_ = internal::WidthHandler(spec).visit(get_arg(s));
+    buffer.append(pointer_from(start), pointer_from(it) - 1);
+
+    format_specs spec;
+    spec.align_ = ALIGN_RIGHT;
+
+    // Parse argument index, flags and width.
+    unsigned arg_index = parse_header(it, spec);
+
+    // Parse precision.
+    if (*it == '.') {
+      ++it;
+      if ('0' <= *it && *it <= '9') {
+        internal::error_handler eh;
+        spec.precision_ = static_cast<int>(parse_nonnegative_int(it, eh));
+      } else if (*it == '*') {
+        ++it;
+        spec.precision_ =
+            visit(internal::printf_precision_handler(), get_arg(it));
+      } else {
+        spec.precision_ = 0;
+      }
     }
-    return arg_index;
-}
 
-template<typename Char, typename AF>
-void PrintfFormatter<Char, AF>::format(BasicCStringRef<Char> format_str)
-{
-    const Char *start = format_str.c_str();
-    const Char *s = start;
-    while (*s)
-    {
-        Char c = *s++;
-        if (c != '%')
-            continue;
-        if (*s == c)
-        {
-            write(writer_, start, s);
-            start = ++s;
-            continue;
-        }
-        write(writer_, start, s - 1);
-
-        FormatSpec spec;
-        spec.align_ = ALIGN_RIGHT;
-
-        // Parse argument index, flags and width.
-        unsigned arg_index = parse_header(s, spec);
-
-        // Parse precision.
-        if (*s == '.')
-        {
-            ++s;
-            if ('0' <= *s && *s <= '9')
-            {
-                spec.precision_ = static_cast<int>(internal::parse_nonnegative_int(s));
-            }
-            else if (*s == '*')
-            {
-                ++s;
-                spec.precision_ = internal::PrecisionHandler().visit(get_arg(s));
-            }
-            else
-            {
-                spec.precision_ = 0;
-            }
-        }
-
-        using internal::Arg;
-        Arg arg = get_arg(s, arg_index);
-        if (spec.flag(HASH_FLAG) && internal::IsZeroInt().visit(arg))
-            spec.flags_ &= ~internal::to_unsigned<int>(HASH_FLAG);
-        if (spec.fill_ == '0')
-        {
-            if (arg.type <= Arg::LAST_NUMERIC_TYPE)
-                spec.align_ = ALIGN_NUMERIC;
-            else
-                spec.fill_ = ' '; // Ignore '0' flag for non-numeric types.
-        }
-
-        // Parse length and convert the argument to the required type.
-        using internal::ArgConverter;
-        switch (*s++)
-        {
-        case 'h':
-            if (*s == 'h')
-                ArgConverter<signed char>(arg, *++s).visit(arg);
-            else
-                ArgConverter<short>(arg, *s).visit(arg);
-            break;
-        case 'l':
-            if (*s == 'l')
-                ArgConverter<fmt::LongLong>(arg, *++s).visit(arg);
-            else
-                ArgConverter<long>(arg, *s).visit(arg);
-            break;
-        case 'j':
-            ArgConverter<intmax_t>(arg, *s).visit(arg);
-            break;
-        case 'z':
-            ArgConverter<std::size_t>(arg, *s).visit(arg);
-            break;
-        case 't':
-            ArgConverter<std::ptrdiff_t>(arg, *s).visit(arg);
-            break;
-        case 'L':
-            // printf produces garbage when 'L' is omitted for long double, no
-            // need to do the same.
-            break;
-        default:
-            --s;
-            ArgConverter<void>(arg, *s).visit(arg);
-        }
-
-        // Parse type.
-        if (!*s)
-            FMT_THROW(FormatError("invalid format string"));
-        spec.type_ = static_cast<char>(*s++);
-
-        if (spec.type_ == 's')
-        {
-            // set the format type to the default if 's' is specified
-            spec.type_ = internal::DefaultType().visit(arg);
-        }
-
-        if (arg.type <= Arg::LAST_INTEGER_TYPE)
-        {
-            // Normalize type.
-            switch (spec.type_)
-            {
-            case 'i':
-            case 'u':
-                spec.type_ = 'd';
-                break;
-            case 'c':
-                // TODO: handle wchar_t
-                internal::CharConverter(arg).visit(arg);
-                break;
-            }
-        }
-
-        start = s;
-
-        // Format argument.
-        AF(writer_, spec).visit(arg);
+    format_arg arg = get_arg(it, arg_index);
+    if (spec.flag(HASH_FLAG) && visit(internal::is_zero_int(), arg))
+      spec.flags_ &= ~internal::to_unsigned<int>(HASH_FLAG);
+    if (spec.fill_ == '0') {
+      if (arg.is_arithmetic())
+        spec.align_ = ALIGN_NUMERIC;
+      else
+        spec.fill_ = ' ';  // Ignore '0' flag for non-numeric types.
     }
-    write(writer_, start, s);
+
+    // Parse length and convert the argument to the required type.
+    using internal::convert_arg;
+    switch (*it++) {
+    case 'h':
+      if (*it == 'h')
+        convert_arg<signed char>(arg, *++it);
+      else
+        convert_arg<short>(arg, *it);
+      break;
+    case 'l':
+      if (*it == 'l')
+        convert_arg<long long>(arg, *++it);
+      else
+        convert_arg<long>(arg, *it);
+      break;
+    case 'j':
+      convert_arg<intmax_t>(arg, *it);
+      break;
+    case 'z':
+      convert_arg<std::size_t>(arg, *it);
+      break;
+    case 't':
+      convert_arg<std::ptrdiff_t>(arg, *it);
+      break;
+    case 'L':
+      // printf produces garbage when 'L' is omitted for long double, no
+      // need to do the same.
+      break;
+    default:
+      --it;
+      convert_arg<void>(arg, *it);
+    }
+
+    // Parse type.
+    if (!*it)
+      FMT_THROW(format_error("invalid format string"));
+    spec.type_ = static_cast<char>(*it++);
+    if (arg.is_integral()) {
+      // Normalize type.
+      switch (spec.type_) {
+      case 'i': case 'u':
+        spec.type_ = 'd';
+        break;
+      case 'c':
+        // TODO: handle wchar_t better?
+        visit(internal::char_converter<basic_printf_context>(arg), arg);
+        break;
+      }
+    }
+
+    start = it;
+
+    // Format argument.
+    visit(AF(buffer, spec, *this), arg);
+  }
+  buffer.append(pointer_from(start), pointer_from(it));
 }
 
-inline void printf(Writer &w, CStringRef format, ArgList args)
-{
-    PrintfFormatter<char>(args, w).format(format);
+template <typename Char, typename Context>
+void printf(internal::basic_buffer<Char> &buf, basic_string_view<Char> format,
+            basic_format_args<Context> args) {
+  Context(std::back_inserter(buf), format, args).format();
 }
-FMT_VARIADIC(void, printf, Writer &, CStringRef)
 
-inline void printf(WWriter &w, WCStringRef format, ArgList args)
-{
-    PrintfFormatter<wchar_t>(args, w).format(format);
+template <typename Buffer>
+struct printf_context {
+  typedef basic_printf_context<
+    std::back_insert_iterator<Buffer>, typename Buffer::value_type> type;
+};
+
+template <typename ...Args>
+inline format_arg_store<printf_context<internal::buffer>::type, Args...>
+    make_printf_args(const Args & ... args) {
+  return format_arg_store<printf_context<internal::buffer>::type, Args...>(
+      args...);
 }
-FMT_VARIADIC(void, printf, WWriter &, WCStringRef)
+typedef basic_format_args<printf_context<internal::buffer>::type> printf_args;
+typedef basic_format_args<printf_context<internal::wbuffer>::type> wprintf_args;
+
+inline std::string vsprintf(string_view format, printf_args args) {
+  memory_buffer buffer;
+  printf(buffer, format, args);
+  return to_string(buffer);
+}
 
 /**
   \rst
@@ -654,21 +587,34 @@ FMT_VARIADIC(void, printf, WWriter &, WCStringRef)
     std::string message = fmt::sprintf("The answer is %d", 42);
   \endrst
 */
-inline std::string sprintf(CStringRef format, ArgList args)
-{
-    MemoryWriter w;
-    printf(w, format, args);
-    return w.str();
+template <typename... Args>
+inline std::string sprintf(string_view format_str, const Args & ... args) {
+  return vsprintf(format_str,
+    make_format_args<typename printf_context<internal::buffer>::type>(args...));
 }
-FMT_VARIADIC(std::string, sprintf, CStringRef)
 
-inline std::wstring sprintf(WCStringRef format, ArgList args)
-{
-    WMemoryWriter w;
-    printf(w, format, args);
-    return w.str();
+inline std::wstring vsprintf(wstring_view format, wprintf_args args) {
+  wmemory_buffer buffer;
+  printf(buffer, format, args);
+  return to_string(buffer);
 }
-FMT_VARIADIC_W(std::wstring, sprintf, WCStringRef)
+
+template <typename... Args>
+inline std::wstring sprintf(wstring_view format_str, const Args & ... args) {
+  return vsprintf(format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+template <typename Char>
+inline int vfprintf(std::FILE *f, basic_string_view<Char> format,
+                    basic_format_args<typename printf_context<
+                      internal::basic_buffer<Char>>::type> args) {
+  basic_memory_buffer<Char> buffer;
+  printf(buffer, format, args);
+  std::size_t size = buffer.size();
+  return std::fwrite(
+    buffer.data(), sizeof(Char), size, f) < size ? -1 : static_cast<int>(size);
+}
 
 /**
   \rst
@@ -679,8 +625,27 @@ FMT_VARIADIC_W(std::wstring, sprintf, WCStringRef)
     fmt::fprintf(stderr, "Don't %s!", "panic");
   \endrst
  */
-FMT_API int fprintf(std::FILE *f, CStringRef format, ArgList args);
-FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
+template <typename... Args>
+inline int fprintf(std::FILE *f, string_view format_str, const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf<char>(f, format_str, vargs);
+}
+
+template <typename... Args>
+inline int fprintf(std::FILE *f, wstring_view format_str,
+                   const Args & ... args) {
+  return vfprintf(f, format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+inline int vprintf(string_view format, printf_args args) {
+  return vfprintf(stdout, format, args);
+}
+
+inline int vprintf(wstring_view format, wprintf_args args) {
+  return vfprintf(stdout, format, args);
+}
 
 /**
   \rst
@@ -691,11 +656,33 @@ FMT_VARIADIC(int, fprintf, std::FILE *, CStringRef)
     fmt::printf("Elapsed time: %.2f seconds", 1.23);
   \endrst
  */
-inline int printf(CStringRef format, ArgList args)
-{
-    return fprintf(stdout, format, args);
+template <typename... Args>
+inline int printf(string_view format_str, const Args & ... args) {
+  return vprintf(format_str,
+    make_format_args<typename printf_context<internal::buffer>::type>(args...));
 }
-FMT_VARIADIC(int, printf, CStringRef)
+
+template <typename... Args>
+inline int printf(wstring_view format_str, const Args & ... args) {
+  return vprintf(format_str,
+    make_format_args<typename printf_context<internal::wbuffer>::type>(args...));
+}
+
+inline int vfprintf(std::ostream &os, string_view format_str,
+                    printf_args args) {
+  memory_buffer buffer;
+  printf(buffer, format_str, args);
+  internal::write(os, buffer);
+  return static_cast<int>(buffer.size());
+}
+
+inline int vfprintf(std::wostream &os, wstring_view format_str,
+                    wprintf_args args) {
+  wmemory_buffer buffer;
+  printf(buffer, format_str, args);
+  internal::write(os, buffer);
+  return static_cast<int>(buffer.size());
+}
 
 /**
   \rst
@@ -703,21 +690,24 @@ FMT_VARIADIC(int, printf, CStringRef)
 
   **Example**::
 
-    fprintf(cerr, "Don't %s!", "panic");
+    fmt::fprintf(cerr, "Don't %s!", "panic");
   \endrst
  */
-inline int fprintf(std::ostream &os, CStringRef format_str, ArgList args)
-{
-    MemoryWriter w;
-    printf(w, format_str, args);
-    internal::write(os, w);
-    return static_cast<int>(w.size());
+template <typename... Args>
+inline int fprintf(std::ostream &os, string_view format_str,
+                   const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf(os, format_str, vargs);
 }
-FMT_VARIADIC(int, fprintf, std::ostream &, CStringRef)
-} // namespace fmt
 
-#ifdef FMT_HEADER_ONLY
-#include "printf.cc"
-#endif
+template <typename... Args>
+inline int fprintf(std::wostream &os, wstring_view format_str,
+                   const Args & ... args) {
+  auto vargs = make_format_args<
+    typename printf_context<internal::buffer>::type>(args...);
+  return vfprintf(os, format_str, vargs);
+}
+FMT_END_NAMESPACE
 
-#endif // FMT_PRINTF_H_
+#endif  // FMT_PRINTF_H_

--- a/include/spdlog/fmt/bundled/ranges.h
+++ b/include/spdlog/fmt/bundled/ranges.h
@@ -1,0 +1,243 @@
+// Formatting library for C++ - the core API
+//
+// Copyright (c) 2012 - present, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
+//
+// Copyright (c) 2018 - present, Remotion (Igor Schulz)
+// All Rights Reserved
+// {fmt} support for ranges, containers and types tuple interface.
+
+#ifndef FMT_RANGES_H_
+#define FMT_RANGES_H_
+
+#include "format.h"
+#include <type_traits>
+
+// output only up to N items from the range.
+#ifndef FMT_RANGE_OUTPUT_LENGTH_LIMIT
+# define FMT_RANGE_OUTPUT_LENGTH_LIMIT 256
+#endif
+
+FMT_BEGIN_NAMESPACE
+
+template <typename Char>
+struct formatting_base {
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+};
+
+template <typename Char, typename Enable = void>
+struct formatting_range : formatting_base<Char> {
+  static FMT_CONSTEXPR_DECL const std::size_t range_length_limit =
+      FMT_RANGE_OUTPUT_LENGTH_LIMIT; // output only up to N items from the range.
+  Char prefix;
+  Char delimiter;
+  Char postfix;
+  formatting_range() : prefix('{'), delimiter(','), postfix('}') {}
+  static FMT_CONSTEXPR_DECL const bool add_delimiter_spaces = true;
+  static FMT_CONSTEXPR_DECL const bool add_prepostfix_space = false;
+};
+
+template <typename Char, typename Enable = void>
+struct formatting_tuple : formatting_base<Char> {
+  Char prefix;
+  Char delimiter;
+  Char postfix;
+  formatting_tuple() : prefix('('), delimiter(','), postfix(')') {}
+  static FMT_CONSTEXPR_DECL const bool add_delimiter_spaces = true;
+  static FMT_CONSTEXPR_DECL const bool add_prepostfix_space = false;
+};
+
+namespace internal {
+
+template <typename RangeT, typename OutputIterator>
+void copy(const RangeT &range, OutputIterator out) {
+  for (auto it = range.begin(), end = range.end(); it != end; ++it)
+    *out++ = *it;
+}
+
+template <typename OutputIterator>
+void copy(const char *str, OutputIterator out) {
+  const char *p_curr = str;
+  while (*p_curr) {
+    *out++ = *p_curr++;
+  }
+}
+
+template <typename OutputIterator>
+void copy(char ch, OutputIterator out) {
+  *out++ = ch;
+}
+
+/// Return true value if T has std::string interface, like std::string_view.
+template <typename T>
+class is_like_std_string {
+  template <typename U>
+  static auto check(U *p) ->
+    decltype(p->find('a'), p->length(), p->data(), int());
+  template <typename>
+  static void check(...);
+
+ public:
+  static FMT_CONSTEXPR_DECL const bool value =
+    !std::is_void<decltype(check<T>(FMT_NULL))>::value;
+};
+
+template <typename... Ts>
+struct conditional_helper {};
+
+template <typename T, typename _ = void>
+struct is_range_ : std::false_type {};
+
+template <typename T>
+struct is_range_<T,typename std::conditional<
+                   false,
+                   conditional_helper<decltype(internal::declval<T>().begin()),
+                                      decltype(internal::declval<T>().end())>,
+                   void>::type> : std::true_type {};
+
+template <typename T>
+struct is_range {
+  static FMT_CONSTEXPR_DECL const bool value =
+    is_range_<T>::value && !is_like_std_string<T>::value;
+};
+
+/// tuple_size and tuple_element check.
+template <typename T>
+class is_tuple_like_ {
+  template <typename U>
+  static auto check(U *p) ->
+    decltype(std::tuple_size<U>::value,
+      internal::declval<typename std::tuple_element<0, U>::type>(), int());
+  template <typename>
+  static void check(...);
+
+ public:
+  static FMT_CONSTEXPR_DECL const bool value =
+    !std::is_void<decltype(check<T>(FMT_NULL))>::value;
+};
+
+template <typename T>
+struct is_tuple_like {
+  static FMT_CONSTEXPR_DECL const bool value =
+    is_tuple_like_<T>::value && !is_range_<T>::value;
+};
+}  // namespace internal
+
+#if FMT_HAS_FEATURE(__cpp_lib_integer_sequence) || FMT_MSC_VER >= 1900
+# define FMT_USE_INTEGER_SEQUENCE 1
+#else
+# define FMT_USE_INTEGER_SEQUENCE 0
+#endif
+
+#if FMT_USE_INTEGER_SEQUENCE
+namespace internal {
+template <size_t... Is, class Tuple, class F>
+void for_each(std::index_sequence<Is...>, Tuple &&tup, F &&f) noexcept {
+  using std::get;
+  // using free function get<I>(T) now.
+  const int _[] = {0, ((void)f(get<Is>(tup)), 0)...};
+  (void)_;  // blocks warnings
+}
+
+template <class T>
+FMT_CONSTEXPR std::make_index_sequence<std::tuple_size<T>::value> 
+get_indexes(T const &) { return {}; }
+
+template <class Tuple, class F>
+void for_each(Tuple &&tup, F &&f) {
+  const auto indexes = get_indexes(tup);
+  for_each(indexes, std::forward<Tuple>(tup), std::forward<F>(f));
+}
+}  // namespace internal
+
+template <typename TupleT, typename Char>
+struct formatter<TupleT, Char, 
+    typename std::enable_if<fmt::internal::is_tuple_like<TupleT>::value>::type> {
+
+  fmt::formatting_tuple<Char> formatting;
+
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return formatting.parse(ctx);
+  }
+
+  template <typename FormatContext = format_context>
+  auto format(const TupleT &values, FormatContext &ctx) -> decltype(ctx.out()) {
+    auto out = ctx.out();
+    std::size_t i = 0;
+    internal::copy(formatting.prefix, out);
+    internal::for_each(values, [&](const auto &v) {
+      if (i > 0) {
+        if (formatting.add_prepostfix_space) {
+          *out++ = ' ';
+        }
+        internal::copy(formatting.delimiter, out);
+      }
+      if (formatting.add_delimiter_spaces && i > 0) {
+        format_to(out, " {}", v);
+      } else {
+        format_to(out, "{}", v);
+      }
+      ++i;
+    });
+    if (formatting.add_prepostfix_space) {
+      *out++ = ' ';
+    }
+    internal::copy(formatting.postfix, out);
+
+    return ctx.out();
+  }
+};
+#endif  // FMT_USE_INTEGER_SEQUENCE
+
+template <typename RangeT, typename Char>
+struct formatter< RangeT, Char,
+    typename std::enable_if<fmt::internal::is_range<RangeT>::value>::type> {
+
+  fmt::formatting_range<Char> formatting;
+
+  template <typename ParseContext>
+  FMT_CONSTEXPR auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    return formatting.parse(ctx);
+  }
+
+  template <typename FormatContext>
+  typename FormatContext::iterator format(
+      const RangeT &values, FormatContext &ctx) {
+    auto out = ctx.out();
+    internal::copy(formatting.prefix, out);
+    std::size_t i = 0;
+    for (auto it = values.begin(), end = values.end(); it != end; ++it) {
+      if (i > 0) {
+        if (formatting.add_prepostfix_space) {
+          *out++ = ' ';
+        }
+        internal::copy(formatting.delimiter, out);
+      }
+      if (formatting.add_delimiter_spaces && i > 0) {
+        format_to(out, " {}", *it);
+      } else {
+        format_to(out, "{}", *it);
+      }
+      if (++i > formatting.range_length_limit) {
+        format_to(out, " ... <other elements>");
+        break;
+      }
+    }
+    if (formatting.add_prepostfix_space) {
+      *out++ = ' ';
+    }
+    internal::copy(formatting.postfix, out);
+    return ctx.out();
+  }
+};
+
+FMT_END_NAMESPACE
+
+#endif // FMT_RANGES_H_
+

--- a/include/spdlog/fmt/bundled/time.h
+++ b/include/spdlog/fmt/bundled/time.h
@@ -1,11 +1,9 @@
-/*
- Formatting library for C++ - time formatting
-
- Copyright (c) 2012 - 2016, Victor Zverovich
- All rights reserved.
-
- For the license information refer to format.h.
- */
+// Formatting library for C++ - time formatting
+//
+// Copyright (c) 2012 - 2016, Victor Zverovich
+// All rights reserved.
+//
+// For the license information refer to format.h.
 
 #ifndef FMT_TIME_H_
 #define FMT_TIME_H_
@@ -13,176 +11,144 @@
 #include "format.h"
 #include <ctime>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4702) // unreachable code
-#pragma warning(disable : 4996) // "deprecated" functions
-#endif
+FMT_BEGIN_NAMESPACE
 
-namespace fmt {
-template<typename ArgFormatter>
-void format_arg(BasicFormatter<char, ArgFormatter> &f, const char *&format_str, const std::tm &tm)
-{
-    if (*format_str == ':')
-        ++format_str;
-    const char *end = format_str;
-    while (*end && *end != '}')
-        ++end;
-    if (*end != '}')
-        FMT_THROW(FormatError("missing '}' in format string"));
-    internal::MemoryBuffer<char, internal::INLINE_BUFFER_SIZE> format;
-    format.append(format_str, end + 1);
-    format[format.size() - 1] = '\0';
-    Buffer<char> &buffer = f.writer().buffer();
-    std::size_t start = buffer.size();
-    for (;;)
-    {
-        std::size_t size = buffer.capacity() - start;
-        std::size_t count = std::strftime(&buffer[start], size, &format[0], &tm);
-        if (count != 0)
-        {
-            buffer.resize(start + count);
-            break;
-        }
-        if (size >= format.size() * 256)
-        {
-            // If the buffer is 256 times larger than the format string, assume
-            // that `strftime` gives an empty result. There doesn't seem to be a
-            // better way to distinguish the two cases:
-            // https://github.com/fmtlib/fmt/issues/367
-            break;
-        }
-        const std::size_t MIN_GROWTH = 10;
-        buffer.reserve(buffer.capacity() + (size > MIN_GROWTH ? size : MIN_GROWTH));
-    }
-    format_str = end + 1;
+namespace internal{
+inline null<> localtime_r(...) { return null<>(); }
+inline null<> localtime_s(...) { return null<>(); }
+inline null<> gmtime_r(...) { return null<>(); }
+inline null<> gmtime_s(...) { return null<>(); }
 }
-
-namespace internal {
-inline Null<> localtime_r(...)
-{
-    return Null<>();
-}
-inline Null<> localtime_s(...)
-{
-    return Null<>();
-}
-inline Null<> gmtime_r(...)
-{
-    return Null<>();
-}
-inline Null<> gmtime_s(...)
-{
-    return Null<>();
-}
-} // namespace internal
 
 // Thread-safe replacement for std::localtime
-inline std::tm localtime(std::time_t time)
-{
-    struct LocalTime
-    {
-        std::time_t time_;
-        std::tm tm_;
+inline std::tm localtime(std::time_t time) {
+  struct dispatcher {
+    std::time_t time_;
+    std::tm tm_;
 
-        LocalTime(std::time_t t)
-            : time_(t)
-        {
-        }
+    dispatcher(std::time_t t): time_(t) {}
 
-        bool run()
-        {
-            using namespace fmt::internal;
-            return handle(localtime_r(&time_, &tm_));
-        }
+    bool run() {
+      using namespace fmt::internal;
+      return handle(localtime_r(&time_, &tm_));
+    }
 
-        bool handle(std::tm *tm)
-        {
-            return tm != FMT_NULL;
-        }
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
 
-        bool handle(internal::Null<>)
-        {
-            using namespace fmt::internal;
-            return fallback(localtime_s(&tm_, &time_));
-        }
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(localtime_s(&tm_, &time_));
+    }
 
-        bool fallback(int res)
-        {
-            return res == 0;
-        }
+    bool fallback(int res) { return res == 0; }
 
-        bool fallback(internal::Null<>)
-        {
-            using namespace fmt::internal;
-            std::tm *tm = std::localtime(&time_);
-            if (tm)
-                tm_ = *tm;
-            return tm != FMT_NULL;
-        }
-    };
-    LocalTime lt(time);
-    if (lt.run())
-        return lt.tm_;
-    // Too big time values may be unsupported.
-    FMT_THROW(fmt::FormatError("time_t value out of range"));
-    return std::tm();
+    bool fallback(internal::null<>) {
+      using namespace fmt::internal;
+      std::tm *tm = std::localtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  dispatcher lt(time);
+  if (lt.run())
+    return lt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(format_error("time_t value out of range"));
+  return std::tm();
 }
 
 // Thread-safe replacement for std::gmtime
-inline std::tm gmtime(std::time_t time)
-{
-    struct GMTime
-    {
-        std::time_t time_;
-        std::tm tm_;
+inline std::tm gmtime(std::time_t time) {
+  struct dispatcher {
+    std::time_t time_;
+    std::tm tm_;
 
-        GMTime(std::time_t t)
-            : time_(t)
-        {
-        }
+    dispatcher(std::time_t t): time_(t) {}
 
-        bool run()
-        {
-            using namespace fmt::internal;
-            return handle(gmtime_r(&time_, &tm_));
-        }
+    bool run() {
+      using namespace fmt::internal;
+      return handle(gmtime_r(&time_, &tm_));
+    }
 
-        bool handle(std::tm *tm)
-        {
-            return tm != FMT_NULL;
-        }
+    bool handle(std::tm *tm) { return tm != FMT_NULL; }
 
-        bool handle(internal::Null<>)
-        {
-            using namespace fmt::internal;
-            return fallback(gmtime_s(&tm_, &time_));
-        }
+    bool handle(internal::null<>) {
+      using namespace fmt::internal;
+      return fallback(gmtime_s(&tm_, &time_));
+    }
 
-        bool fallback(int res)
-        {
-            return res == 0;
-        }
+    bool fallback(int res) { return res == 0; }
 
-        bool fallback(internal::Null<>)
-        {
-            std::tm *tm = std::gmtime(&time_);
-            if (tm != FMT_NULL)
-                tm_ = *tm;
-            return tm != FMT_NULL;
-        }
-    };
-    GMTime gt(time);
-    if (gt.run())
-        return gt.tm_;
-    // Too big time values may be unsupported.
-    FMT_THROW(fmt::FormatError("time_t value out of range"));
-    return std::tm();
+    bool fallback(internal::null<>) {
+      std::tm *tm = std::gmtime(&time_);
+      if (tm) tm_ = *tm;
+      return tm != FMT_NULL;
+    }
+  };
+  dispatcher gt(time);
+  if (gt.run())
+    return gt.tm_;
+  // Too big time values may be unsupported.
+  FMT_THROW(format_error("time_t value out of range"));
+  return std::tm();
 }
-} // namespace fmt
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+namespace internal {
+inline std::size_t strftime(char *str, std::size_t count, const char *format,
+                            const std::tm *time) {
+  return std::strftime(str, count, format, time);
+}
 
-#endif // FMT_TIME_H_
+inline std::size_t strftime(wchar_t *str, std::size_t count,
+                            const wchar_t *format, const std::tm *time) {
+  return std::wcsftime(str, count, format, time);
+}
+}
+
+template <typename Char>
+struct formatter<std::tm, Char> {
+  template <typename ParseContext>
+  auto parse(ParseContext &ctx) -> decltype(ctx.begin()) {
+    auto it = internal::null_terminating_iterator<Char>(ctx);
+    if (*it == ':')
+      ++it;
+    auto end = it;
+    while (*end && *end != '}')
+      ++end;
+    tm_format.reserve(end - it + 1);
+    using internal::pointer_from;
+    tm_format.append(pointer_from(it), pointer_from(end));
+    tm_format.push_back('\0');
+    return pointer_from(end);
+  }
+
+  template <typename FormatContext>
+  auto format(const std::tm &tm, FormatContext &ctx) -> decltype(ctx.out()) {
+    internal::basic_buffer<Char> &buf = internal::get_container(ctx.out());
+    std::size_t start = buf.size();
+    for (;;) {
+      std::size_t size = buf.capacity() - start;
+      std::size_t count =
+        internal::strftime(&buf[start], size, &tm_format[0], &tm);
+      if (count != 0) {
+        buf.resize(start + count);
+        break;
+      }
+      if (size >= tm_format.size() * 256) {
+        // If the buffer is 256 times larger than the format string, assume
+        // that `strftime` gives an empty result. There doesn't seem to be a
+        // better way to distinguish the two cases:
+        // https://github.com/fmtlib/fmt/issues/367
+        break;
+      }
+      const std::size_t MIN_GROWTH = 10;
+      buf.reserve(buf.capacity() + (size > MIN_GROWTH ? size : MIN_GROWTH));
+    }
+    return ctx.out();
+  }
+
+  basic_memory_buffer<Char> tm_format;
+};
+FMT_END_NAMESPACE
+
+#endif  // FMT_TIME_H_

--- a/include/spdlog/sinks/file_sinks.h
+++ b/include/spdlog/sinks/file_sinks.h
@@ -81,18 +81,18 @@ public:
     // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
     static filename_t calc_filename(const filename_t &filename, std::size_t index)
     {
-        typename std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
+        typename std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::memory_buffer, fmt::wmemory_buffer>::type w;
         if (index != 0u)
         {
             filename_t basename, ext;
             std::tie(basename, ext) = details::file_helper::split_by_extenstion(filename);
-            w.write(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
+            fmt::format_to(w, SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
         }
         else
         {
-            w.write(SPDLOG_FILENAME_T("{}"), filename);
+            fmt::format_to(w, SPDLOG_FILENAME_T("{}"), filename);
         }
-        return w.str();
+        return fmt::to_string(w);
     }
 
 protected:
@@ -163,10 +163,13 @@ struct default_daily_file_name_calculator
         std::tm tm = spdlog::details::os::localtime();
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extenstion(filename);
-        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
-        w.write(SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}_{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+
+        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::memory_buffer, fmt::wmemory_buffer>::type w;
+        fmt::format_to(
+            w,
+            SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}_{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
             tm.tm_hour, tm.tm_min, ext);
-        return w.str();
+        return fmt::to_string(w);
     }
 };
 
@@ -181,9 +184,9 @@ struct dateonly_daily_file_name_calculator
         std::tm tm = spdlog::details::os::localtime();
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extenstion(filename);
-        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::MemoryWriter, fmt::WMemoryWriter>::type w;
-        w.write(SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, ext);
-        return w.str();
+        std::conditional<std::is_same<filename_t::value_type, char>::value, fmt::memory_buffer, fmt::wmemory_buffer>::type w;
+        fmt::format_to(w, SPDLOG_FILENAME_T("{}_{:04d}-{:02d}-{:02d}{}"), basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, ext);
+        return fmt::to_string(w);
     }
 };
 

--- a/tests/file_helper.cpp
+++ b/tests/file_helper.cpp
@@ -11,7 +11,7 @@ static const std::string target_filename = "logs/file_helper_test.txt";
 static void write_with_helper(file_helper &helper, size_t howmany)
 {
     log_msg msg;
-    msg.formatted << std::string(howmany, '1');
+    fmt::format_to(msg.formatted, std::string(howmany, '1'));
     helper.write(msg);
     helper.flush();
 }

--- a/tests/file_log.cpp
+++ b/tests/file_log.cpp
@@ -99,8 +99,8 @@ TEST_CASE("daily_logger", "[daily_logger]]")
     // calculate filename (time based)
     std::string basename = "logs/daily_log";
     std::tm tm = spdlog::details::os::localtime();
-    fmt::MemoryWriter w;
-    w.write("{}_{:04d}-{:02d}-{:02d}_{:02d}-{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min);
+    fmt::memory_buffer w;
+    fmt::format_to(w, "{}_{:04d}-{:02d}-{:02d}_{:02d}-{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min);
 
     auto logger = spdlog::daily_logger_mt("logger", basename, 0, 0);
     logger->flush_on(spdlog::level::info);
@@ -113,7 +113,7 @@ TEST_CASE("daily_logger", "[daily_logger]]")
 #endif
     }
 
-    auto filename = w.str();
+    auto filename = fmt::to_string(w);
     REQUIRE(count_lines(filename) == 10);
 }
 
@@ -125,8 +125,8 @@ TEST_CASE("daily_logger with dateonly calculator", "[daily_logger_dateonly]]")
     // calculate filename (time based)
     std::string basename = "logs/daily_dateonly";
     std::tm tm = spdlog::details::os::localtime();
-    fmt::MemoryWriter w;
-    w.write("{}_{:04d}-{:02d}-{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
+    fmt::memory_buffer w;
+    fmt::format_to(w, "{}_{:04d}-{:02d}-{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
 
     auto logger = spdlog::create<sink_type>("logger", basename, 0, 0);
     for (int i = 0; i < 10; ++i)
@@ -138,7 +138,7 @@ TEST_CASE("daily_logger with dateonly calculator", "[daily_logger_dateonly]]")
 #endif
     }
     logger->flush();
-    auto filename = w.str();
+    auto filename = fmt::to_string(w);
     REQUIRE(count_lines(filename) == 10);
 }
 
@@ -147,9 +147,9 @@ struct custom_daily_file_name_calculator
     static spdlog::filename_t calc_filename(const spdlog::filename_t &basename)
     {
         std::tm tm = spdlog::details::os::localtime();
-        fmt::MemoryWriter w;
-        w.write("{}{:04d}{:02d}{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
-        return w.str();
+        fmt::memory_buffer w;
+        fmt::format_to(w, "{}{:04d}{:02d}{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
+        return fmt::to_string(w);
     }
 };
 
@@ -161,8 +161,8 @@ TEST_CASE("daily_logger with custom calculator", "[daily_logger_custom]]")
     // calculate filename (time based)
     std::string basename = "logs/daily_dateonly";
     std::tm tm = spdlog::details::os::localtime();
-    fmt::MemoryWriter w;
-    w.write("{}{:04d}{:02d}{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
+    fmt::memory_buffer w;
+    fmt::format_to(w, "{}{:04d}{:02d}{:02d}", basename, tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday);
 
     auto logger = spdlog::create<sink_type>("logger", basename, 0, 0);
     for (int i = 0; i < 10; ++i)
@@ -175,7 +175,7 @@ TEST_CASE("daily_logger with custom calculator", "[daily_logger_custom]]")
     }
 
     logger->flush();
-    auto filename = w.str();
+    auto filename = fmt::to_string(w);
     REQUIRE(count_lines(filename) == 10);
 }
 

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -68,7 +68,7 @@ TEST_CASE("color range test1", "[pattern_formatter]")
 {
     auto formatter = std::make_shared<spdlog::pattern_formatter>("%^%v%$", spdlog::pattern_time_type::local, "\n");
     spdlog::details::log_msg msg;
-    msg.raw << "Hello";
+    fmt::format_to(msg.raw, "Hello");
     formatter->format(msg);
     REQUIRE(msg.color_range_start == 0);
     REQUIRE(msg.color_range_end == 5);
@@ -98,7 +98,7 @@ TEST_CASE("color range test4", "[pattern_formatter]")
 {
     auto formatter = std::make_shared<spdlog::pattern_formatter>("XX%^YYY%$", spdlog::pattern_time_type::local, "\n");
     spdlog::details::log_msg msg;
-    msg.raw << "ignored";
+    fmt::format_to(msg.raw, "ignored");
     formatter->format(msg);
     REQUIRE(msg.color_range_start == 2);
     REQUIRE(msg.color_range_end == 5);


### PR DESCRIPTION
I won't actually actively recommend merging this (though I certainly won't recommend *against* merging it), but it does pass the tests.

Some notes:

-  I couldn't run the benchmarks because glog wouldn't run, so I don't know how this affects performance. fmt v5 claims performance improvements, so it should improve it, but I have no numbers to back this up whatsoever.
- This does pass the mostly-unmodified tests (they were only modified in a handful of cases where the tests were using fmt directly, and I believe it was to create fixtures rather than as an actual part of spdlog), but I haven't tried to actually merge this into any real project.
- I basically took the quickest route to getting the tests to pass in most cases. This includes writing a somewhat hacky `operator<<` to avoid rewriting many lines in `pattern_formatter_impl.h`. While I don't think this will harm performance or really even readability, it's probably unideal.
- Sort of an addendum to the previous point, fmt now offers additional features which may improve performance or at least correctness or perhaps ergonomics. Chiefly, it now offers a `fmt` function which wraps templates and evaluates them **at compile-time**. I don't believe this occurs if you don't wrap them, so we're potentially losing out on significant performance on C++14 and beyond.

Hope this is helpful!

#708 