### PR TITLE
Add meson support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ example/*
 !example/example.sln
 !example/example.vcxproj
 !example/CMakeLists.txt
+!example/meson.build
 !example/multisink.cpp
 !example/jni
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ build/*
 # Codelite
 .codelite
 
+# KDevelop
+*.kdev4
+
 # .orig files
 *.orig
 

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,0 +1,13 @@
+benchmark = dependency('benchmark')
+
+bench_matrix = [
+  ['bench',           [spdlog_dep],            []],
+  ['async_bench',     [spdlog_dep],            []],
+  ['formatter-bench', [spdlog_dep, benchmark], ['all']],
+  ['latency',         [spdlog_dep, benchmark], []],
+]
+
+foreach i : bench_matrix
+  bench_exe = executable(i[0], i[0] + '.cpp', dependencies: i[1])
+  benchmark('bench_' + i[0], bench_exe, args: i[2])
+endforeach

--- a/example/meson.build
+++ b/example/meson.build
@@ -1,0 +1,8 @@
+example_matrix =  [
+  ['spdlog-example',    spdlog_dep],
+  ['spdlog-example-ho', spdlog_headeronly_dep],
+]
+
+foreach i : example_matrix
+  test_exe = executable(i[0], ['example.cpp'], dependencies: i[1])
+endforeach

--- a/extract_version.py
+++ b/extract_version.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os
+import re
+
+base_path = os.path.abspath(os.path.dirname(__file__))
+config_h  = os.path.join(base_path, 'include', 'spdlog', 'version.h')
+data      = {'MAJOR': 0, 'MINOR': 0, 'PATCH': 0}
+reg       = re.compile(r'^\s*#define\s+SPDLOG_VER_([A-Z]+)\s+([0-9]+).*$')
+
+with open(config_h, 'r') as fp:
+  for l in fp:
+    m = reg.match(l)
+    if m:
+      data[m.group(1)] = int(m.group(2))
+
+print('{}.{}.{}'.format(data['MAJOR'], data['MINOR'], data['PATCH']))

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('spdlog', ['cpp'],
   license         : 'MIT',
-  version         : run_command(find_program('extract_version.py')).stdout().strip(),
+  version         : run_command(find_program('scripts/extract_version.py')).stdout().strip(),
   default_options : [
     'warning_level=3',
     'cpp_std=c++11',

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,13 @@
 project('spdlog', ['cpp'],
   license         : 'MIT',
-  version         : '1.3.1',
-  default_options : ['warning_level=3', 'cpp_std=c++11', 'default_library=static'],
+  version         : run_command(find_program('extract_version.py')).stdout().strip(),
+  default_options : [
+    'warning_level=3',
+    'cpp_std=c++11',
+    'default_library=static',
+    'buildtype=release',
+    'b_colorout=always',
+  ],
 )
 
 # ------------------------

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,105 @@
+project('spdlog', ['cpp'],
+  license         : 'MIT',
+  version         : '1.3.1',
+  default_options : ['warning_level=3', 'cpp_std=c++11', 'default_library=static'],
+)
+
+# ------------------------
+# ---   Dependencies   ---
+# ------------------------
+
+dep_list = []
+compile_args = []
+
+# Threads
+dep_list += dependency('threads')
+
+# Check for FMT
+if get_option('extrenal_fmt')
+  if not meson.version().version_compare('>=0.49.0')
+    warning('Finding fmt can fail wit meson versions before 0.49.0')
+  endif
+  dep_list     += dependency('fmt')
+  compile_args += '-DSPDLOG_FMT_EXTERNAL'
+endif
+
+# ------------------------------------
+# ---   Compiled library version   ---
+# ------------------------------------
+
+spdlog_inc = include_directories('./include')
+
+spdlog = library('spdlog', ['src/spdlog.cpp'],
+  cpp_args            : [compile_args] + ['-DSPDLOG_COMPILED_LIB'],
+  include_directories : spdlog_inc,
+  dependencies        : dep_list,
+  install             : true,
+)
+
+spdlog_dep = declare_dependency(
+  link_with           : spdlog,
+  include_directories : spdlog_inc,
+  compile_args        : compile_args + ['-DSPDLOG_COMPILED_LIB'],
+  dependencies        : dep_list,
+  version             : meson.project_version(),
+)
+
+# ----------------------------------
+# ---   Header only dependency   ---
+# ----------------------------------
+
+spdlog_headeronly_dep = declare_dependency(
+  include_directories : spdlog_inc,
+  compile_args        : compile_args,
+  dependencies        : dep_list,
+  version             : meson.project_version(),
+)
+
+# ------------------------
+# ---   Installation   ---
+# ------------------------
+
+install_subdir('include/spdlog', install_dir: get_option('includedir'))
+
+pkg = import('pkgconfig')
+pkg.generate(spdlog,
+  name         : 'spdlog',
+  description  : 'Fast C++ logging library',
+  url          : 'https://github.com/gabime/spdlog',
+  extra_cflags : ['-DSPDLOG_COMPILED_LIB']
+)
+
+# -------------------------------------
+# ---   Conditionally add subdirs   ---
+# -------------------------------------
+
+if get_option('enable_tests')
+  subdir('tests')
+endif
+
+if get_option('enable_examples')
+  subdir('example')
+endif
+
+if get_option('enable_benchmarks')
+  subdir('bench')
+endif
+
+# -------------------
+# ---   Summary   ---
+# -------------------
+
+summary_str = '''spdlog build summary:
+
+  - using extrenal fmt:  @0@
+  - building tests:      @1@
+  - building examples:   @2@
+  - building benchmarks: @3@
+'''.format(
+  get_option('extrenal_fmt'),
+  get_option('enable_tests'),
+  get_option('enable_examples'),
+  get_option('enable_benchmarks')
+)
+
+message(summary_str)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,4 @@
+option('extrenal_fmt',      type: 'boolean', value: false)
+option('enable_examples',   type: 'boolean', value: false)
+option('enable_benchmarks', type: 'boolean', value: false)
+option('enable_tests',      type: 'boolean', value: false)

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,1 +1,6 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+cd ..
+
 clang-tidy example/example.cpp -- -I ./include

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-base_path = os.path.abspath(os.path.dirname(__file__))
+base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 config_h  = os.path.join(base_path, 'include', 'spdlog', 'version.h')
 data      = {'MAJOR': 0, 'MINOR': 0, 'PATCH': 0}
 reg       = re.compile(r'^\s*#define\s+SPDLOG_VER_([A-Z]+)\s+([0-9]+).*$')

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+cd ..
+
 echo -n "Running dos2unix     "
 find . -name "*\.h" -o -name "*\.cpp"|grep -v bundled|xargs -I {} sh -c "dos2unix '{}' 2>/dev/null; echo -n '.'"
 echo

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,43 @@
+test_sources = files([
+  'main.cpp',
+  'test_async.cpp',
+  'test_dup_filter.cpp',
+  'test_errors.cpp',
+  'test_file_helper.cpp',
+  'test_file_logging.cpp',
+  'test_fmt_helper.cpp',
+  'test_macros.cpp',
+  'test_misc.cpp',
+  'test_mpmc_q.cpp',
+  'test_pattern_formatter.cpp',
+  'test_registry.cpp',
+  'test_stdout_api.cpp',
+  'utils.cpp',
+])
+
+global_test_deps = []
+
+# -----------------------------------------------------
+# ---   Add the systemd test if libsystemd is found ---
+# -----------------------------------------------------
+
+systemd_dep = dependency('libsystemd', required: false)
+
+if systemd_dep.found()
+  test_sources += files(['test_systemd.cpp'])
+  global_test_deps += systemd_dep
+endif
+
+# --------------------------------------
+# ---   Build the test executables   ---
+# --------------------------------------
+
+test_matrix =  [
+  ['spdlog-utest',    spdlog_dep],
+  ['spdlog-utest-ho', spdlog_headeronly_dep],
+]
+
+foreach i : test_matrix
+  test_exe = executable(i[0], test_sources, dependencies: global_test_deps + [i[1]])
+  test('test_' + i[0], test_exe)
+endforeach


### PR DESCRIPTION
This PR adds support for the meson build system. This change allows easy inclusion of spdlog in meson projects. Additionally, most features from the current CMake build should also be supported.

A working example:

```
.
├── main.cpp
├── meson.build
└── subprojects
    └── spdlog
```

meson.build:

```meson
project('mesonTest', ['cpp'])

sub = subproject('spdlog')
dep = sub.get_variable('spdlog_dep')

executable('main', ['main.cpp'], dependencies: [dep])
```

main.cpp:

```cpp
#include <spdlog/spdlog.h>

int main(int argc, char *argv[]) {
  spdlog::info("Hello World");
  return 0;
}
```

Build instructions:
```bash
cd /path/to/source/root
meson build
ninja -C build
./build/main
```


