### PR TITLE
Add option to force color output without TTY

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -160,6 +160,16 @@ using level_hasher = std::hash<int>;
 } // namespace level
 
 //
+// Color mode used by sinks with color support.
+//
+enum class color_mode
+{
+    always,
+    automatic,
+    never
+};
+
+//
 // Pattern time - specific time getting to use for pattern_formatter.
 // local time by default
 //

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -33,12 +33,12 @@ class ansicolor_sink final : public sink
 {
 public:
     using mutex_t = typename ConsoleMutex::mutex_t;
-    ansicolor_sink()
+    ansicolor_sink(color_mode mode = color_mode::automatic)
         : target_file_(TargetStream::stream())
         , mutex_(ConsoleMutex::mutex())
 
     {
-        should_do_colors_ = details::os::in_terminal(target_file_) && details::os::is_color_terminal();
+        set_color_mode(mode);
         colors_[level::trace] = white;
         colors_[level::debug] = cyan;
         colors_[level::info] = green;
@@ -136,6 +136,22 @@ public:
     bool should_color()
     {
         return should_do_colors_;
+    }
+
+    void set_color_mode(color_mode mode)
+    {
+        switch (mode)
+        {
+        case color_mode::always:
+            should_do_colors_ = true;
+            return;
+        case color_mode::automatic:
+            should_do_colors_ = details::os::in_terminal(target_file_) && details::os::is_color_terminal();
+            return;
+        case color_mode::never:
+            should_do_colors_ = false;
+            return;
+        }
     }
 
 private:

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -31,26 +31,26 @@ using stderr_color_sink_st = ansicolor_stderr_sink_st;
 } // namespace sinks
 
 template<typename Factory = default_factory>
-inline std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name)
+inline std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic)
 {
-    return Factory::template create<sinks::stdout_color_sink_mt>(logger_name);
+    return Factory::template create<sinks::stdout_color_sink_mt>(logger_name, mode);
 }
 
 template<typename Factory = default_factory>
-inline std::shared_ptr<logger> stdout_color_st(const std::string &logger_name)
+inline std::shared_ptr<logger> stdout_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic)
 {
-    return Factory::template create<sinks::stdout_color_sink_st>(logger_name);
+    return Factory::template create<sinks::stdout_color_sink_st>(logger_name, mode);
 }
 
 template<typename Factory = default_factory>
-inline std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name)
+inline std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic)
 {
-    return Factory::template create<sinks::stderr_color_sink_mt>(logger_name);
+    return Factory::template create<sinks::stderr_color_sink_mt>(logger_name, mode);
 }
 
 template<typename Factory = default_factory>
-inline std::shared_ptr<logger> stderr_color_st(const std::string &logger_name)
+inline std::shared_ptr<logger> stderr_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic)
 {
-    return Factory::template create<sinks::stderr_color_sink_st>(logger_name);
+    return Factory::template create<sinks::stderr_color_sink_st>(logger_name, mode);
 }
 } // namespace spdlog

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -37,10 +37,11 @@ public:
     const WORD WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
     const WORD YELLOW = FOREGROUND_RED | FOREGROUND_GREEN;
 
-    wincolor_sink()
+    wincolor_sink(color_mode mode = color_mode::automatic)
         : out_handle_(OutHandle::handle())
         , mutex_(ConsoleMutex::mutex())
     {
+        set_color_mode(mode);
         colors_[level::trace] = WHITE;
         colors_[level::debug] = CYAN;
         colors_[level::info] = GREEN;
@@ -70,7 +71,7 @@ public:
         std::lock_guard<mutex_t> lock(mutex_);
         fmt::memory_buffer formatted;
         formatter_->format(msg, formatted);
-        if (msg.color_range_end > msg.color_range_start)
+        if (should_do_colors_ && msg.color_range_end > msg.color_range_start)
         {
             // before color range
             print_range_(formatted, 0, msg.color_range_start);
@@ -83,7 +84,7 @@ public:
                                // after color range
             print_range_(formatted, msg.color_range_end, formatted.size());
         }
-        else // print without colors if color range is invalid
+        else // print without colors if color range is invalid (or color is disabled)
         {
             print_range_(formatted, 0, formatted.size());
         }
@@ -104,6 +105,20 @@ public:
     {
         std::lock_guard<mutex_t> lock(mutex_);
         formatter_ = std::move(sink_formatter);
+    }
+
+    void set_color_mode(color_mode mode)
+    {
+        switch (mode)
+        {
+        case color_mode::always:
+        case color_mode::automatic:
+            should_do_colors_ = true;
+            return;
+        case color_mode::never:
+            should_do_colors_ = false;
+            return;
+        }
     }
 
 private:
@@ -130,6 +145,7 @@ private:
 
     HANDLE out_handle_;
     mutex_t &mutex_;
+    bool should_do_colors_;
     std::unordered_map<level::level_enum, WORD, level::level_hasher> colors_;
 };
 


### PR DESCRIPTION
This adds a member function `ansicolor_sink::force_color_output` which can be used to force the output of color codes even when no TTY with color support is detected, as discussed in #1074. The `std[out|err]_color_[mt|st]` factory functions now support an optional argument `force_color_output` (which defaults to `false`) to make it more convenient to set this option directly upon construction.

As per @gabime's request I didn't add a new parameter to `ansicolor_sink`'s constructor, which makes the factory functions a bit clunky, but I tried to keep everything DRY.