### PR TITLE
Add logger name for macro "SPDLOG_CATCH_AND_HANDLE"

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -176,13 +176,13 @@ using filename_t = std::wstring;
 using filename_t = std::string;
 #endif
 
-#define SPDLOG_CATCH_AND_HANDLE                                                                                                            \
+#define SPDLOG_CATCH_AND_HANDLE(_name)                                                                                                     \
     catch (const std::exception &ex)                                                                                                       \
     {                                                                                                                                      \
         _err_handler(ex.what());                                                                                                           \
     }                                                                                                                                      \
     catch (...)                                                                                                                            \
     {                                                                                                                                      \
-        _err_handler("Unknown exeption in logger");                                                                                        \
+        _err_handler("Unknown exeption in logger" + _name);                                                                                \
     }
 } // namespace spdlog

--- a/include/spdlog/details/async_log_helper.h
+++ b/include/spdlog/details/async_log_helper.h
@@ -240,7 +240,7 @@ inline void spdlog::details::async_log_helper::worker_loop()
         {
             active = process_next_msg();
         }
-        SPDLOG_CATCH_AND_HANDLE
+        SPDLOG_CATCH_AND_HANDLE(_logger_name)
     }
     if (_worker_teardown_cb)
     {
@@ -282,7 +282,7 @@ inline bool spdlog::details::async_log_helper::process_next_msg()
                 {
                     s->log(incoming_log_msg);
                 }
-                SPDLOG_CATCH_AND_HANDLE
+                SPDLOG_CATCH_AND_HANDLE(_logger_name)
             }
         }
         handle_flush_interval();
@@ -327,7 +327,7 @@ inline void spdlog::details::async_log_helper::flush_sinks()
         {
             s->flush();
         }
-        SPDLOG_CATCH_AND_HANDLE
+        SPDLOG_CATCH_AND_HANDLE(_logger_name)
     }
     _last_flush = os::now();
 }

--- a/include/spdlog/details/async_logger_impl.h
+++ b/include/spdlog/details/async_logger_impl.h
@@ -83,13 +83,5 @@ inline void spdlog::async_logger::_sink_it(details::log_msg &msg)
             _async_log_helper->flush(); // do async flush
         }
     }
-    catch (const std::exception &ex)
-    {
-        _err_handler(ex.what());
-    }
-    catch (...)
-    {
-        _err_handler("Unknown exception in logger " + _name);
-        throw;
-    }
+    SPDLOG_CATCH_AND_HANDLE(_name)
 }

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -68,7 +68,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char *fmt, const Ar
 #endif
         _sink_it(log_msg);
     }
-    SPDLOG_CATCH_AND_HANDLE
+    SPDLOG_CATCH_AND_HANDLE(_name)
 }
 
 template<typename... Args>
@@ -84,7 +84,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const char *msg)
         log_msg.raw << msg;
         _sink_it(log_msg);
     }
-    SPDLOG_CATCH_AND_HANDLE
+    SPDLOG_CATCH_AND_HANDLE(_name)
 }
 
 template<typename T>
@@ -100,7 +100,7 @@ inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
         log_msg.raw << msg;
         _sink_it(log_msg);
     }
-    SPDLOG_CATCH_AND_HANDLE
+    SPDLOG_CATCH_AND_HANDLE(_name)
 }
 
 template<typename Arg1, typename... Args>
@@ -314,7 +314,7 @@ inline void spdlog::logger::flush()
             sink->flush();
         }
     }
-    SPDLOG_CATCH_AND_HANDLE
+    SPDLOG_CATCH_AND_HANDLE(_name)
 }
 
 inline void spdlog::logger::_default_err_handler(const std::string &msg)


### PR DESCRIPTION
1.add logger name for exception handler macro "SPDLOG_CATCH_AND_HANDLE"
2.change exception handler to macro "SPDLOG_CATCH_AND_HANDLE" in function "spdlog::async_logger::_sink_it"
