### PR TITLE
add remove_all_sinks method to dist_sink

### DIFF
--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -62,6 +62,12 @@ public:
         std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
         _sinks.erase(std::remove(_sinks.begin(), _sinks.end(), sink), _sinks.end());
     }
+
+    void remove_all_sinks()
+    {
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::_mutex);
+        _sinks.clear();
+    }
 };
 
 using dist_sink_mt = dist_sink<std::mutex>;


### PR DESCRIPTION
This allows users to set exactly the sinks they want, even if other unknown application code has added bespoke sinks in the meantime.