### PR TITLE
Change the default value for SPDLOG_BUILD_xxx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,17 @@ include(cmake/sanitizers.cmake)
 add_library(spdlog INTERFACE)
 add_library(spdlog::spdlog ALIAS spdlog)
 
-option(SPDLOG_BUILD_EXAMPLES "Build examples" ON)
-option(SPDLOG_BUILD_BENCH "Build benchmarks" ON)
+# Check if spdlog is being used directly or via add_subdirectory
+set(SPDLOG_MASTER_PROJECT OFF)
+if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(SPDLOG_MASTER_PROJECT ON)
+endif()
+
+option(SPDLOG_BUILD_EXAMPLES "Build examples" ${SPDLOG_MASTER_PROJECT})
+option(SPDLOG_BUILD_BENCH "Build benchmarks" ${SPDLOG_MASTER_PROJECT})
 
 cmake_dependent_option(SPDLOG_BUILD_TESTING
-    "Build spdlog tests" ON
+    "Build spdlog tests" ${SPDLOG_MASTER_PROJECT}
     "BUILD_TESTING" OFF
 )
 


### PR DESCRIPTION
The value is based on whether _spdlog_ is used as a third-party dependency or as a standalone project. If _spdlog_ is included through `add_subdirectory`, the tests/examples/benchmarks are disabled by default, and if _spdlog_ is configured standalone, then the tests are enabled by default.

Closes #830. (I did not talk about examples/benchmarks in that issue, however the logic is the same, these are not needed when _spdlog_ is a third-party dependency.)