### PR TITLE
Locking vector in dist_sink::sink_it_ and dist_sink::flush_

### DIFF
--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -43,7 +43,7 @@ public:
 protected:
     void sink_it_(const details::log_msg &msg) override
     {
-
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
         for (auto &sink : sinks_)
         {
             if (sink->should_log(msg.level))
@@ -55,6 +55,7 @@ protected:
 
     void flush_() override
     {
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
         for (auto &sink : sinks_)
             sink->flush();
     }


### PR DESCRIPTION
`dist_sink` needs locking to read the `sinks_` vector because another thread may `add_sink()` or `remove_sink()` while `sink_it_()` or `flush_()` is running. Changing the container while another thread is reading may lead to container corruption.

```
Data races
 If a reallocation happens, all contained elements are modified.
```
http://www.cplusplus.com/reference/vector/vector/push_back/