### PR TITLE
Adding Bazel Build rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Auto generated files
+bazel*
 build/*
 *.slo
 *.lo

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Auto generated files
+.vscode*
 bazel*
+# Auto generated files
 build/*
 *.slo
 *.lo

--- a/BUILD
+++ b/BUILD
@@ -5,57 +5,16 @@ cc_library(
     includes = ["include"],
 )
 
-cc_binary(
-  name="bench",
-  srcs=[
-    "bench/utils.h",
-    "bench/bench.cpp"
-  ],
-  includes=[
-    "bench"
-  ],
-  deps=[
-    ":headers"
-  ]
+
+cc_library(
+    name = "spdlog",
+    visibility = ["//visibility:public"],
+    defines=[
+      "SPDLOG_COMPILED_LIB"
+    ],
+    srcs = ["src/spdlog.cpp"],
+    includes = ["include"],
 )
 
-cc_binary(
-  name="async_bench",
-  srcs=[
-    "bench/utils.h",
-    "bench/async_bench.cpp"
-  ],
-  includes=[
-    "bench"
-  ],
-  deps=[
-    ":headers"
-  ]
-)
 
-cc_binary(
-  name="latency",
-  srcs=[
-    "bench/utils.h",
-    "bench/latency.cpp"
-  ],
-  includes=[
-    "bench"
-  ],
-  deps=[
-    ":headers"
-  ]
-)
 
-cc_binary(
-  name="example",
-  srcs=[
-    "example/example.cpp"
-  ],
-  includes=[
-    "bench"
-  ],
-  deps=[
-    ":headers"
-  ]
-)

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,61 @@
+cc_library(
+    name = "headers",
+    visibility = ["//visibility:public"],
+    hdrs = glob(["include/**/*.h*"]),
+    includes = ["include"],
+)
+
+cc_binary(
+  name="bench",
+  srcs=[
+    "bench/utils.h",
+    "bench/bench.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)
+
+cc_binary(
+  name="async_bench",
+  srcs=[
+    "bench/utils.h",
+    "bench/async_bench.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)
+
+cc_binary(
+  name="latency",
+  srcs=[
+    "bench/utils.h",
+    "bench/latency.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)
+
+cc_binary(
+  name="example",
+  srcs=[
+    "example/example.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)

--- a/bench/BUILD
+++ b/bench/BUILD
@@ -1,0 +1,41 @@
+cc_binary(
+  name="bench",
+  srcs=[
+    "bench/utils.h",
+    "bench/bench.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)
+
+cc_binary(
+  name="async_bench",
+  srcs=[
+    "bench/utils.h",
+    "bench/async_bench.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)
+
+cc_binary(
+  name="latency",
+  srcs=[
+    "bench/utils.h",
+    "bench/latency.cpp"
+  ],
+  includes=[
+    "bench"
+  ],
+  deps=[
+    ":headers"
+  ]
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,0 +1,23 @@
+cc_test(
+  name="main",
+  srcs=glob([
+    "*.h*",
+    "utils.cpp",
+    "main.cpp",
+    "test_*.cpp"
+    ],
+    exclude=[
+      "test_systemd.cpp"
+    ]
+  ) + select({
+    "@bazel_tools//src/conditions:windows": [],
+    "@bazel_tools//src/conditions:darwin": [],
+    "//conditions:default": ["test_systemd.cpp"],
+  }),
+  includes=[
+    "tests"
+  ],
+  deps=[
+    "//:headers"
+  ]
+)


### PR DESCRIPTION
This PR adds [bazel](https://bazel.build/) build rules to spdlog, allowing it to be used as a dependency in bazel projects.

## Usage
Given a correctly installed bazel and msvc/gcc/clang
### WORKSPACE file
```
load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
http_archive(
    name = "spdlog",
    urls = ["https://github.com/cgrinker/spdlog/archive/3bf4a07dc286e10fa32d6503fded647c9ee02d26.zip"],
    strip_prefix = "spdlog-3bf4a07dc286e10fa32d6503fded647c9ee02d26",
    sha256 = "d00ccd202e2abae832441b9121330a4b8b82fdc60564edb315c89506fa3772c3",
)
```

### BUILD file
```
cc_binary(
    name="example",
    srcs=[
      "main.cpp"
    ],
    deps=[
        "@spdlog//:headers",
    ]
)

```

### main.cpp
```cpp
#include <spdlog/spdlog.h>
#include <spdlog/fmt/ostr.h>
#include "spdlog/sinks/stdout_color_sinks.h"

int main(int argc, char** argv)
{
    auto logger = spdlog::stdout_color_mt("example");
    logger->info("Hello With Bazel");
    return 0;
}
```
