### PR TITLE
Fix rotation condition when SPDLOG_NO_DATETIME is defined.

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -67,8 +67,11 @@ public:
 protected:
     void sink_it_(const details::log_msg &msg) override
     {
-
+#ifdef SPDLOG_NO_DATETIME
+        if (log_clock::now() >= rotation_tp_)
+#else
         if (msg.time >= rotation_tp_)
+#endif
         {
             file_helper_.open(FileNameCalc::calc_filename(base_filename_, now_tm(msg.time)), truncate_);
             rotation_tp_ = next_rotation_tp_();


### PR DESCRIPTION
I noticed daily rotation was not worked when `SPDLOG_NO_DATETIME` is defined.
This PR will fix it :)


