### PR TITLE
Add missing include

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -7,6 +7,7 @@
 #include "spdlog/sinks/ansicolor_sink.h"
 #endif
 
+#include "spdlog/details/pattern_formatter.h"
 #include "spdlog/details/os.h"
 
 namespace spdlog {


### PR DESCRIPTION
This fixes the follows (compiler: clang-8):
```
...build/_deps/spdlog-src/include/spdlog/sinks/ansicolor_sink-inl.h:19:47: error: no member named
      'pattern_formatter' in namespace 'spdlog'
    , formatter_(details::make_unique<spdlog::pattern_formatter>())
                                      ~~~~~~~~^
...build/_deps/spdlog-src/include/spdlog/sinks/ansicolor_sink-inl.h:77:57: error: unknown type name
      'pattern_formatter'
    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
```