### PR TITLE
Fix compiler and linker errors

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -14,14 +14,6 @@
 #include <memory>
 #include <string>
 
-template<typename It>
-SPDLOG_INLINE spdlog::async_logger::async_logger(
-    std::string logger_name, It begin, It end, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
-    : logger(std::move(logger_name), begin, end)
-    , thread_pool_(std::move(tp))
-    , overflow_policy_(overflow_policy)
-{}
-
 SPDLOG_INLINE spdlog::async_logger::async_logger(
     std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : async_logger(std::move(logger_name), sinks_list.begin(), sinks_list.end(), std::move(tp), overflow_policy)

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -37,7 +37,11 @@ class async_logger final : public std::enable_shared_from_this<async_logger>, pu
 public:
     template<typename It>
     async_logger(std::string logger_name, It begin, It end, std::weak_ptr<details::thread_pool> tp,
-        async_overflow_policy overflow_policy = async_overflow_policy::block);
+        async_overflow_policy overflow_policy = async_overflow_policy::block)
+        : logger(std::move(logger_name), begin, end)
+        , thread_pool_(std::move(tp))
+        , overflow_policy_(overflow_policy)
+    {}
 
     async_logger(std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp,
         async_overflow_policy overflow_policy = async_overflow_policy::block);

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -41,6 +41,6 @@ protected:
 } // namespace sinks
 } // namespace spdlog
 
-#ifndef SPDLOG_COMPILED_LIB
+#ifdef SPDLOG_HEADER_ONLY
 #include "base_sink-inl.h"
 #endif

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "spdlog/details/console_globals.h"
+#include "spdlog/details/pattern_formatter.h"
 #include <memory>
 
 namespace spdlog {


### PR DESCRIPTION
This PR fixes two issues I recently encountered:

1. Following code triggers compilation error caused by missing include of `spdlog/details/pattern_formatter.h`.
```cpp
#include <spdlog/spdlog.h>
#include <spdlog/sinks/stdout_sinks.h>

int main()
{
    std::make_shared<spdlog::sinks::stdout_sink_mt>();
}
```

2. Using templated constructor for `async_logger` along with building spdlog as a static library triggers linker error when:

a) We use anything else than `std::vector` iterators:
```cpp
#include <spdlog/async.h>
#include <spdlog/sinks/stdout_sinks.h>
#include <list>

int main()
{
    std::list<spdlog::sink_ptr> sinks = {std::make_shared<spdlog::sinks::stdout_sink_mt>()};
    std::make_shared<spdlog::async_logger>("logger", begin(sinks), end(sinks), spdlog::thread_pool());
}
```
Using vector as a sink container "seems" fine because `async_logger::clone` instantiates the template specialization for `std::vector` iterators.

b) We compile with clang (tested with 6.0) with -O2 and -flto. This makes the aforementioned function `async_logger::clone` to be dead-code eliminated and subsequently no one instantiates vector iterator specialization of templated `async_logger` constructor.

