### PR TITLE
Fix use of incomplete type in stdout sinks

### DIFF
--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -5,6 +5,7 @@
 
 #include "spdlog/details/console_globals.h"
 #include "spdlog/details/synchronous_factory.h"
+#include "spdlog/sinks/sink.h"
 #include <cstdio>
 
 namespace spdlog {


### PR DESCRIPTION
Snippet (includes sorted by clang-format):
```c++
#include <spdlog/sinks/stdout_sinks.h>
#include <spdlog/spdlog.h>

int main()
{
    auto sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
    auto my_logger = std::make_shared<spdlog::logger>("mylogger", sink);
}
```

Result:
```
/usr/local/include/spdlog/sinks/stdout_sinks.h:15: error: invalid use of incomplete type ‘class spdlog::sinks::sink’
 class stdout_sink_base : public sink
                                 ^~~~
```