### PR TITLE
add spdlog_api macros for visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,12 @@ target_include_directories(spdlog PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(spdlog PUBLIC Threads::Threads)
+set_target_properties(spdlog PROPERTIES DEFINE_SYMBOL SPDLOG_EXPORTS)
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(spdlog PUBLIC SPDLOG_SHARED)
+endif ()
+
 spdlog_enable_warnings(spdlog)
 
 #---------------------------------------------------------------------------------------
@@ -92,7 +98,6 @@ target_include_directories(spdlog_header_only INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
-
 
 #---------------------------------------------------------------------------------------
 # Use fmt package if using exertnal fmt

--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -14,6 +14,7 @@
 // This is because each message in the queue holds a shared_ptr to the
 // originating logger.
 
+#include "spdlog/common.h"
 #include "spdlog/async_logger.h"
 #include "spdlog/details/registry.h"
 #include "spdlog/details/thread_pool.h"
@@ -25,14 +26,14 @@
 namespace spdlog {
 
 namespace details {
-static const size_t default_async_q_size = 8192;
+SPDLOG_CONSTEXPR static const size_t default_async_q_size = 8192;
 }
 
 // async logger factory - creates async loggers backed with thread pool.
 // if a global thread pool doesn't already exist, create it with default queue
 // size of 8192 items and single thread.
 template<async_overflow_policy OverflowPolicy = async_overflow_policy::block>
-struct async_factory_impl
+struct SPDLOG_API async_factory_impl
 {
     template<typename Sink, typename... SinkArgs>
     static std::shared_ptr<async_logger> create(std::string logger_name, SinkArgs &&... args)

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -14,6 +14,7 @@
 // Upon destruction, logs all remaining messages in the queue before
 // destructing..
 
+#include "spdlog/common.h"
 #include "spdlog/logger.h"
 
 namespace spdlog {
@@ -30,7 +31,7 @@ namespace details {
 class thread_pool;
 }
 
-class async_logger final : public std::enable_shared_from_this<async_logger>, public logger
+class SPDLOG_API async_logger final : public std::enable_shared_from_this<async_logger>, public logger
 {
     friend class details::thread_pool;
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -34,6 +34,26 @@
 #define SPDLOG_INLINE inline
 #endif
 
+#if !defined(SPDLOG_HEADER_ONLY)
+# if defined(_WIN32) || defined(__CYGWIN__)
+#  if defined(SPDLOG_EXPORTS)
+#   define SPDLOG_API __declspec(dllexport)
+#  elif defined(SPDLOG_SHARED)
+#   define SPDLOG_API __declspec(dllimport)
+#  endif
+# elif __GNUC__ >= 4
+#  define SPDLOG_API     __attribute__ ((visibility ("default")))
+#  define SPDLOG_PRIVATE __attribute__ ((visibility ("hidden")))
+# endif
+#endif
+
+#ifndef SPDLOG_API
+# define SPDLOG_API
+#endif
+#ifndef SPDLOG_PRIVATE
+# define SPDLOG_PRIVATE
+#endif
+
 #include "spdlog/fmt/fmt.h"
 
 // visual studio upto 2013 does not support noexcept nor constexpr
@@ -144,9 +164,9 @@ enum level_enum
     }
 #endif
 
-string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
-const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
-spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
+SPDLOG_API string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
+SPDLOG_API const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
+SPDLOG_API spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
 
 using level_hasher = std::hash<int>;
 } // namespace level
@@ -174,7 +194,7 @@ enum class pattern_time_type
 //
 // Log exception
 //
-class spdlog_ex : public std::exception
+class SPDLOG_API spdlog_ex : public std::exception
 {
 public:
     explicit spdlog_ex(std::string msg);
@@ -185,7 +205,7 @@ private:
     std::string msg_;
 };
 
-struct source_loc
+struct SPDLOG_API source_loc
 {
     SPDLOG_CONSTEXPR source_loc() = default;
     SPDLOG_CONSTEXPR source_loc(const char *filename_in, int line_in, const char *funcname_in)

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -5,11 +5,12 @@
 #pragma once
 
 #include <vector>
+#include "spdlog/common.h"
 
 namespace spdlog {
 namespace details {
 template<typename T>
-class circular_q
+class SPDLOG_API circular_q
 {
 public:
     using item_type = T;

--- a/include/spdlog/details/console_globals-inl.h
+++ b/include/spdlog/details/console_globals-inl.h
@@ -1,0 +1,26 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include "spdlog/common.h"
+#include "spdlog/details/console_globals.h"
+
+namespace spdlog {
+namespace details {
+
+SPDLOG_INLINE console_mutex::mutex_t &console_mutex::mutex()
+{
+    static mutex_t s_mutex;
+    return s_mutex;
+}
+
+SPDLOG_INLINE console_nullmutex::mutex_t &console_nullmutex::mutex()
+{
+    static mutex_t s_mutex;
+    return s_mutex;
+}
+
+} // namespace details
+} // namespace spdlog
+

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -12,21 +12,17 @@ namespace details {
 struct console_mutex
 {
     using mutex_t = std::mutex;
-    static mutex_t &mutex()
-    {
-        static mutex_t s_mutex;
-        return s_mutex;
-    }
+    static mutex_t &mutex();
 };
 
 struct console_nullmutex
 {
     using mutex_t = null_mutex;
-    static mutex_t &mutex()
-    {
-        static mutex_t s_mutex;
-        return s_mutex;
-    }
+    static mutex_t &mutex();
 };
 } // namespace details
 } // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+#include "console_globals-inl.h"
+#endif

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -3,19 +3,20 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/null_mutex.h"
 #include <mutex>
 
 namespace spdlog {
 namespace details {
 
-struct console_mutex
+struct SPDLOG_API console_mutex
 {
     using mutex_t = std::mutex;
     static mutex_t &mutex();
 };
 
-struct console_nullmutex
+struct SPDLOG_API console_nullmutex
 {
     using mutex_t = null_mutex;
     static mutex_t &mutex();

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -13,7 +13,7 @@ namespace details {
 // When failing to open a file, retry several times(5) with a delay interval(10 ms).
 // Throw spdlog_ex exception on errors.
 
-class file_helper
+class SPDLOG_API file_helper
 {
 public:
     explicit file_helper() = default;

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -4,8 +4,8 @@
 
 #include <chrono>
 #include <type_traits>
-#include "spdlog/fmt/fmt.h"
 #include "spdlog/common.h"
+#include "spdlog/fmt/fmt.h"
 
 // Some fmt helpers to efficiently format and pad ints and strings
 namespace spdlog {

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -8,7 +8,7 @@
 
 namespace spdlog {
 namespace details {
-struct log_msg
+struct SPDLOG_API log_msg
 {
     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -10,6 +10,7 @@
 // dequeue_for(..) - will block until the queue is not empty or timeout have
 // passed.
 
+#include "spdlog/common.h"
 #include "spdlog/details/circular_q.h"
 
 #include <condition_variable>
@@ -19,7 +20,7 @@ namespace spdlog {
 namespace details {
 
 template<typename T>
-class mpmc_blocking_queue
+class SPDLOG_API mpmc_blocking_queue
 {
 public:
     using item_type = T;

--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -4,11 +4,12 @@
 #pragma once
 
 #include <atomic>
+#include "spdlog/common.h"
 // null, no cost dummy "mutex" and dummy "atomic" int
 
 namespace spdlog {
 namespace details {
-struct null_mutex
+struct SPDLOG_API null_mutex
 {
     void lock() {}
     void unlock() {}

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -10,15 +10,15 @@ namespace spdlog {
 namespace details {
 namespace os {
 
-spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT;
+SPDLOG_API spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT;
 
-std::tm localtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT;
+SPDLOG_API std::tm localtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT;
 
-std::tm localtime() SPDLOG_NOEXCEPT;
+SPDLOG_API std::tm localtime() SPDLOG_NOEXCEPT;
 
-std::tm gmtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT;
+SPDLOG_API std::tm gmtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT;
 
-std::tm gmtime() SPDLOG_NOEXCEPT;
+SPDLOG_API std::tm gmtime() SPDLOG_NOEXCEPT;
 
 // eol definition
 #if !defined(SPDLOG_EOL)
@@ -38,50 +38,50 @@ const char folder_sep = '\\';
 SPDLOG_CONSTEXPR static const char folder_sep = '/';
 #endif
 
-void prevent_child_fd(FILE *f);
+SPDLOG_API void prevent_child_fd(FILE *f);
 
 // fopen_s on non windows for writing
-bool fopen_s(FILE **fp, const filename_t &filename, const filename_t &mode);
+SPDLOG_API bool fopen_s(FILE **fp, const filename_t &filename, const filename_t &mode);
 
-int remove(const filename_t &filename) SPDLOG_NOEXCEPT;
+SPDLOG_API int remove(const filename_t &filename) SPDLOG_NOEXCEPT;
 
-int rename(const filename_t &filename1, const filename_t &filename2) SPDLOG_NOEXCEPT;
+SPDLOG_API int rename(const filename_t &filename1, const filename_t &filename2) SPDLOG_NOEXCEPT;
 
 // Return if file exists
-bool file_exists(const filename_t &filename) SPDLOG_NOEXCEPT;
+SPDLOG_API bool file_exists(const filename_t &filename) SPDLOG_NOEXCEPT;
 
 // Return file size according to open FILE* object
-size_t filesize(FILE *f);
+SPDLOG_API size_t filesize(FILE *f);
 
 // Return utc offset in minutes or throw spdlog_ex on failure
-int utc_minutes_offset(const std::tm &tm = details::os::localtime());
+SPDLOG_API int utc_minutes_offset(const std::tm &tm = details::os::localtime());
 
 // Return current thread id as size_t
 // It exists because the std::this_thread::get_id() is much slower(especially
 // under VS 2013)
-size_t _thread_id() SPDLOG_NOEXCEPT;
+SPDLOG_API size_t _thread_id() SPDLOG_NOEXCEPT;
 
 // Return current thread id as size_t (from thread local storage)
-size_t thread_id() SPDLOG_NOEXCEPT;
+SPDLOG_API size_t thread_id() SPDLOG_NOEXCEPT;
 
 // This is avoid msvc issue in sleep_for that happens if the clock changes.
 // See https://github.com/gabime/spdlog/issues/609
-void sleep_for_millis(int milliseconds) SPDLOG_NOEXCEPT;
+SPDLOG_API void sleep_for_millis(int milliseconds) SPDLOG_NOEXCEPT;
 
-std::string filename_to_str(const filename_t &filename);
+SPDLOG_API std::string filename_to_str(const filename_t &filename);
 
-int pid() SPDLOG_NOEXCEPT;
+SPDLOG_API int pid() SPDLOG_NOEXCEPT;
 
 // Determine if the terminal supports colors
 // Source: https://github.com/agauniyal/rang/
-bool is_color_terminal() SPDLOG_NOEXCEPT;
+SPDLOG_API bool is_color_terminal() SPDLOG_NOEXCEPT;
 
 // Detrmine if the terminal attached
 // Source: https://github.com/agauniyal/rang/
-bool in_terminal(FILE *file) SPDLOG_NOEXCEPT;
+SPDLOG_API bool in_terminal(FILE *file) SPDLOG_NOEXCEPT;
 
 #if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
-void wstr_to_utf8buf(basic_string_view_t<wchar_t> wstr, fmt::memory_buffer &target);
+SPDLOG_API void wstr_to_utf8buf(basic_string_view_t<wchar_t> wstr, fmt::memory_buffer &target);
 #endif
 
 } // namespace os

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -865,7 +865,6 @@ public:
 
 // print elapsed time since last message
 template<typename ScopedPadder, typename Units>
-
 class elapsed_formatter final : public flag_formatter
 {
 public:

--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -19,7 +19,7 @@ namespace spdlog {
 namespace details {
 
 // padding information.
-struct padding_info
+struct SPDLOG_API padding_info
 {
     enum pad_side
     {
@@ -42,7 +42,7 @@ struct padding_info
     const pad_side side_ = left;
 };
 
-class flag_formatter
+class SPDLOG_API flag_formatter
 {
 public:
     explicit flag_formatter(padding_info padinfo)
@@ -58,7 +58,7 @@ protected:
 
 } // namespace details
 
-class pattern_formatter final : public formatter
+class SPDLOG_API pattern_formatter final : public formatter
 {
 public:
     explicit pattern_formatter(
@@ -81,16 +81,16 @@ private:
     std::chrono::seconds last_log_secs_;
     std::vector<std::unique_ptr<details::flag_formatter>> formatters_;
 
-    std::tm get_time_(const details::log_msg &msg);
+    SPDLOG_PRIVATE std::tm get_time_(const details::log_msg &msg);
     template<typename Padder>
-    void handle_flag_(char flag, details::padding_info padding);
+    SPDLOG_PRIVATE void handle_flag_(char flag, details::padding_info padding);
 
     // Extract given pad spec (e.g. %8X)
     // Advance the given it pass the end of the padding spec found (if any)
     // Return padding.
-    details::padding_info handle_padspec_(std::string::const_iterator &it, std::string::const_iterator end);
+    SPDLOG_PRIVATE details::padding_info handle_padspec_(std::string::const_iterator &it, std::string::const_iterator end);
 
-    void compile_pattern_(const std::string &pattern);
+    SPDLOG_PRIVATE void compile_pattern_(const std::string &pattern);
 };
 } // namespace spdlog
 

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -14,10 +14,11 @@
 #include <functional>
 #include <mutex>
 #include <thread>
+#include "spdlog/common.h"
 namespace spdlog {
 namespace details {
 
-class periodic_worker
+class SPDLOG_API periodic_worker
 {
 public:
     periodic_worker(const std::function<void()> &callback_fun, std::chrono::seconds interval);

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -24,7 +24,7 @@ namespace details {
 class thread_pool;
 class periodic_worker;
 
-class registry
+class SPDLOG_API registry
 {
 public:
     registry(const registry &) = delete;
@@ -78,11 +78,12 @@ public:
     static registry &instance();
 
 private:
-    registry();
-    ~registry() = default;
+    SPDLOG_PRIVATE registry();
+    SPDLOG_PRIVATE ~registry() = default;
 
-    void throw_if_exists_(const std::string &logger_name);
-    void register_logger_(std::shared_ptr<logger> new_logger);
+    SPDLOG_PRIVATE void throw_if_exists_(const std::string &logger_name);
+    SPDLOG_PRIVATE void register_logger_(std::shared_ptr<logger> new_logger);
+
     std::mutex logger_map_mutex_, flusher_mutex_;
     std::recursive_mutex tp_mutex_;
     std::unordered_map<std::string, std::shared_ptr<logger>> loggers_;

--- a/include/spdlog/details/synchronous_factory.h
+++ b/include/spdlog/details/synchronous_factory.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "registry.h"
 
 namespace spdlog {
@@ -10,7 +11,7 @@ namespace spdlog {
 // Default logger factory-  creates synchronous loggers
 class logger;
 
-struct synchronous_factory
+struct SPDLOG_API synchronous_factory
 {
     template<typename Sink, typename... SinkArgs>
     static std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs &&... args)

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/log_msg.h"
 #include "spdlog/details/mpmc_blocking_q.h"
 #include "spdlog/details/os.h"
@@ -29,7 +30,7 @@ enum class async_msg_type
 
 // Async msg to move to/from the queue
 // Movable only. should never be copied
-struct async_msg
+struct SPDLOG_API async_msg
 {
     async_msg_type msg_type;
     level::level_enum level;
@@ -113,7 +114,7 @@ struct async_msg
     }
 };
 
-class thread_pool
+class SPDLOG_API thread_pool
 {
 public:
     using item_type = async_msg;
@@ -137,13 +138,13 @@ private:
 
     std::vector<std::thread> threads_;
 
-    void post_async_msg_(async_msg &&new_msg, async_overflow_policy overflow_policy);
-    void worker_loop_();
+    SPDLOG_PRIVATE void post_async_msg_(async_msg &&new_msg, async_overflow_policy overflow_policy);
+    SPDLOG_PRIVATE void worker_loop_();
 
     // process next message in the queue
     // return true if this thread should still be active (while no terminate msg
     // was received)
-    bool process_next_msg_();
+    SPDLOG_PRIVATE bool process_next_msg_();
 };
 
 } // namespace details

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -155,11 +155,15 @@
 # define FMT_BEGIN_NAMESPACE namespace fmt { FMT_INLINE_NAMESPACE v5 {
 #endif
 
-#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
-# ifdef FMT_EXPORT
-#  define FMT_API __declspec(dllexport)
-# elif defined(FMT_SHARED)
-#  define FMT_API __declspec(dllimport)
+#if !defined(FMT_HEADER_ONLY)
+# if defined(_WIN32) || defined(__CYGWIN__)
+#  ifdef FMT_EXPORT
+#   define FMT_API __declspec(dllexport)
+#  elif defined(FMT_SHARED)
+#   define FMT_API __declspec(dllimport)
+#  endif
+# elif __GNUC__ >= 4
+#  define FMT_API __attribute__((visibility ("default")))
 # endif
 #endif
 #ifndef FMT_API

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -11,17 +11,19 @@
 //
 
 #if !defined(SPDLOG_FMT_EXTERNAL)
-#ifdef SPDLOG_HEADER_ONLY
-#ifndef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY
-#endif
-#endif
-#ifndef FMT_USE_WINDOWS_H
-#define FMT_USE_WINDOWS_H 0
-#endif
-#include "bundled/core.h"
-#include "bundled/format.h"
+# include "spdlog/common.h"
+# if defined(SPDLOG_HEADER_ONLY) && !defined(FMT_HEADER_ONLY)
+#  define FMT_HEADER_ONLY
+# endif
+# if defined(SDPLOG_SHARED) && !defined(FMT_SHARED)
+#  define FMT_SHARED
+# endif
+# ifndef FMT_USE_WINDOWS_H
+#  define FMT_USE_WINDOWS_H 0
+# endif
+# include "bundled/core.h"
+# include "bundled/format.h"
 #else // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
-#include "fmt/core.h"
-#include "fmt/format.h"
+# include "fmt/core.h"
+# include "fmt/format.h"
 #endif

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -18,6 +18,9 @@
 # if defined(SDPLOG_SHARED) && !defined(FMT_SHARED)
 #  define FMT_SHARED
 # endif
+# if defined(SDPLOG_EXPORTS) && !defined(FMT_EXPORT)
+#  define FMT_EXPORT
+# endif
 # ifndef FMT_USE_WINDOWS_H
 #  define FMT_USE_WINDOWS_H 0
 # endif

--- a/include/spdlog/fmt/ostr.h
+++ b/include/spdlog/fmt/ostr.h
@@ -8,11 +8,9 @@
 // include bundled or external copy of fmtlib's ostream support
 //
 #if !defined(SPDLOG_FMT_EXTERNAL)
-#ifndef FMT_HEADER_ONLY
-#define FMT_HEADER_ONLY
-#endif
-#include "bundled/ostream.h"
+#include "spdlog/common.h"
 #include "fmt.h"
+#include "bundled/ostream.h"
 #else
 #include <fmt/ostream.h>
 #endif

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -3,12 +3,13 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "fmt/fmt.h"
 #include "spdlog/details/log_msg.h"
 
 namespace spdlog {
 
-class formatter
+class SPDLOG_API formatter
 {
 public:
     virtual ~formatter() = default;

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -35,7 +35,7 @@
     }
 
 namespace spdlog {
-class logger
+class SPDLOG_API logger
 {
 public:
     // Empty logger
@@ -328,7 +328,7 @@ protected:
     void err_handler_(const std::string &msg);
 };
 
-void swap(logger &a, logger &b);
+SPDLOG_API void swap(logger &a, logger &b);
 
 } // namespace spdlog
 

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -5,6 +5,7 @@
 
 #ifdef __ANDROID__
 
+#include "spdlog/common.h"
 #include "spdlog/details/fmt_helper.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/details/os.h"
@@ -28,7 +29,7 @@ namespace sinks {
  * Android sink (logging using __android_log_write)
  */
 template<typename Mutex>
-class android_sink final : public base_sink<Mutex>
+class SPDLOG_API android_sink final : public base_sink<Mutex>
 {
 public:
     explicit android_sink(std::string tag = "spdlog", bool use_raw_msg = false)

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/console_globals.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/sink.h"
@@ -22,7 +23,7 @@ namespace sinks {
  */
 
 template<typename ConsoleMutex>
-class ansicolor_sink : public sink
+class SPDLOG_API ansicolor_sink : public sink
 {
 public:
     using mutex_t = typename ConsoleMutex::mutex_t;
@@ -81,19 +82,19 @@ private:
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;
     std::unordered_map<level::level_enum, string_view_t, level::level_hasher> colors_;
-    void print_ccode_(const string_view_t &color_code);
-    void print_range_(const fmt::memory_buffer &formatted, size_t start, size_t end);
+    SPDLOG_PRIVATE void print_ccode_(const string_view_t &color_code);
+    SPDLOG_PRIVATE void print_range_(const fmt::memory_buffer &formatted, size_t start, size_t end);
 };
 
 template<typename ConsoleMutex>
-class ansicolor_stdout_sink : public ansicolor_sink<ConsoleMutex>
+class SPDLOG_API ansicolor_stdout_sink : public ansicolor_sink<ConsoleMutex>
 {
 public:
     explicit ansicolor_stdout_sink(color_mode mode = color_mode::automatic);
 };
 
 template<typename ConsoleMutex>
-class ansicolor_stderr_sink : public ansicolor_sink<ConsoleMutex>
+class SPDLOG_API ansicolor_stderr_sink : public ansicolor_sink<ConsoleMutex>
 {
 public:
     explicit ansicolor_stderr_sink(color_mode mode = color_mode::automatic);

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -16,7 +16,7 @@
 namespace spdlog {
 namespace sinks {
 template<typename Mutex>
-class base_sink : public sink
+class SPDLOG_API base_sink : public sink
 {
 public:
     base_sink();

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/file_helper.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/base_sink.h"
@@ -17,7 +18,7 @@ namespace sinks {
  * Trivial file sink with single file as target
  */
 template<typename Mutex>
-class basic_file_sink final : public base_sink<Mutex>
+class SPDLOG_API basic_file_sink final : public base_sink<Mutex>
 {
 public:
     explicit basic_file_sink(const filename_t &filename, bool truncate = false);

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/file_helper.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/fmt/fmt.h"
@@ -22,7 +23,7 @@ namespace sinks {
 /*
  * Generator of daily log file names in format basename.YYYY-MM-DD.ext
  */
-struct daily_filename_calculator
+struct SPDLOG_API daily_filename_calculator
 {
     // Create filename for the form basename.YYYY-MM-DD
     static filename_t calc_filename(const filename_t &filename, const tm &now_tm)
@@ -40,7 +41,7 @@ struct daily_filename_calculator
  * Rotating file sink based on date. rotates at midnight
  */
 template<typename Mutex, typename FileNameCalc = daily_filename_calculator>
-class daily_file_sink final : public base_sink<Mutex>
+class SPDLOG_API daily_file_sink final : public base_sink<Mutex>
 {
 public:
     // create daily file sink which rotates on given time

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "base_sink.h"
 #include "spdlog/details/log_msg.h"
 #include "spdlog/details/null_mutex.h"
@@ -20,7 +21,7 @@ namespace spdlog {
 namespace sinks {
 
 template<typename Mutex>
-class dist_sink : public base_sink<Mutex>
+class SPDLOG_API dist_sink : public base_sink<Mutex>
 {
 public:
     dist_sink() = default;

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "dist_sink.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/details/log_msg.h"
@@ -40,7 +41,7 @@
 namespace spdlog {
 namespace sinks {
 template<typename Mutex>
-class dup_filter_sink : public dist_sink<Mutex>
+class SPDLOG_API dup_filter_sink : public dist_sink<Mutex>
 {
 public:
     template<class Rep, class Period>

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -5,6 +5,7 @@
 
 #if defined(_WIN32)
 
+#include "spdlog/common.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/base_sink.h"
 
@@ -19,7 +20,7 @@ namespace sinks {
  * MSVC sink (logging using OutputDebugStringA)
  */
 template<typename Mutex>
-class msvc_sink : public base_sink<Mutex>
+class SPDLOG_API msvc_sink : public base_sink<Mutex>
 {
 public:
     explicit msvc_sink() {}

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/synchronous_factory.h"
@@ -13,7 +14,7 @@ namespace spdlog {
 namespace sinks {
 
 template<typename Mutex>
-class null_sink : public base_sink<Mutex>
+class SPDLOG_API null_sink : public base_sink<Mutex>
 {
 protected:
     void sink_it_(const details::log_msg &) override {}

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/base_sink.h"
 
@@ -12,7 +13,7 @@
 namespace spdlog {
 namespace sinks {
 template<typename Mutex>
-class ostream_sink final : public base_sink<Mutex>
+class SPDLOG_API ostream_sink final : public base_sink<Mutex>
 {
 public:
     explicit ostream_sink(std::ostream &os, bool force_flush = false)

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/file_helper.h"
 #include "spdlog/details/null_mutex.h"
@@ -19,7 +20,7 @@ namespace sinks {
 // Rotating file sink based on size
 //
 template<typename Mutex>
-class rotating_file_sink final : public base_sink<Mutex>
+class SPDLOG_API rotating_file_sink final : public base_sink<Mutex>
 {
 public:
     rotating_file_sink(filename_t base_filename, std::size_t max_size, std::size_t max_files, bool rotate_on_open = false);
@@ -36,11 +37,11 @@ private:
     // log.1.txt -> log.2.txt
     // log.2.txt -> log.3.txt
     // log.3.txt -> delete
-    void rotate_();
+    SPDLOG_PRIVATE void rotate_();
 
     // delete the target if exists, and rename the src file  to target
     // return true on success, false otherwise.
-    bool rename_file(const filename_t &src_filename, const filename_t &target_filename);
+    SPDLOG_PRIVATE bool rename_file(const filename_t &src_filename, const filename_t &target_filename);
 
     filename_t base_filename_;
     std::size_t max_size_;

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -3,13 +3,14 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/log_msg.h"
 #include "spdlog/formatter.h"
 
 namespace spdlog {
 
 namespace sinks {
-class sink
+class SPDLOG_API sink
 {
 public:
     virtual ~sink() = default;

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "spdlog/common.h"
+
 #ifdef _WIN32
 #include "spdlog/sinks/wincolor_sink.h"
 #else
@@ -27,16 +29,16 @@ using stderr_color_sink_st = ansicolor_stderr_sink_st;
 } // namespace sinks
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic);
+SPDLOG_API std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stdout_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic);
+SPDLOG_API std::shared_ptr<logger> stdout_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic);
+SPDLOG_API std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name, color_mode mode = color_mode::automatic);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stderr_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic);
+SPDLOG_API std::shared_ptr<logger> stderr_color_st(const std::string &logger_name, color_mode mode = color_mode::automatic);
 
 } // namespace spdlog
 

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/details/console_globals.h"
 #include "spdlog/details/synchronous_factory.h"
 #include "spdlog/sinks/sink.h"
@@ -13,7 +14,7 @@ namespace spdlog {
 namespace sinks {
 
 template<typename ConsoleMutex>
-class stdout_sink_base : public sink
+class SPDLOG_API stdout_sink_base : public sink
 {
 public:
     using mutex_t = typename ConsoleMutex::mutex_t;
@@ -35,14 +36,14 @@ protected:
 };
 
 template<typename ConsoleMutex>
-class stdout_sink : public stdout_sink_base<ConsoleMutex>
+class SPDLOG_API stdout_sink : public stdout_sink_base<ConsoleMutex>
 {
 public:
     stdout_sink();
 };
 
 template<typename ConsoleMutex>
-class stderr_sink : public stdout_sink_base<ConsoleMutex>
+class SPDLOG_API stderr_sink : public stdout_sink_base<ConsoleMutex>
 {
 public:
     stderr_sink();
@@ -58,16 +59,16 @@ using stderr_sink_st = stderr_sink<details::console_nullmutex>;
 
 // factory methods
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stdout_logger_mt(const std::string &logger_name);
+SPDLOG_API std::shared_ptr<logger> stdout_logger_mt(const std::string &logger_name);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stdout_logger_st(const std::string &logger_name);
+SPDLOG_API std::shared_ptr<logger> stdout_logger_st(const std::string &logger_name);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stderr_logger_mt(const std::string &logger_name);
+SPDLOG_API std::shared_ptr<logger> stderr_logger_mt(const std::string &logger_name);
 
 template<typename Factory = spdlog::synchronous_factory>
-std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name);
+SPDLOG_API std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name);
 
 } // namespace spdlog
 

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/null_mutex.h"
 
@@ -16,7 +17,7 @@ namespace sinks {
  * Sink that write to syslog using the `syscall()` library call.
  */
 template<typename Mutex>
-class syslog_sink : public base_sink<Mutex>
+class SPDLOG_API syslog_sink : public base_sink<Mutex>
 {
 
 public:

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "spdlog/common.h"
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/details/synchronous_factory.h"
@@ -18,7 +19,7 @@ namespace sinks {
  * Locking is not needed, as `sd_journal_send()` itself is thread-safe.
  */
 template<typename Mutex>
-class systemd_sink : public base_sink<Mutex>
+class SPDLOG_API systemd_sink : public base_sink<Mutex>
 {
 public:
     //

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -21,7 +21,7 @@ namespace sinks {
  * colors
  */
 template<typename ConsoleMutex>
-class wincolor_sink : public sink
+class SPDLOG_API wincolor_sink : public sink
 {
 public:
     const WORD BOLD = FOREGROUND_INTENSITY;
@@ -65,14 +65,14 @@ protected:
 };
 
 template<typename ConsoleMutex>
-class wincolor_stdout_sink : public wincolor_sink<ConsoleMutex>
+class SPDLOG_API wincolor_stdout_sink : public wincolor_sink<ConsoleMutex>
 {
 public:
     explicit wincolor_stdout_sink(color_mode mode = color_mode::automatic);
 };
 
 template<typename ConsoleMutex>
-class wincolor_stderr_sink : public wincolor_sink<ConsoleMutex>
+class SPDLOG_API wincolor_stderr_sink : public wincolor_sink<ConsoleMutex>
 {
 public:
     explicit wincolor_stderr_sink(color_mode mode = color_mode::automatic);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -46,52 +46,52 @@ inline std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs 
 //   auto console_sink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
 //   auto console_logger = std::make_shared<spdlog::logger>("console_logger", console_sink);
 //   spdlog::initialize_logger(console_logger);
-void initialize_logger(std::shared_ptr<logger> logger);
+SPDLOG_API void initialize_logger(std::shared_ptr<logger> logger);
 
 // Return an existing logger or nullptr if a logger with such name doesn't
 // exist.
 // example: spdlog::get("my_logger")->info("hello {}", "world");
-std::shared_ptr<logger> get(const std::string &name);
+SPDLOG_API std::shared_ptr<logger> get(const std::string &name);
 
 // Set global formatter. Each sink in each logger will get a clone of this object
-void set_formatter(std::unique_ptr<spdlog::formatter> formatter);
+SPDLOG_API void set_formatter(std::unique_ptr<spdlog::formatter> formatter);
 
 // Set global format string.
 // example: spdlog::set_pattern("%Y-%m-%d %H:%M:%S.%e %l : %v");
-void set_pattern(std::string pattern, pattern_time_type time_type = pattern_time_type::local);
+SPDLOG_API void set_pattern(std::string pattern, pattern_time_type time_type = pattern_time_type::local);
 
 // Set global logging level
-void set_level(level::level_enum log_level);
+SPDLOG_API void set_level(level::level_enum log_level);
 
 // Set global flush level
-void flush_on(level::level_enum log_level);
+SPDLOG_API void flush_on(level::level_enum log_level);
 
 // Start/Restart a periodic flusher thread
 // Warning: Use only if all your loggers are thread safe!
-void flush_every(std::chrono::seconds interval);
+SPDLOG_API void flush_every(std::chrono::seconds interval);
 
 // Set global error handler
-void set_error_handler(void (*handler)(const std::string &msg));
+SPDLOG_API void set_error_handler(void (*handler)(const std::string &msg));
 
 // Register the given logger with the given name
-void register_logger(std::shared_ptr<logger> logger);
+SPDLOG_API void register_logger(std::shared_ptr<logger> logger);
 
 // Apply a user defined function on all registered loggers
 // Example:
 // spdlog::apply_all([&](std::shared_ptr<spdlog::logger> l) {l->flush();});
-void apply_all(const std::function<void(std::shared_ptr<logger>)> &fun);
+SPDLOG_API void apply_all(const std::function<void(std::shared_ptr<logger>)> &fun);
 
 // Drop the reference to the given logger
-void drop(const std::string &name);
+SPDLOG_API void drop(const std::string &name);
 
 // Drop all references from the registry
-void drop_all();
+SPDLOG_API void drop_all();
 
 // stop any running threads started by spdlog and clean registry loggers
-void shutdown();
+SPDLOG_API void shutdown();
 
 // Automatic registration of loggers when using spdlog::create() or spdlog::create_async
-void set_automatic_registration(bool automatic_registation);
+SPDLOG_API void set_automatic_registration(bool automatic_registation);
 
 // API for using default logger (stdout_color_mt),
 // e.g: spdlog::info("Message {}", 1);
@@ -108,11 +108,11 @@ void set_automatic_registration(bool automatic_registation);
 // set_default_logger() *should not* be used concurrently with the default API.
 // e.g do not call set_default_logger() from one thread while calling spdlog::info() from another.
 
-std::shared_ptr<spdlog::logger> default_logger();
+SPDLOG_API std::shared_ptr<spdlog::logger> default_logger();
 
-spdlog::logger *default_logger_raw();
+SPDLOG_API spdlog::logger *default_logger_raw();
 
-void set_default_logger(std::shared_ptr<spdlog::logger> default_logger);
+SPDLOG_API void set_default_logger(std::shared_ptr<spdlog::logger> default_logger);
 
 template<typename... Args>
 inline void log(source_loc source, level::level_enum lvl, string_view_t fmt, const Args &... args)

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -105,6 +105,10 @@ template std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st<spdlog::async_
 // All rights reserved.
 
 #if !defined(SPDLOG_FMT_EXTERNAL)
+
+#if defined(SPDLOG_SHARED) && !defined(FMT_SHARED)
+# define FMT_SHARED
+#endif
 #include "spdlog/fmt/bundled/format-inl.h"
 
 FMT_BEGIN_NAMESPACE

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -34,6 +34,7 @@ template class spdlog::sinks::rotating_file_sink<std::mutex>;
 template class spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;
 
 #include "spdlog/details/registry-inl.h"
+#include "spdlog/details/console_globals-inl.h"
 
 #include "spdlog/details/os-inl.h"
 #include "spdlog/details/periodic_worker-inl.h"

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -109,6 +109,9 @@ template std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st<spdlog::async_
 #if defined(SPDLOG_SHARED) && !defined(FMT_SHARED)
 # define FMT_SHARED
 #endif
+#if defined(SPDLOG_EXPORTS) && !defined(FMT_EXPORT)
+# define FMT_EXPORT
+#endif
 #include "spdlog/fmt/bundled/format-inl.h"
 
 FMT_BEGIN_NAMESPACE


### PR DESCRIPTION
This PR adds import/export (for windows) and visibility (for linux) attributes, as well as a few small changes.

adds portable(hopefully) `SPDLOG_API` and `SPDLOG_PRIVATE` macros to mark spdlogs public types+functions and private functions respectively.
adds public compile_definition `SPDLOG_SHARED` when building shared library.
made fmt libs API macro portable, could probably be upstreamed.
made sure `FMT_SHARED`, `FMT_EXPORT`, `FMT_HEADER_ONLY` are defined when spdlogs version of those are defined when using bundled fmt.
added common.h to first of every include to ensure defines are defined when needed.
put console_globals singleton functions into a inline header.
~made stdout_sinks inline header guarded like other sinks.~ in upstream, rebased to remove.


This has only been tested on linux so far, but when using `BUILD_SHARED_LIBS=ON` all tests and examples work with `-fvisibility=hidden` which means all the symbols we need (at least what gets tested) are being exported properly.
hopefully this might fix the shared library issue on windows.
