### PR TITLE
Allow the inclusion of an external fmtlib as as sub_directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(SPDLOG_BUILD_BENCH "Build benchmarks (Requires https://github.com/google/
 option(SPDLOG_BUILD_TESTS "Build tests" ${SPDLOG_MASTER_PROJECT})
 option(SPDLOG_FMT_EXTERNAL "Use external fmt library instead of bundled" OFF)
 
-if(SPDLOG_FMT_EXTERNAL)
+if(SPDLOG_FMT_EXTERNAL AND NOT TARGET fmt::fmt)
     find_package(fmt REQUIRED CONFIG)
 endif()
 


### PR DESCRIPTION
Fixes #982 

Tested to work well on Windows and Ubuntu and the newest versions of fmtlib. But coverage has been limited. Really curious what the CI will tell...