### PR TITLE
custom thread id types

### DIFF
--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -41,7 +41,7 @@ struct log_msg
     const std::string *logger_name{nullptr};
     level::level_enum level{level::off};
     log_clock::time_point time;
-    size_t thread_id{0};
+    details::os::thread_t thread_id{};
     size_t msg_id{0};
 
     // wrapping the formatted text with color (updated by pattern_formatter).

--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -687,6 +687,13 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
+#if defined(SPDLOG_CUSTOM_THREAD_ID_PRINTER)
+        SPDLOG_CUSTOM_THREAD_ID_PRINTER
+#else
+        using used_thread_t = decltype(msg.thread_id);
+        static_assert(std::is_convertible<used_thread_t, size_t>::value,
+                      "custom thread_t is not convertible to size_t, use SPDLOG_CUSTOM_THREAD_ID_PRINTER macro");
+
         if (padinfo_.enabled())
         {
             const auto field_size = fmt_helper::count_digits(msg.thread_id);
@@ -697,6 +704,7 @@ public:
         {
             fmt_helper::append_int(msg.thread_id, dest);
         }
+#endif
     }
 };
 

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -143,3 +143,21 @@
 //
 // #define SPDLOG_FUNCTION __PRETTY_FUNCTION__
 ///////////////////////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// Uncomment to use custom thread identifier type.
+//
+// WARNING: Custom thread id getter should be used when thread_t is not
+// convertible to size_t (which is default type) or values should be received
+// from another source, e.g. pthread identifiers under Linux.
+//
+// WARNING: If custom thread_t is not convertible to size_t and custom thread
+// id printer code is not set then compile-time assert will fail. Use 
+// SPDLOG_CUSTOM_THREAD_ID_PRINTER macro to provide corresponding code to print
+// thread id. This code will be placed inside t_formatter (for '%t') in
+// details/pattern_formatter.h.
+//
+// #define SPDLOG_CUSTOM_THREAD_T custom_type
+// #define SPDLOG_CUSTOM_THREAD_ID_GETTER custom_type_get_func()
+// #define SPDLOG_CUSTOM_THREAD_ID_PRINTER {  } // see t_formatter::format
+///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
These changes allows to use custom types as thread identifiers to get more information inside formatters.
I faced with problem in spdlog when I tried to print thread names, which were named by pthread_setname_np function. Because thread identifiers (under Linux) received by syscall there is no way to get pthread identifier to use it in pthread_getname_np function. But now thread identifiers can have any type, can be received from any function and can be printed with any custom code (this is the most confusing one).
Some examples (all in tweakme.h):
_to use pthread on Linux_
`#define SPDLOG_CUSTOM_THREAD_T pthread_t`
`#define SPDLOG_CUSTOM_THREAD_ID_GETTER pthread_self()`
SPDLOG_CUSTOM_THREAD_ID_PRINTER can be not defined if pthread_t is integral, but if it is not then this macro can be defined but be empty - in case if you don't want to use pattern formatter

_to show what you can do with this_
`struct custom_thread_t
{
    some_type some_variable;
    int value = 42;
};`
`#define SPDLOG_CUSTOM_THREAD_T custom_thread_t`
`#define SPDLOG_CUSTOM_THREAD_ID_GETTER custom_thread_t()`
`#define SPDLOG_CUSTOM_THREAD_ID_PRINTER { fmt_helper::append_int(msg.thread_id.value, dest); }`

I think you should look at this as just a suggestion of using custom thread types, because I hope someone have better ideas to implement this. This feature will be really useful.