### PR TITLE
Add dependency to Android's log target in CMake

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -32,7 +32,13 @@ endif()
 find_package(Threads REQUIRED)
 
 add_executable(example example.cpp)
-target_link_libraries(example spdlog::spdlog Threads::Threads)
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    find_library(log-lib log)
+    target_link_libraries(example spdlog::spdlog Threads::Threads log)
+else()
+    target_link_libraries(example spdlog::spdlog Threads::Threads)
+endif()
+
 
 add_executable(multisink multisink.cpp)
 target_link_libraries(multisink spdlog::spdlog Threads::Threads)


### PR DESCRIPTION
Not sure what the interest is in this PR but I found that building for Android fails for me out-of-the-box when cross-compiling using the NDK. The error message is:
```
$: cmake --build . 
Scanning dependencies of target multisink
[  4%] Building CXX object example/CMakeFiles/multisink.dir/multisink.cpp.o
[  8%] Linking CXX executable multisink
[  8%] Built target multisink
Scanning dependencies of target example
[ 13%] Building CXX object example/CMakeFiles/example.dir/example.cpp.o
[ 17%] Linking CXX executable example
/tmp/bar/spdlog/include/spdlog/sinks/android_sink.h:56: error: undefined reference to '__android_log_write'
/tmp/bar/spdlog/include/spdlog/sinks/android_sink.h:61: error: undefined reference to '__android_log_write'
collect2: error: ld returned 1 exit status
make[2]: *** [example/CMakeFiles/example.dir/build.make:84: example/example] Error 1
make[1]: *** [CMakeFiles/Makefile2:1058: example/CMakeFiles/example.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
My interpretation of this error is that the linker can not find Android's log library.

Going through the Wiki and README I could not find a recommended way to setup the toolchain for Android NDK. In my case I was using CMake 3.7 (with support for cross-compiling for Android) with the following setteings:
```
cmake PATH_TO_SPDLOG_SOURCE \
  -DCMAKE_SYSTEM_NAME=Android \
  -DCMAKE_SYSTEM_VERSION=21 \
  -DCMAKE_ANDROID_ARCH_ABI="armeabi-v7a" \
  -DCMAKE_ANDROID_ARM_NEON=ON \
  -DCMAKE_ANDROID_NDK=$HOME/Android/Ndk/android-ndk-r13b/ 
```
Which are all existing cross-compile settings for CMake 3.7.

I also could not find a minimum target NDK version or Android API level for spdlog? The above example target Android API level 21 (Android 5) and NDK r13b.

To make cross-compilation work with this NDK and CMake 3.7 I just did what is stated about compiling with the NDK and CMake in the documentation: https://developer.android.com/studio/projects/configure-cmake and also add a check for if the target system name is Android.

It is not obvious that this PR should go into spdlog since there may already exist an established way of cross-compiling spdlog that I am unaware of, but I figured it may be of interest to discuss the general problem of how to build for Android?

