### PR TITLE
Fix exceptions on file size calculation on Windows XP x64 and Windows Server 2003 x64

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -210,7 +210,7 @@ inline size_t filesize(FILE *f)
 #if defined(_WIN32) && !defined(__CYGWIN__)
     int fd = _fileno(f);
 #if _WIN64 // 64 bits
-    long long ret = _filelengthi64(fd);
+    __int64 ret = _filelengthi64(fd);
     if (ret >= 0)
     {
         return static_cast<size_t>(ret);

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -210,10 +210,10 @@ inline size_t filesize(FILE *f)
 #if defined(_WIN32) && !defined(__CYGWIN__)
     int fd = _fileno(f);
 #if _WIN64 // 64 bits
-    struct _stat64 st;
-    if (_fstat64(fd, &st) == 0)
+    long long ret = _filelengthi64(fd);
+    if (ret >= 0)
     {
-        return st.st_size;
+        return static_cast<size_t>(ret);
     }
 
 #else // windows 32 bits


### PR DESCRIPTION
For some reason, `_fstat64` fails with errno 22 on Windows Server 2003 x64 (and probably Windows XP x64 as well) when compiled using the `v141_xp` toolset.
Using `_filelengthi64` instead solves this issue.