### PR TITLE
Corrected the text alignment in the example

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -31,7 +31,7 @@ int main(int, char *[])
     spdlog::critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
     spdlog::info("Support for floats {:03.2f}", 1.23456);
     spdlog::info("Positional args are {1} {0}..", "too", "supported");
-    spdlog::info("{:>8} aligned, {:>8} aligned", "right", "left");
+    spdlog::info("{:>8} aligned, {:<8} aligned", "right", "left");
 
     // Runtime log levels
     spdlog::set_level(spdlog::level::info); // Set global log level to info


### PR DESCRIPTION
I've changed the alignment character in the example to illustrate left alignment of text. Originally, the alignment was right.