### PR TITLE
Namespace qualify stat functions

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -196,7 +196,7 @@ inline bool file_exists(const filename_t &filename) SPDLOG_NOEXCEPT
     return (attribs != INVALID_FILE_ATTRIBUTES && !(attribs & FILE_ATTRIBUTE_DIRECTORY));
 #else // common linux/unix all have the stat system call
     struct stat buffer;
-    return (stat(filename.c_str(), &buffer) == 0);
+    return (::stat(filename.c_str(), &buffer) == 0);
 #endif
 }
 
@@ -229,14 +229,14 @@ inline size_t filesize(FILE *f)
 // 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
 #if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
     struct stat64 st;
-    if (fstat64(fd, &st) == 0)
+    if (::fstat64(fd, &st) == 0)
     {
         return static_cast<size_t>(st.st_size);
     }
 #else // unix 32 bits or cygwin
     struct stat st;
 
-    if (fstat(fd, &st) == 0)
+    if (::fstat(fd, &st) == 0)
     {
         return static_cast<size_t>(st.st_size);
     }


### PR DESCRIPTION
Hi,

This is trivial change. In a large codebase where I use spdlog, I had to do this change. I know this is not at all a bug in spdlog but this could save trouble where people have to deal with large codebases and namespace abuses (In my case, a few _bad_ "using namespace My_NAME" directives, where MY_NAME contains a stat() function and fixing it will take quite some effort).

If nothing else, this makes it explicit that POSIX functions from global namespace are used.

Thanks.