### PR TITLE
Remove unnecessary semicolons (-Wextra-semi)

### DIFF
--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -352,7 +352,7 @@ class Y_formatter final : public flag_formatter
 {
 public:
     explicit Y_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -418,7 +418,7 @@ class I_formatter final : public flag_formatter
 {
 public:
     explicit I_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -433,7 +433,7 @@ class M_formatter final : public flag_formatter
 {
 public:
     explicit M_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -448,7 +448,7 @@ class S_formatter final : public flag_formatter
 {
 public:
     explicit S_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -463,7 +463,7 @@ class e_formatter final : public flag_formatter
 {
 public:
     explicit e_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -486,7 +486,7 @@ class f_formatter final : public flag_formatter
 {
 public:
     explicit f_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -509,7 +509,7 @@ class F_formatter final : public flag_formatter
 {
 public:
     explicit F_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -532,7 +532,7 @@ class E_formatter final : public flag_formatter
 {
 public:
     explicit E_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -549,7 +549,7 @@ class p_formatter final : public flag_formatter
 {
 public:
     explicit p_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -564,7 +564,7 @@ class r_formatter final : public flag_formatter
 {
 public:
     explicit r_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -586,7 +586,7 @@ class R_formatter final : public flag_formatter
 {
 public:
     explicit R_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -604,7 +604,7 @@ class T_formatter final : public flag_formatter
 {
 public:
     explicit T_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &tm_time, fmt::memory_buffer &dest) override
     {
@@ -624,7 +624,7 @@ class z_formatter final : public flag_formatter
 {
 public:
     explicit z_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     const std::chrono::seconds cache_refresh = std::chrono::seconds(5);
 
@@ -683,7 +683,7 @@ class t_formatter final : public flag_formatter
 {
 public:
     explicit t_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -705,7 +705,7 @@ class pid_formatter final : public flag_formatter
 {
 public:
     explicit pid_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -728,7 +728,7 @@ class i_formatter final : public flag_formatter
 {
 public:
     explicit i_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -742,7 +742,7 @@ class v_formatter final : public flag_formatter
 {
 public:
     explicit v_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -829,7 +829,7 @@ class source_location_formatter final : public flag_formatter
 {
 public:
     explicit source_location_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -858,7 +858,7 @@ class source_filename_formatter final : public flag_formatter
 {
 public:
     explicit source_filename_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -875,7 +875,7 @@ class source_linenum_formatter final : public flag_formatter
 {
 public:
     explicit source_linenum_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {
@@ -900,7 +900,7 @@ class source_funcname_formatter final : public flag_formatter
 {
 public:
     explicit source_funcname_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo){}
 
     void format(const details::log_msg &msg, const std::tm &, fmt::memory_buffer &dest) override
     {


### PR DESCRIPTION
I'm compiling my code with [`-Wextra-semi`](https://clang.llvm.org/docs/DiagnosticsReference.html#wextra-semi) which causes warnings in one of spdlog's headers.

I haven't added `-Wextra-semi` in spdlog's CMakeLists.txt since it's only supported by newer GCC and Clang versions.