### PR TITLE
Expose a counter for how many messages were dropped in async mode

### DIFF
--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -31,6 +31,7 @@ public:
         if (tail_ == head_) // overrun last item if full
         {
             head_ = (head_ + 1) % max_items_;
+            ++overrun_counter_;
         }
     }
 
@@ -53,12 +54,19 @@ public:
         return ((tail_ + 1) % max_items_) == head_;
     }
 
+    int overrun_counter() const
+    {
+      return overrun_counter_;
+    }
+
 private:
     size_t max_items_;
     typename std::vector<T>::size_type head_ = 0;
     typename std::vector<T>::size_type tail_ = 0;
 
     std::vector<T> v_;
+
+    int overrun_counter_ = 0;
 };
 } // namespace details
 } // namespace spdlog

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -54,7 +54,7 @@ public:
         return ((tail_ + 1) % max_items_) == head_;
     }
 
-    int overrun_counter() const
+    size_t overrun_counter() const
     {
       return overrun_counter_;
     }
@@ -66,7 +66,7 @@ private:
 
     std::vector<T> v_;
 
-    int overrun_counter_ = 0;
+    size_t overrun_counter_ = 0;
 };
 } // namespace details
 } // namespace spdlog

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -30,6 +30,11 @@ public:
     {
     }
 
+    int overrun_counter() const
+    {
+      return q_.overrun_counter();
+    }
+
 #ifndef __MINGW32__
     // try to enqueue and block if no room left
     void enqueue(T &&item)

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -30,7 +30,7 @@ public:
     {
     }
 
-    int overrun_counter() const
+    size_t overrun_counter() const
     {
       return q_.overrun_counter();
     }

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -32,6 +32,7 @@ public:
 
     size_t overrun_counter() const
     {
+      std::unique_lock<std::mutex> lock(queue_mutex_);
       return q_.overrun_counter();
     }
 

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -157,6 +157,11 @@ public:
         post_async_msg_(async_msg(std::move(worker_ptr), async_msg_type::flush), overflow_policy);
     }
 
+    int overrun_counter() const
+    {
+      return q_.overrun_counter();
+    }
+
 private:
     q_type q_;
 

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -157,7 +157,7 @@ public:
         post_async_msg_(async_msg(std::move(worker_ptr), async_msg_type::flush), overflow_policy);
     }
 
-    int overrun_counter() const
+    size_t overrun_counter() const
     {
       return q_.overrun_counter();
     }

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -7,7 +7,7 @@ TEST_CASE("basic async test ", "[async]")
 {
     using namespace spdlog;
     auto test_sink = std::make_shared<sinks::test_sink_mt>();
-    int overrun_counter = 0;
+    size_t overrun_counter = 0;
     size_t queue_size = 128;
     size_t messages = 256;
     {

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -7,6 +7,7 @@ TEST_CASE("basic async test ", "[async]")
 {
     using namespace spdlog;
     auto test_sink = std::make_shared<sinks::test_sink_mt>();
+    int overrun_counter = 0;
     size_t queue_size = 128;
     size_t messages = 256;
     {
@@ -17,9 +18,11 @@ TEST_CASE("basic async test ", "[async]")
             logger->info("Hello message #{}", i);
         }
         logger->flush();
+        overrun_counter = tp->overrun_counter();
     }
     REQUIRE(test_sink->msg_counter() == messages);
     REQUIRE(test_sink->flush_counter() == 1);
+    REQUIRE(overrun_counter == 0);
 }
 
 TEST_CASE("discard policy ", "[async]")
@@ -37,6 +40,7 @@ TEST_CASE("discard policy ", "[async]")
         logger->info("Hello message");
     }
     REQUIRE(test_sink->msg_counter() < messages);
+    REQUIRE(tp->overrun_counter() > 0);
 }
 
 TEST_CASE("discard policy using factory ", "[async]")


### PR DESCRIPTION
Increment a counter every time a message is overridden so that users can inspect and adjust their queue sizes accordingly.

In my specific use case I don't mind losing a few messages every once in a while but I'd rather not lose any so at the end of the day I pull the counter and issue an alert if the counter is greater than zero and adjust the queue size for the next day.
