### PR TITLE
Fix some minor warnings found with a recent clang version

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -193,7 +193,7 @@ struct source_loc
     }
     SPDLOG_CONSTEXPR source_loc(const char *filename, int line)
         : filename(filename)
-        , line(line)
+        , line(static_cast<uint32_t>(line))
     {
     }
 

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -37,7 +37,6 @@ struct log_msg
     }
 
     log_msg(const log_msg &other) = default;
-    log_msg &operator=(const log_msg &other) = default;
 
     const std::string *logger_name{nullptr};
     level::level_enum level{level::off};


### PR DESCRIPTION
Two warnings fixed:
   * incorrectly default'ing operator= in a struct with a const data member (removed the line)
   * implicitly casting an int to a uint32_t; I suppose that ideally the cast shouldn't be necessary
     to begin with, but while it is still being done, better to have it explicit.  This also fixes a warning.