### PR TITLE
Conditional evaluation of macro arguments

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -96,7 +96,7 @@ enum level_enum
     debug = SPDLOG_LEVEL_DEBUG,
     info = SPDLOG_LEVEL_INFO,
     warn = SPDLOG_LEVEL_WARN,
-    err = SPDLOG_LEVEL_ERROR,
+    error = SPDLOG_LEVEL_ERROR,
     critical = SPDLOG_LEVEL_CRITICAL,
     off = SPDLOG_LEVEL_OFF,
 };
@@ -128,7 +128,7 @@ inline spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCE
             {level_names[1], level::debug},                            // debug
             {level_names[2], level::info},                             // info
             {level_names[3], level::warn},                             // warn
-            {level_names[4], level::err},                              // err
+            {level_names[4], level::error},                            // error
             {level_names[5], level::critical},                         // critical
             {level_names[6], level::off}};                             // off
 

--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -151,7 +151,7 @@ inline void spdlog::logger::warn(const char *fmt, const Args &... args)
 template<typename... Args>
 inline void spdlog::logger::error(const char *fmt, const Args &... args)
 {
-    log(level::err, fmt, args...);
+    log(level::error, fmt, args...);
 }
 
 template<typename... Args>
@@ -187,7 +187,7 @@ inline void spdlog::logger::warn(const T &msg)
 template<typename T>
 inline void spdlog::logger::error(const T &msg)
 {
-    log(level::err, msg);
+    log(level::error, msg);
 }
 
 template<typename T>
@@ -268,7 +268,7 @@ inline void spdlog::logger::warn(const wchar_t *fmt, const Args &... args)
 template<typename... Args>
 inline void spdlog::logger::error(const wchar_t *fmt, const Args &... args)
 {
-    log(level::err, fmt, args...);
+    log(level::error, fmt, args...);
 }
 
 template<typename... Args>

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -87,7 +87,7 @@ private:
             return ANDROID_LOG_INFO;
         case spdlog::level::warn:
             return ANDROID_LOG_WARN;
-        case spdlog::level::err:
+        case spdlog::level::error:
             return ANDROID_LOG_ERROR;
         case spdlog::level::critical:
             return ANDROID_LOG_FATAL;

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -43,7 +43,7 @@ public:
         colors_[level::debug] = cyan;
         colors_[level::info] = green;
         colors_[level::warn] = yellow + bold;
-        colors_[level::err] = red + bold;
+        colors_[level::error] = red + bold;
         colors_[level::critical] = bold + on_red;
         colors_[level::off] = reset;
     }

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -34,7 +34,7 @@ public:
         priorities_[static_cast<size_t>(level::debug)] = LOG_DEBUG;
         priorities_[static_cast<size_t>(level::info)] = LOG_INFO;
         priorities_[static_cast<size_t>(level::warn)] = LOG_WARNING;
-        priorities_[static_cast<size_t>(level::err)] = LOG_ERR;
+        priorities_[static_cast<size_t>(level::error)] = LOG_ERR;
         priorities_[static_cast<size_t>(level::critical)] = LOG_CRIT;
         priorities_[static_cast<size_t>(level::off)] = LOG_INFO;
 

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -45,7 +45,7 @@ public:
         colors_[level::debug] = CYAN;
         colors_[level::info] = GREEN;
         colors_[level::warn] = YELLOW | BOLD;
-        colors_[level::err] = RED | BOLD;                         // red bold
+        colors_[level::error] = RED | BOLD;                         // red bold
         colors_[level::critical] = BACKGROUND_RED | WHITE | BOLD; // white bold on red background
         colors_[level::off] = 0;
     }

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -295,49 +295,67 @@ inline void critical(const wchar_t *fmt, const Args &... args)
 // can be enabled/disabled using SPDLOG_ACTIVE_LEVEL (info by default).
 //
 
+#define SPDLOG_LOGGER_GENERIC(logger, log_level, ...)                                                                                      \
+    do                                                                                                                                     \
+    {                                                                                                                                      \
+        if (logger->should_log(spdlog::level::log_level))                                                                                  \
+        {                                                                                                                                  \
+            logger->log_level(__VA_ARGS__);                                                                                                \
+        }                                                                                                                                  \
+    } while (0)
+
+#define SPDLOG_GENERIC(log_level, ...)                                                                                                     \
+    do                                                                                                                                     \
+    {                                                                                                                                      \
+        if (logger->should_log(spdlog::level::log_level))                                                                                  \
+        {                                                                                                                                  \
+            spdlog::log_level(__VA_ARGS__);                                                                                                \
+        }                                                                                                                                  \
+    } while (0)
+
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-#define SPDLOG_LOGGER_TRACE(logger, ...) logger->trace(__VA_ARGS__)
-#define SPDLOG_TRACE(...) spdlog::trace(__VA_ARGS__)
+#define SPDLOG_LOGGER_TRACE(logger, ...) SPDLOG_LOGGER_GENERIC(logger, trace, __VA_ARGS__)
+#define SPDLOG_TRACE(...) SPDLOG_GENERIC(trace, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
 #define SPDLOG_TRACE(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
-#define SPDLOG_LOGGER_DEBUG(logger, ...) logger->debug(__VA_ARGS__)
-#define SPDLOG_DEBUG(...) spdlog::debug(__VA_ARGS__)
+#define SPDLOG_LOGGER_DEBUG(logger, ...) SPDLOG_LOGGER_GENERIC(logger, debug, __VA_ARGS__)
+#define SPDLOG_DEBUG(...) SPDLOG_GENERIC(debug, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
 #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define SPDLOG_LOGGER_INFO(logger, ...) logger->info(__VA_ARGS__)
