### PR TITLE
Disable building benchmarks by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
     add_compile_options("-Wconversion")
     add_compile_options("-pedantic")
     add_compile_options("-Wfatal-errors")
-    
 endif()
 
 #---------------------------------------------------------------------------------------
@@ -47,11 +46,11 @@ add_library(spdlog::spdlog ALIAS spdlog)
 # Check if spdlog is being used directly or via add_subdirectory
 set(SPDLOG_MASTER_PROJECT OFF)
 if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(SPDLOG_MASTER_PROJECT ON)
+    set(SPDLOG_MASTER_PROJECT ON)
 endif()
 
 option(SPDLOG_BUILD_EXAMPLES "Build examples" ${SPDLOG_MASTER_PROJECT})
-option(SPDLOG_BUILD_BENCH "Build benchmarks" ${SPDLOG_MASTER_PROJECT})
+option(SPDLOG_BUILD_BENCH "Build benchmarks (Requires https://github.com/google/benchmark.git to be installed)" OFF)
 option(SPDLOG_BUILD_TESTS "Build tests" ${SPDLOG_MASTER_PROJECT})
 option(SPDLOG_FMT_EXTERNAL "Use external fmt library instead of bundled" OFF)
 


### PR DESCRIPTION
Building the benchmarks requires google-benchmark to be installed which is
not the case for most of the build systems. The option now has a tiny
hint what the requirement is and where to get it.

[ccmake configuration example](https://i.imgur.com/12BzEOk.png)

closes #975 