### PR TITLE
Provide source location support for systemd_sink.h

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set(SPDLOG_UTESTS_SOURCES
     test_mpmc_q.cpp
     test_sink.h
     test_fmt_helper.cpp
-	test_stdout_api.cpp)
+    test_stdout_api.cpp)
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")
 enable_testing()

--- a/tests/test_systemd.cpp
+++ b/tests/test_systemd.cpp
@@ -8,6 +8,6 @@ TEST_CASE("systemd", "[all]")
     spdlog::logger logger("spdlog_systemd_test", systemd_sink);
 
     logger.debug("test debug");
-    logger.error("test error");
+    SPDLOG_LOGGER_ERROR((&logger), "test error");
     logger.info("test info");
 }


### PR DESCRIPTION
This PR includes support to send source code location information to the journal.
It replaces `sd_journal_print` with `sd_journal_send`, which allows more control over the journal's metadata.

If `spdlog-utets` contains `test_systemd.cpp`, the output may look like:
```
$ journalctl -r -o json-pretty _PID=20564 | jq -C 'select(.CODE_FILE != null)'
{
  "_PID": "20564",
  "_SYSTEMD_OWNER_UID": "1000",
  "_CMDLINE": "tests/spdlog-utests -n systemd",
  "_CAP_EFFECTIVE": "0",
  "_TRANSPORT": "journal",
  "_SYSTEMD_INVOCATION_ID": "db6561d285914cd59c2ee2e55bb786b4",
  "_UID": "1000",
  "_GID": "1000",
  "_COMM": "spdlog-utests",
  "CODE_LINE": "11",
  "_SYSTEMD_USER_UNIT": "gnome-terminal-server.service",
  "_SYSTEMD_CGROUP": "/user.slice/user-1000.slice/user@1000.service/gnome-terminal-server.service",
  "_AUDIT_LOGINUID": "1000",
  "_AUDIT_SESSION": "3",
  "CODE_FILE": "/home/jcastro/dev/libraries/spdlog/tests/test_systemd.cpp",
  "SYSLOG_IDENTIFIER": "spdlog-utests",
  "_SOURCE_REALTIME_TIMESTAMP": "1561643730729194",
  "_SYSTEMD_UNIT": "user@1000.service",
  "PRIORITY": "3",
  "MESSAGE": "test error",
  "__MONOTONIC_TIMESTAMP": "17746029539",
  "_SYSTEMD_USER_SLICE": "-.slice",
  "_SYSTEMD_SLICE": "user-1000.slice",
  "_EXE": "/home/jcastro/dev/libraries/spdlog/build/tests/spdlog-utests",
  "CODE_FUNC": "____C_A_T_C_H____T_E_S_T____0"
}
```