### PR TITLE
Add set_sinks method to dist_sink

### DIFF
--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -40,6 +40,12 @@ public:
         sinks_.erase(std::remove(sinks_.begin(), sinks_.end(), sink), sinks_.end());
     }
 
+    void set_sinks(std::vector<std::shared_ptr<sink>> sinks)
+    {
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
+        sinks_ = std::move(sinks);
+    }
+
 protected:
     void sink_it_(const details::log_msg &msg) override
     {


### PR DESCRIPTION
This allows users to set exactly the sinks they want, even if other unknown application code has added bespoke sinks in the meantime.

(This is a re-submission of #735, which was merged against the master (v0.x) branch.)