### PR TITLE
For Windows, make sure the file handle created by os::fopen_s() is never inherited by child processes launched using CreateProcess().

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -153,6 +153,13 @@ inline bool fopen_s(FILE **fp, const filename_t &filename, const filename_t &mod
 #else
     *fp = _fsopen((filename.c_str()), mode.c_str(), _SH_DENYNO);
 #endif
+
+	// Make sure the file handle is never inherited by child processes created using CreateProcess().
+	// Otherwise, file rotation will fail since the file is left open by the child process.
+	auto fn = _fileno(*fp);
+	auto handle = HANDLE(_get_osfhandle(fn));
+	::SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0);
+
 #else // unix
     *fp = fopen((filename.c_str()), mode.c_str());
 #endif


### PR DESCRIPTION
By default, the file handle under FILE is inheritable by child processes in Windows. If the current process creates a child process using CreateProcess() API, and set inherit handles to TRUE, then the log file of spdlog will be kept open by the child process and is never closed.
In this case, log file rotation will always fail since you cannot do rename() because another process is still using the file.
