### PR TITLE
Closes gabime/spdlog#74

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -282,7 +282,7 @@ inline int utc_minutes_offset(const std::tm &tm = details::os::localtime())
     return offset;
 #else
 
-#if defined(sun) || defined(__sun)
+#if defined(sun) || defined(__sun) || defined(_AIX)
     // 'tm_gmtoff' field is BSD extension and it's missing on SunOS/Solaris
     struct helper
     {


### PR DESCRIPTION
Support for AIX. Tested on AIX 6.1 with GCC 6.3.