### PR TITLE
Pessimizing move removed

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -357,5 +357,5 @@ inline std::shared_ptr<spdlog::logger> spdlog::logger::clone(std::string logger_
     cloned->set_level(this->level());
     cloned->flush_on(this->flush_level());
     cloned->set_error_handler(this->error_handler());
-    return std::move(cloned);
+    return cloned;
 }


### PR DESCRIPTION
An instance of pessimizing move removed.

It actually makes code less performing, as is prevents copy elision.
It was also causing compilation error with -Weverything enabled in clang.