### PR TITLE
Add systemd sink.

### DIFF
--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -59,8 +59,9 @@ protected:
     {
         if( sd_journal_print(
                 syslog_level(msg.level),
-                "%s",
-                fmt::to_string(msg.payload).c_str()
+                "%.*s",
+                static_cast<int>(msg.payload.size()),
+                msg.payload.data()
             )
         )
             throw spdlog_ex("Failed writing to systemd");

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -1,0 +1,90 @@
+//
+// Copyright(c) 2015 Gabi Melman.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+//
+
+#pragma once
+
+#ifndef SPDLOG_H
+#include "spdlog/spdlog.h"
+#endif
+
+#include "spdlog/sinks/base_sink.h"
+
+#include <array>
+#include <string>
+#include <systemd/sd-journal.h>
+
+namespace spdlog {
+namespace sinks {
+
+inline int syslog_level(level::level_enum l) {
+    switch(l) {
+        case level::off:
+        case level::trace:
+        case level::debug:
+            return LOG_DEBUG;
+        case level::info:
+            return LOG_INFO;
+        case level::warn:
+            return LOG_WARNING;
+        case level::err:
+            return LOG_ERR;
+        case level::critical:
+            return LOG_CRIT;
+        default:
+            throw std::invalid_argument("systemd_sink.h syslog_level()");
+    }
+}
+
+/**
+ * Sink that write to systemd using the `sd_journal_print()` library call.
+ *
+ * Locking is not needed, as `sd_journal_print()` itself is thread-safe.
+ */
+template<typename Mutex>
+class systemd_sink : public base_sink<Mutex>
+{
+public:
+    //
+    explicit systemd_sink(void) {}
+
+    ~systemd_sink() override {}
+
+    systemd_sink(const systemd_sink &) = delete;
+    systemd_sink &operator=(const systemd_sink &) = delete;
+
+protected:
+    void sink_it_(const details::log_msg &msg) override
+    {
+        if( sd_journal_print(
+                syslog_level(msg.level),
+                "%s",
+                fmt::to_string(msg.payload).c_str()
+            )
+        )
+            throw spdlog_ex("Failed writing to systemd");
+    }
+
+    void flush_() override {}
+};
+
+using systemd_sink_mt = systemd_sink<std::mutex>;
+using systemd_sink_st = systemd_sink<details::null_mutex>;
+} // namespace sinks
+
+// Create and register a syslog logger
+template<typename Factory = default_factory>
+inline std::shared_ptr<logger> systemd_logger_mt(
+    const std::string &logger_name)
+{
+    return Factory::template create<sinks::systemd_sink_mt>(logger_name);
+}
+
+template<typename Factory = default_factory>
+inline std::shared_ptr<logger> systemd_logger_st(
+    const std::string &logger_name)
+{
+    return Factory::template create<sinks::systemd_sink_st>(logger_name);
+}
+} // namespace spdlog

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -1,5 +1,5 @@
 //
-// Copyright(c) 2015 Gabi Melman.
+// Copyright(c) 2019 ZVYAGIN.Alexander@gmail.com
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 //
 

--- a/tests/test_systemd.cpp
+++ b/tests/test_systemd.cpp
@@ -1,0 +1,35 @@
+#include "includes.h"
+#include <spdlog/sinks/systemd_sink.h>
+
+namespace {
+const char *tested_logger_name = "main";
+}
+
+void run(spdlog::logger &logger) {
+    logger.debug("test debug");
+    logger.error("test error");
+    logger.info("test info");
+}
+
+// std::shared_ptr<spdlog::logger> create_stdout_and_systemd_logger(
+//     std::string name="",
+//     spdlog::level::level_enum level_stdout=spdlog::level::level_enum::debug,
+//     spdlog::level::level_enum level_systemd=spdlog::level::level_enum::err
+// ) {
+//     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+//     console_sink->set_level(level_stdout);
+//     auto systemd_sink = std::make_shared<spdlog::sinks::systemd_sink_st>();
+//     systemd_sink->set_level(level_systemd);
+//     return std::make_shared<spdlog::logger>(name, {console_sink, systemd_sink});
+
+// }
+
+TEST_CASE("systemd", "[all]")
+{
+    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    console_sink->set_level(spdlog::level::level_enum::debug);
+    auto systemd_sink = std::make_shared<spdlog::sinks::systemd_sink_st>();
+    systemd_sink->set_level(spdlog::level::level_enum::err);
+    spdlog::logger logger("spdlog_systemd_test", {console_sink, systemd_sink});
+    run(logger);
+}


### PR DESCRIPTION
The *test_systemd.cpp* is added, but is not linked. It requires *systemd* library, and I am not sure it is a good idea to add it unconditionally to the tests. And I am too lazy write CMake configuration for the *systemd* dependency.

Also, there is a code duplication with *syslog_sink.h*. The syslog sink also uses "syslog_priorities", but I cannot use directly. So a special function *syslog_level()* was introduced.