### PR TITLE
Allow flush period to be any duration instead of std::chrono:seconds

### DIFF
--- a/include/spdlog/details/periodic_worker-inl.h
+++ b/include/spdlog/details/periodic_worker-inl.h
@@ -10,27 +10,6 @@
 namespace spdlog {
 namespace details {
 
-SPDLOG_INLINE periodic_worker::periodic_worker(const std::function<void()> &callback_fun, std::chrono::seconds interval)
-{
-    active_ = (interval > std::chrono::seconds::zero());
-    if (!active_)
-    {
-        return;
-    }
-
-    worker_thread_ = std::thread([this, callback_fun, interval]() {
-        for (;;)
-        {
-            std::unique_lock<std::mutex> lock(this->mutex_);
-            if (this->cv_.wait_for(lock, interval, [this] { return !this->active_; }))
-            {
-                return; // active_ == false, so exit this thread
-            }
-            callback_fun();
-        }
-    });
-}
-
 // stop the worker thread and join it
 SPDLOG_INLINE periodic_worker::~periodic_worker()
 {

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -20,7 +20,27 @@ namespace details {
 class periodic_worker
 {
 public:
-    periodic_worker(const std::function<void()> &callback_fun, std::chrono::seconds interval);
+    template<class Rep, class Period>
+    SPDLOG_INLINE periodic_worker(const std::function<void()> &callback_fun, std::chrono::duration<Rep, Period> interval)
+    {
+        active_ = (interval > std::chrono::duration<Rep, Period>::zero());
+        if (!active_)
+        {
+            return;
+        }
+
+        worker_thread_ = std::thread([this, callback_fun, interval]() {
+            for (;;)
+            {
+                std::unique_lock<std::mutex> lock(this->mutex_);
+                if (this->cv_.wait_for(lock, interval, [this] { return !this->active_; }))
+                {
+                    return; // active_ == false, so exit this thread
+                }
+                callback_fun();
+            }
+        });
+    }
     periodic_worker(const periodic_worker &) = delete;
     periodic_worker &operator=(const periodic_worker &) = delete;
     // stop the worker thread and join it

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -156,13 +156,6 @@ SPDLOG_INLINE void registry::flush_on(level::level_enum log_level)
     flush_level_ = log_level;
 }
 
-SPDLOG_INLINE void registry::flush_every(std::chrono::seconds interval)
-{
-    std::lock_guard<std::mutex> lock(flusher_mutex_);
-    std::function<void()> clbk = std::bind(&registry::flush_all, this);
-    periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
-}
-
 SPDLOG_INLINE void registry::set_error_handler(void (*handler)(const std::string &msg))
 {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -56,7 +56,13 @@ public:
 
     void flush_on(level::level_enum log_level);
 
-    void flush_every(std::chrono::seconds interval);
+    template<class Rep, class Period>
+    void flush_every(std::chrono::duration<Rep, Period> interval)
+    {
+        std::lock_guard<std::mutex> lock(flusher_mutex_);
+        std::function<void()> clbk = std::bind(&registry::flush_all, this);
+        periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
+    }
 
     void set_error_handler(void (*handler)(const std::string &msg));
 

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -42,11 +42,6 @@ SPDLOG_INLINE void flush_on(level::level_enum log_level)
     details::registry::instance().flush_on(log_level);
 }
 
-SPDLOG_INLINE void flush_every(std::chrono::seconds interval)
-{
-    details::registry::instance().flush_every(interval);
-}
-
 SPDLOG_INLINE void set_error_handler(void (*handler)(const std::string &msg))
 {
     details::registry::instance().set_error_handler(handler);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "spdlog/common.h"
+#include "spdlog/details/periodic_worker.h"
 #include "spdlog/details/registry.h"
 #include "spdlog/logger.h"
 #include "spdlog/version.h"
@@ -67,7 +68,11 @@ void flush_on(level::level_enum log_level);
 
 // Start/Restart a periodic flusher thread
 // Warning: Use only if all your loggers are thread safe!
-void flush_every(std::chrono::seconds interval);
+template<class Rep, class Period>
+inline void flush_every(std::chrono::duration<Rep, Period> interval)
+{
+    details::registry::instance().flush_every(interval);
+}
 
 // Set global error handler
 void set_error_handler(void (*handler)(const std::string &msg));


### PR DESCRIPTION
I need to flush logs faster than one second, but discovered that it's not possible with current implementation of spdlog::flush_every.
I provided templated version of spdlog::flush_every and periodic_worker::periodic_worker() for support of arbitrary duration from std::chrono