### PR TITLE
Closes #717

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -383,18 +383,6 @@ inline std::string filename_to_str(const filename_t &filename)
 }
 #endif
 
-// Return errno string (thread safe)
-inline std::string errno_str(int err_num)
-{
-    char buf[256], *buf_ptr = buf;
-    SPDLOG_CONSTEXPR auto buf_size = sizeof(buf);
-    if (fmt::safe_strerror(err_num, buf_ptr, buf_size) == 0)
-    {
-        return std::string(buf_ptr);
-    }
-    return "Unknown error";
-}
-
 inline int pid()
 {
 

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -397,6 +397,11 @@ inline std::string errno_to_string(char buf[256], int res)
     return "Unknown error";
 }
 
+inline std::string errno_to_string(char buf[256], const fmt::internal::Null<> &/*tag*/)
+{
+    return errno_to_string(buf, -1);
+}
+
 // Return errno string (thread safe)
 inline std::string errno_str(int err_num)
 {


### PR DESCRIPTION
This fix uses the fmt::safe_strerror instead of the underlying
strerror_r functionality. I think this is better - but I'm not
sure if there is a reason for avoiding the use of this function.