-#define SPDLOG_INFO(...) spdlog::info(__VA_ARGS__)
+#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_GENERIC(logger, info, __VA_ARGS__)
+#define SPDLOG_INFO(...) SPDLOG_GENERIC(info, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
 #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define SPDLOG_LOGGER_WARN(logger, ...) logger->warn(__VA_ARGS__)
-#define SPDLOG_WARN(...) spdlog::warn(__VA_ARGS__)
+#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_GENERIC(logger, warn, __VA_ARGS__)
+#define SPDLOG_WARN(...) SPDLOG_GENERIC(warn, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
 #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define SPDLOG_LOGGER_ERROR(logger, ...) logger->error(__VA_ARGS__)
-#define SPDLOG_ERROR(...) spdlog::error(__VA_ARGS__)
+#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_GENERIC(logger, error, __VA_ARGS__)
+#define SPDLOG_ERROR(...) SPDLOG_GENERIC(error, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
 #define SPDLOG_ERROR(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
-#define SPDLOG_LOGGER_CRITICAL(logger, ...) logger->critical(__VA_ARGS__)
-#define SPDLOG_CRITICAL(...) spdlog::critical(__VA_ARGS__)
+#define SPDLOG_LOGGER_CRITICAL(logger, ...) SPDLOG_LOGGER_GENERIC(logger, critical, __VA_ARGS__)
+#define SPDLOG_CRITICAL(...) SPDLOG_GENERIC(critical, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -10,7 +10,6 @@
 
 TEST_CASE("debug and trace w/o format string", "[macros]]")
 {
-
     prepare_logdir();
     std::string filename = "logs/simple_log";
 
@@ -29,4 +28,32 @@ TEST_CASE("debug and trace w/o format string", "[macros]]")
 TEST_CASE("disable param evaluation", "[macros]")
 {
     SPDLOG_TRACE("Test message {}", throw std::runtime_error("Should not be evaluated"));
+}
+
+TEST_CASE("disable param evaluation in runtime", "[macros]")
+{
+    prepare_logdir();
+    std::string filename = "logs/simple_log";
+    auto logger = spdlog::create<spdlog::sinks::basic_file_sink_mt>("logger", filename);
+
+    int x{0};
+
+    logger->set_level(spdlog::level::off);
+    SPDLOG_LOGGER_TRACE(logger, ++x);
+    SPDLOG_LOGGER_DEBUG(logger, ++x);
+    SPDLOG_LOGGER_INFO(logger, ++x);
+    SPDLOG_LOGGER_WARN(logger, ++x);
+    SPDLOG_LOGGER_ERROR(logger, ++x);
+    SPDLOG_LOGGER_CRITICAL(logger, ++x);
+
+    spdlog::set_default_logger(logger);
+    SPDLOG_TRACE(++x);
+    SPDLOG_DEBUG(++x);
+    SPDLOG_INFO(++x);
+    SPDLOG_WARN(++x);
+    SPDLOG_ERROR(++x);
+    SPDLOG_CRITICAL(++x);
+
+    REQUIRE(x == 0);
+    REQUIRE(count_lines(filename) == 0);
 }

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -36,7 +36,7 @@ TEST_CASE("basic_logging ", "[basic_logging]")
 
 TEST_CASE("log_levels", "[log_levels]")
 {
-    REQUIRE(log_info("Hello", spdlog::level::err) == "");
+    REQUIRE(log_info("Hello", spdlog::level::error) == "");
     REQUIRE(log_info("Hello", spdlog::level::critical) == "");
     REQUIRE(log_info("Hello", spdlog::level::info) == "Hello");
     REQUIRE(log_info("Hello", spdlog::level::debug) == "Hello");
@@ -49,7 +49,7 @@ TEST_CASE("to_c_str", "[convert_to_c_str]")
     REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::debug)) == "debug");
     REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::info)) == "info");
     REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::warn)) == "warning");
-    REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::err)) == "error");
+    REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::error)) == "error");
     REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::critical)) == "critical");
     REQUIRE(std::string(spdlog::level::to_c_str(spdlog::level::off)) == "off");
 }
@@ -60,7 +60,7 @@ TEST_CASE("to_short_c_str", "[convert_to_short_c_str]")
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::debug)) == "D");
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::info)) == "I");
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::warn)) == "W");
-    REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::err)) == "E");
+    REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::error)) == "E");
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::critical)) == "C");
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::off)) == "O");
 }
@@ -71,7 +71,7 @@ TEST_CASE("to_level_enum", "[convert_to_level_enum]")
     REQUIRE(spdlog::level::from_str("debug") == spdlog::level::debug);
     REQUIRE(spdlog::level::from_str("info") == spdlog::level::info);
     REQUIRE(spdlog::level::from_str("warning") == spdlog::level::warn);
-    REQUIRE(spdlog::level::from_str("error") == spdlog::level::err);
+    REQUIRE(spdlog::level::from_str("error") == spdlog::level::error);
     REQUIRE(spdlog::level::from_str("critical") == spdlog::level::critical);
     REQUIRE(spdlog::level::from_str("off") == spdlog::level::off);
     REQUIRE(spdlog::level::from_str("null") == spdlog::level::off);


### PR DESCRIPTION
Implements #638 

Hey,
This PR introduces the lazy evaluation of macro arguments in cases where logging won't even happen. The number of macros increased since the issue was created so I kept the behaviour constant across all of them.

I changed `err` to `error` as a convenience since logging functions are called `error`, but it's not necessary, additional parameter to `*_GENERIC` macros can be added.

This unfortunately breaks the code that somehow relies on evaluation in macros but the exact same thing would happen if `SPDLOG_ACTIVE_LEVEL` was changed.

Let me know if this enhancement is still desired.