### PR TITLE
Added !defined(__HAIKU__) to #if for stat64 struct.

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -237,7 +237,7 @@ inline size_t filesize(FILE *f)
 #else // unix
     int fd = fileno(f);
     // 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
-#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
+#if !defined(__OpenBSD__) && !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(__HAIKU__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
     struct stat64 st;
     if (fstat64(fd, &st) == 0)
     {


### PR DESCRIPTION
Adding `!defined(__HAIKU__)` to os.h allows for use on [Haiku](https://www.haiku-os.og).