### PR TITLE
Remove unnecessary log function

### DIFF
--- a/include/spdlog/details/logger_impl.h
+++ b/include/spdlog/details/logger_impl.h
@@ -102,6 +102,12 @@ inline void spdlog::logger::log(level::level_enum lvl, const char *msg)
     log(source_loc{}, lvl, msg);
 }
 
+template<class T>
+inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
+{
+    log(source_loc{}, lvl, msg);
+}
+
 template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
 inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const T &msg)
 {
@@ -115,12 +121,6 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
         sink_it_(log_msg);
     }
     SPDLOG_CATCH_AND_HANDLE
-}
-
-template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
-{
-    log(source_loc{}, lvl, msg);
 }
 
 template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
@@ -139,12 +139,6 @@ inline void spdlog::logger::log(source_loc source, level::level_enum lvl, const 
         sink_it_(log_msg);
     }
     SPDLOG_CATCH_AND_HANDLE
-}
-
-template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type *>
-inline void spdlog::logger::log(level::level_enum lvl, const T &msg)
-{
-    log(source_loc{}, lvl, msg);
 }
 
 template<typename... Args>

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -100,17 +100,12 @@ public:
 #endif // _WIN32
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
-    // T can be statically converted to string_view
-    template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T>
     void log(level::level_enum lvl, const T &);
 
     // T can be statically converted to string_view
     template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &);
-
-    // T cannot be statically converted to string_view
-    template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
-    void log(level::level_enum lvl, const T &);
 
     // T cannot be statically converted to string_view
     template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>


### PR DESCRIPTION
Looks like one of the log functions is unnecessary since the "enable_if" check is later performed for log(source_loc...) version.