### PR TITLE
Fix unexpected log macro expansion

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -327,8 +327,10 @@ inline void critical(const wchar_t *fmt, const Args &... args)
 //
 
 #define SPDLOG_LOGGER_CALL(logger, level, ...)                                                                                             \
-    if (logger->should_log(level))                                                                                                         \
-    logger->log(spdlog::source_loc{SPDLOG_FILE_BASENAME(__FILE__), __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+    do {                                                                                                                                   \
+        if (logger->should_log(level))                                                                                                     \
+            logger->log(spdlog::source_loc{SPDLOG_FILE_BASENAME(__FILE__), __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)                 \
+    } while (0)
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define SPDLOG_LOGGER_TRACE(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__)


### PR DESCRIPTION
Old macros caused trouble if used in if-statements with an else-block not wrapped in curly braces.

See issue #1052 and referenced stackoverflow posts.