### PR TITLE
Update log_msg.h

### DIFF
--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -25,9 +25,9 @@ struct log_msg
 
 #ifndef SPDLOG_NO_THREAD_ID
         , thread_id(os::thread_id())
+#endif
         , source(loc)
         , payload(view)
-#endif
     {
     }
 


### PR DESCRIPTION
`SPDLOG_NO_THREAD_ID` should only affect thread retrieval.