### PR TITLE
Prevent NEAR and FAR macro definitions from leaking on Windows platforms

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -32,6 +32,10 @@
 #include <process.h> //  _get_pid support
 #include <windows.h>
 
+// windows.h leaks NEAR and FAR macros, prevent those from leaking further
+#undef NEAR
+#undef FAR
+
 #ifdef __MINGW32__
 #include <share.h>
 #endif


### PR DESCRIPTION
We recently encountered an issue in a project which has NEAR and FAR variables (constexpr in some namespace), after including spdlog.

Turns out that including `windows.h` leaks those, and that happened transitively through spdlog.

Now obviously this really is more of a Windows issue, but I think it would be convenient - especially for multi-platform users of spdlog - to prevent leakage of these symbols (with the same reasoning as e.g. for defining NOMINMAX). 

The required change is rather trivial.