### PR TITLE
Closes #717

### DIFF
--- a/example/bench.cpp
+++ b/example/bench.cpp
@@ -108,7 +108,7 @@ void bench_mt(int howmany, std::shared_ptr<spdlog::logger> log, int thread_count
 
     cout << log->name() << "...\t\t" << flush;
     std::atomic<int> msg_counter{0};
-    vector<thread> threads;
+    vector<std::thread> threads;
     auto start = system_clock::now();
     for (int t = 0; t < thread_count; ++t)
     {

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -397,6 +397,11 @@ inline std::string errno_to_string(char buf[256], int res)
     return "Unknown error";
 }
 
+inline std::string errno_to_string(char buf[256], const fmt::internal::Null<> &/*tag*/)
+{
+    return errno_to_string(buf, -1);
+}
+
 // Return errno string (thread safe)
 inline std::string errno_str(int err_num)
 {


### PR DESCRIPTION
Failure to compile to systems that don't have a valid definition
of strerror_r.