### PR TITLE
Expose should_do_colors_ in ansicolor_sink.h

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -133,7 +133,7 @@ public:
         formatter_ = std::move(sink_formatter);
     }
 
-    bool colors_enabled()
+    bool should_color()
     {
         return should_do_colors_;
     }

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -133,6 +133,11 @@ public:
         formatter_ = std::move(sink_formatter);
     }
 
+    bool colors_enabled()
+    {
+        return should_do_colors_;
+    }
+
 private:
     void print_ccode_(const std::string &color_code)
     {


### PR DESCRIPTION
As described in #1004 it would be nice to have the private member `should_do_colors_` exposed.