### PR TITLE
WIN32: Don't deny access to file sinks from other processes

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -159,9 +159,9 @@ inline bool fopen_s(FILE **fp, const filename_t &filename, const filename_t &mod
 {
 #ifdef _WIN32
 #ifdef SPDLOG_WCHAR_FILENAMES
-    *fp = _wfsopen((filename.c_str()), mode.c_str(), _SH_DENYWR);
+    *fp = _wfsopen((filename.c_str()), mode.c_str(), _SH_DENYNO);
 #else
-    *fp = _fsopen((filename.c_str()), mode.c_str(), _SH_DENYWR);
+    *fp = _fsopen((filename.c_str()), mode.c_str(), _SH_DENYNO);
 #endif
 #else // unix
     *fp = fopen((filename.c_str()), mode.c_str());


### PR DESCRIPTION
Hello! I don't know why is the file open mode set to _SH_DENYWR in Windows, but it prevents to read the file when it is being used by the logger.
I have just changed the mode to _SH_DENYNO and it seams to work perfectly in all my production environments.