### PR TITLE
Add missing include in console_globals.h

### DIFF
--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -9,7 +9,16 @@
 #include <mutex>
 
 #ifdef _WIN32
-#include "spdlog/details/os.h"
+
+#ifndef NOMINMAX
+#define NOMINMAX // prevent windows redefining min/max
+#endif
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
 #endif
 
 namespace spdlog {

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -8,6 +8,10 @@
 #include <cstdio>
 #include <mutex>
 
+#ifdef _WIN32
+#include "spdlog/details/os.h"
+#endif
+
 namespace spdlog {
 namespace details {
 struct console_stdout


### PR DESCRIPTION
Fixes #803 

@gabime I was also thinking of including just the windows.h, up to you.