### PR TITLE
ansicolor_sink.h - add missing sink include

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -8,6 +8,7 @@
 #include "spdlog/details/console_globals.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/details/os.h"
+#include "spdlog/sinks/sink.h"
 
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Hello!

Looks like this include was missed!

Thanks!