### PR TITLE
Shadowed parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 #---------------------------------------------------------------------------------------
 # compiler config
 #---------------------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -30,6 +30,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
     add_compile_options("-Wconversion")
     add_compile_options("-pedantic")
     add_compile_options("-Wfatal-errors")
+    add_compile_options("-Wshadow")
 endif()
 
 #---------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 #---------------------------------------------------------------------------------------
 # compiler config
 #---------------------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -30,7 +30,6 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
     add_compile_options("-Wconversion")
     add_compile_options("-pedantic")
     add_compile_options("-Wfatal-errors")
-    add_compile_options("-Wshadow")
 endif()
 
 #---------------------------------------------------------------------------------------

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -210,10 +210,10 @@ struct source_loc
         , funcname{""}
     {
     }
-    SPDLOG_CONSTEXPR source_loc(const char *filename, int line, const char *funcname)
-        : filename{filename}
-        , line{static_cast<uint32_t>(line)}
-        , funcname{funcname}
+    SPDLOG_CONSTEXPR source_loc(const char *t_filename, int t_line, const char *t_funcname)
+        : filename{t_filename}
+        , line{static_cast<uint32_t>(t_line)}
+        , funcname{t_funcname}
     {
     }
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -210,10 +210,10 @@ struct source_loc
         , funcname{""}
     {
     }
-    SPDLOG_CONSTEXPR source_loc(const char *t_filename, int t_line, const char *t_funcname)
-        : filename{t_filename}
-        , line{static_cast<uint32_t>(t_line)}
-        , funcname{t_funcname}
+    SPDLOG_CONSTEXPR source_loc(const char *filename_in, int line_in, const char *funcname_in)
+        : filename{filename_in}
+        , line{static_cast<uint32_t>(line_in)}
+        , funcname{funcname_in}
     {
     }
 


### PR DESCRIPTION
Hi,
This pull request is certainly not a priority, but I modified slightly common.h so to remove some compile warnings, that are problematic for projects that build with -Werror.
Thought I would share this simple fix. 

When including the following logging utilities and the compile flag:

**-Wshadow**

#include "spdlog/sinks/stdout_color_sinks.h"
#include "spdlog/sinks/basic_file_sink.h"


To reproduce the errors without this pull request:
 - add the compile flag -Wshadow

I know the naming of the parameters, starting with "t_" might be controversial.

Best,
Charles-David
