### PR TITLE
Fix #849, Can't build with SPDLOG_ENABLE_MESSAGE_COUNTER

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -358,7 +358,7 @@ inline void spdlog::logger::default_err_handler_(const std::string &msg)
     fmt::print(stderr, "[*** LOG ERROR ***] [{}] [{}] {}\n", date_buf, name(), msg);
 }
 
-inline void spdlog::logger::incr_msg_counter_(details::log_msg &msg)
+inline void spdlog::logger::incr_msg_counter_(const details::log_msg &msg)
 {
     msg.msg_id = msg_counter_.fetch_add(1, std::memory_order_relaxed);
 }

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -152,7 +152,7 @@ protected:
     void default_err_handler_(const std::string &msg);
 
     // increment the message count (only if defined(SPDLOG_ENABLE_MESSAGE_COUNTER))
-    void incr_msg_counter_(details::log_msg &msg);
+    void incr_msg_counter_(const details::log_msg &msg);
 
     const std::string name_;
     std::vector<sink_ptr> sinks_;


### PR DESCRIPTION
I am sorry to check the commit c5011181bb0f77fd73cac4bf0b6c9fe20eccedde late.

Defining `SPDLOG_ENABLE_MESSAGE_COUNTER` in `v1.x` still caused a build error.