### PR TITLE
Revert "Add `conda` to package managers in README"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Very fast, header only, C++ logging library. [![Build Status](https://travis-ci.
 * Gentoo: `emerge dev-libs/spdlog`
 * Arch Linux: `yaourt -S spdlog-git`
 * vcpkg: `vcpkg install spdlog`
-* Conda: `conda install -c conda-forge spdlog`
  
 
 ## Platforms


### PR DESCRIPTION
Reverts gabime/spdlog#822

The conda contains very old spdlog version