### PR TITLE
Fix syslog output

### DIFF
--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -59,7 +59,8 @@ protected:
             payload = msg.payload;
         }
 
-        ::syslog(syslog_prio_from_level(msg), "%s", payload.data());
+        int length = std::min<std::common_type<int, std::size_t>::type>(std::numeric_limits<int>::max(), payload.size());
+        ::syslog(syslog_prio_from_level(msg), "%.*s", length, payload.data());
     }
 
     void flush_() override {}


### PR DESCRIPTION
payload does not appear to be reliably null terminated and leaks
data. Use size to the formatter to reliably terminate messages.