### PR TITLE
Little cmake and tests refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,11 @@ include(GNUInstallDirs)
 #---------------------------------------------------------------------------------------
 # set default build to release
 #---------------------------------------------------------------------------------------
-if (NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
 endif()
 
-message("Build type: " ${CMAKE_BUILD_TYPE})
-
-
+message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
 #---------------------------------------------------------------------------------------
 # compiler config
@@ -28,9 +26,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra ${CMAKE_CXX_FLAGS}")
+    add_compile_options("-Wall")
+    add_compile_options("-Wextra")
 endif()
-
 
 #---------------------------------------------------------------------------------------
 # address sanitizers check

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -24,10 +24,6 @@
 cmake_minimum_required(VERSION 3.1)
 project(SpdlogBench CXX)
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-endif()
-
 if(NOT TARGET spdlog)
   # Stand-alone build
   find_package(spdlog CONFIG REQUIRED)
@@ -44,7 +40,4 @@ target_link_libraries(async_bench spdlog::spdlog Threads::Threads)
 add_executable(latency latency.cpp)
 target_link_libraries(latency spdlog::spdlog Threads::Threads)
 
-
-
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
-

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(example spdlog::spdlog Threads::Threads)
 add_executable(multisink multisink.cpp)
 target_link_libraries(multisink spdlog::spdlog Threads::Threads)
 
-enable_testing()
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
+
+enable_testing()
 add_test(NAME example COMMAND example)

--- a/example/multisink.cpp
+++ b/example/multisink.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <memory>
 
-namespace spd = spdlog;
 int main(int, char *[])
 {
     bool enable_debug = true;
@@ -39,7 +38,7 @@ int main(int, char *[])
         spdlog::drop_all();
     }
     // Exceptions will only be thrown upon failed logger or sink construction (not during logging)
-    catch (const spd::spdlog_ex &ex)
+    catch (const spdlog::spdlog_ex &ex)
     {
         std::cout << "Log init failed: " << ex.what() << std::endl;
         return 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(spdlog-utests CXX)
-enable_testing()
+
 find_package(Threads REQUIRED)
 
 set(SPDLOG_UTESTS_SOURCES
@@ -7,18 +7,23 @@ set(SPDLOG_UTESTS_SOURCES
     file_helper.cpp
     file_log.cpp
     test_misc.cpp
-	test_pattern_formatter.cpp
+    test_pattern_formatter.cpp
     test_async.cpp
     includes.h
     registry.cpp
     test_macros.cpp
     utils.cpp
     utils.h
-    main.cpp test_mpmc_q.cpp)
+    main.cpp
+    test_mpmc_q.cpp
+    test_sink.h
+)
 
 add_executable(${PROJECT_NAME} ${SPDLOG_UTESTS_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 target_link_libraries(${PROJECT_NAME} PRIVATE spdlog::spdlog)
 
-add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
+
+enable_testing()
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/errors.cpp
+++ b/tests/errors.cpp
@@ -9,15 +9,15 @@ class failing_sink : public spdlog::sinks::base_sink<std::mutex>
 {
 public:
     failing_sink() = default;
-    ~failing_sink() = default;
+    ~failing_sink() final = default;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &) override
+    void sink_it_(const spdlog::details::log_msg &) final
     {
         throw std::runtime_error("some error happened during log");
     }
 
-    void flush_() override
+    void flush_() final
     {
         throw std::runtime_error("some error happened during flush");
     }
@@ -25,7 +25,6 @@ protected:
 
 TEST_CASE("default_error_handler", "[errors]]")
 {
-
     prepare_logdir();
     std::string filename = "logs/simple_log.txt";
 

--- a/tests/registry.cpp
+++ b/tests/registry.cpp
@@ -9,7 +9,7 @@ TEST_CASE("register_drop", "[registry]")
     spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name);
     REQUIRE(spdlog::get(tested_logger_name) != nullptr);
     // Throw if registring existing name
-    REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), spdlog::spdlog_ex);
+    REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), const spdlog::spdlog_ex&);
 }
 
 TEST_CASE("explicit register"
@@ -20,7 +20,7 @@ TEST_CASE("explicit register"
     spdlog::register_logger(logger);
     REQUIRE(spdlog::get(tested_logger_name) != nullptr);
     // Throw if registring existing name
-    REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), spdlog::spdlog_ex);
+    REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), const spdlog::spdlog_ex&);
 }
 
 TEST_CASE("apply_all"


### PR DESCRIPTION
Change from spdlog_ex to const spdlog_ex& got rid of the GCC8 warning.