### PR TITLE
Fix use of old style cast in os-inl.h

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -122,7 +122,7 @@ SPDLOG_INLINE void prevent_child_fd(FILE *f)
 
 #ifdef _WIN32
 #if !defined(__cplusplus_winrt)
-    auto file_handle = (HANDLE)_get_osfhandle(_fileno(f));
+    auto file_handle = reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(f)));
     if (!::SetHandleInformation(file_handle, HANDLE_FLAG_INHERIT, 0))
         throw spdlog_ex("SetHandleInformation failed", errno);
 #endif


### PR DESCRIPTION
Saw this warning cluttering my CI build logs. Shouldn't break anything since c style casts in C++ simply use the appropriate cast anyways. ([Reference](https://en.cppreference.com/w/cpp/language/explicit_cast))
[Example of the warning in CI build log](https://ci.appveyor.com/project/CppAndre/age/build/job/5gqj4sl6b33u03jf#L647)

Cheers and keep up the good work!