### PR TITLE
 improve cmake files, option to use clang-tidy while compile 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(SPDLOG_INSTALL)
     # Include files
     #---------------------------------------------------------------------------------------
     install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    install(TARGETS spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
+    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
 
     #---------------------------------------------------------------------------------------
     # Package and version files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,21 @@
 # Copyright(c) 2019 spdlog authors
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
+
+
+# use ccache if found
+find_program(CCACHE_EXECUTABLE "ccache" HINTS /usr/local/bin /opt/local/bin)
+if(CCACHE_EXECUTABLE AND NOT CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "use ccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE PATH "ccache" FORCE)
+endif()
 
 #---------------------------------------------------------------------------------------
 # Start spdlog project
 #---------------------------------------------------------------------------------------
 include(GNUInstallDirs)
 include(cmake/utils.cmake)
-include(cmake/ide.cmake)
 
 spdlog_extract_version()
 
@@ -22,6 +29,8 @@ endif()
 project(spdlog VERSION ${SPDLOG_VERSION} LANGUAGES CXX)
 message(STATUS "Build spdlog: ${SPDLOG_VERSION}")
 
+include(cmake/ide.cmake)
+
 #---------------------------------------------------------------------------------------
 # Compiler config
 #---------------------------------------------------------------------------------------
@@ -33,13 +42,31 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Set SPDLOG_MASTER_PROJECT to ON if we are building spdlog
 #---------------------------------------------------------------------------------------
 # Check if spdlog is being used directly or via add_subdirectory, but allow overriding
-if (NOT DEFINED SPDLOG_MASTER_PROJECT)
-    if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(NOT DEFINED SPDLOG_MASTER_PROJECT)
+    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         set(SPDLOG_MASTER_PROJECT ON)
     else()
         set(SPDLOG_MASTER_PROJECT OFF)
     endif()
-endif ()
+endif()
+
+
+# Where to put all the RUNTIME targets when built.  This variable is used to
+# initialize the RUNTIME_OUTPUT_DIRECTORY property for all the targets.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+# Create logs directory, needed for examples! CK
+file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/logs")
+
+# initialize the ARCHIVE_OUTPUT_DIRECTORY property for all the targets.
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+
+# clang-tidy options
+option(SPDLOG_USE_CLANG_TIDY "run clang-tidy along with the compiler and report any problems" OFF)
+if(SPDLOG_USE_CLANG_TIDY)
+    find_program(CMAKE_CXX_CLANG_TIDY clang-tidy HINTS /usr/local/bin /opt/local/bin)
+else()
+    unset(CMAKE_CXX_CLANG_TIDY CACHE)
+endif()
 
 # example options
 option(SPDLOG_BUILD_EXAMPLE "Build example" ${SPDLOG_MASTER_PROJECT})
@@ -66,7 +93,7 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 #---------------------------------------------------------------------------------------
 # Static/Shared library (shared not supported in windows yet)
 #---------------------------------------------------------------------------------------
-if (BUILD_SHARED_LIBS AND WIN32)
+if(BUILD_SHARED_LIBS AND WIN32)
     message(WARNING "shared libs is not supported in spdlog - building static instead")
     add_library(spdlog STATIC src/spdlog.cpp ${SPDLOG_ALL_HEADERS})
 else()
@@ -98,9 +125,9 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 # Use fmt package if using exertnal fmt
 #---------------------------------------------------------------------------------------
 if(SPDLOG_FMT_EXTERNAL)
-    if (NOT TARGET fmt::fmt)
+    if(NOT TARGET fmt::fmt)
         find_package(fmt REQUIRED)
-    endif ()
+    endif()
 
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_link_libraries(spdlog PUBLIC fmt::fmt)
@@ -119,7 +146,7 @@ endif()
 
 if(SPDLOG_BUILD_TESTS OR SPDLOG_BUILD_TESTS_HO)
     message(STATUS "Generating tests")
-    include(CTest)
+    enable_testing()
     add_subdirectory(tests)
 endif()
 
@@ -131,7 +158,7 @@ endif()
 #---------------------------------------------------------------------------------------
 # Install
 #---------------------------------------------------------------------------------------
-if (SPDLOG_INSTALL)
+if(SPDLOG_INSTALL)
     message(STATUS "Generating install")
     set(project_config_in "${CMAKE_CURRENT_LIST_DIR}/cmake/spdlogConfig.cmake.in")
     set(project_config_out "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfig.cmake")
@@ -143,7 +170,7 @@ if (SPDLOG_INSTALL)
     # Include files
     #---------------------------------------------------------------------------------------
     install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
+    install(TARGETS spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
 
     #---------------------------------------------------------------------------------------
     # Package and version files
@@ -165,4 +192,4 @@ if (SPDLOG_INSTALL)
     #---------------------------------------------------------------------------------------
     include(cmake/spdlogCPack.cmake)
 
-endif ()
+endif()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright(c) 2019 spdlog authors
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 project(spdlog_bench CXX)
 
 if(NOT TARGET spdlog)

--- a/cmake/ide.cmake
+++ b/cmake/ide.cmake
@@ -1,18 +1,27 @@
 #---------------------------------------------------------------------------------------
 # IDE support for headers
 #---------------------------------------------------------------------------------------
-set(SPDLOG_HEADERS_DIR "${CMAKE_CURRENT_LIST_DIR}/../include")
+set(SPDLOG_HEADERS_DIR "${PROJECT_SOURCE_DIR}/include")
+message(STATUS "${PROJECT_NAME} include path: ${SPDLOG_HEADERS_DIR}")
+
 
 file(GLOB SPDLOG_TOP_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/*.h")
 file(GLOB SPDLOG_DETAILS_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/details/*.h")
 file(GLOB SPDLOG_SINKS_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/sinks/*.h")
-file(GLOB SPDLOG_FMT_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/fmt/*.h")
-file(GLOB SPDLOG_FMT_BUNDELED_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/fmt/bundled/*.h")
+
+if(NOT SPDLOG_FMT_EXTERNAL)
+    file(GLOB SPDLOG_FMT_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/fmt/*.h")
+    file(GLOB SPDLOG_FMT_BUNDELED_HEADERS "${SPDLOG_HEADERS_DIR}/spdlog/fmt/bundled/*.h")
+endif()
+
 set(SPDLOG_ALL_HEADERS ${SPDLOG_TOP_HEADERS} ${SPDLOG_DETAILS_HEADERS} ${SPDLOG_SINKS_HEADERS} ${SPDLOG_FMT_HEADERS} ${SPDLOG_FMT_BUNDELED_HEADERS})
 
 source_group("Header Files\\spdlog" FILES ${SPDLOG_TOP_HEADERS})
 source_group("Header Files\\spdlog\\details" FILES ${SPDLOG_DETAILS_HEADERS})
 source_group("Header Files\\spdlog\\sinks" FILES ${SPDLOG_SINKS_HEADERS})
-source_group("Header Files\\spdlog\\fmt" FILES ${SPDLOG_FMT_HEADERS})
-source_group("Header Files\\spdlog\\fmt\\bundled\\" FILES ${SPDLOG_FMT_BUNDELED_HEADERS})
+
+if(NOT SPDLOG_FMT_EXTERNAL)
+    source_group("Header Files\\spdlog\\fmt" FILES ${SPDLOG_FMT_HEADERS})
+    source_group("Header Files\\spdlog\\fmt\\bundled\\" FILES ${SPDLOG_FMT_BUNDELED_HEADERS})
+endif()
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -27,14 +27,14 @@ endfunction()
 function(spdlog_enable_warnings target_name)
     target_compile_options(${target_name} PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-            -Wall -Wextra -Wconversion -pedantic -Wfatal-errors>
+            -Wall -Wextra -Wconversion -pedantic -Werror -Wfatal-errors>
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>)
 endfunction()
 
 
 # Enable address sanitizer (gcc/clang only)
 function(spdlog_enable_sanitizer target_name)
-	if (NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+	if(NOT CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 		message(FATAL_ERROR "Sanitizer supported only for gcc/clang")
 	endif()
 	message(STATUS "Address sanitizer enabled")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(spdlog_examples CXX)
 
-if(NOT TARGET spdlog_header_only)
+if(NOT TARGET spdlog)
     # Stand-alone build
     find_package(spdlog REQUIRED)
 endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Copyright(c) 2019 spdlog authors
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 project(spdlog_examples CXX)
 
-if(NOT TARGET spdlog)
+if(NOT TARGET spdlog_header_only)
     # Stand-alone build
     find_package(spdlog REQUIRED)
 endif()

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -141,7 +141,7 @@ void async_example()
 #include "spdlog/fmt/bin_to_hex.h"
 void binary_example()
 {
-    std::vector<char> buf;
+    std::vector<char> buf(80);
     for (int i = 0; i < 80; i++)
     {
         buf.push_back(static_cast<char>(i & 0xff));

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -85,8 +85,13 @@ using sink_ptr = std::shared_ptr<sinks::sink>;
 using sinks_init_list = std::initializer_list<sink_ptr>;
 using err_handler = std::function<void(const std::string &err_msg)>;
 
+#ifdef SPDLOG_FMT_EXTERNAL
+template<typename T>
+using basic_string_view_t = std::basic_string_view<T>;
+#else
 template<typename T>
 using basic_string_view_t = fmt::basic_string_view<T>;
+#endif
 
 using string_view_t = basic_string_view_t<char>;
 

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -380,8 +380,8 @@ SPDLOG_INLINE bool is_color_terminal() SPDLOG_NOEXCEPT
 #ifdef _WIN32
     return true;
 #else
-    static constexpr std::array<const char *, 14> Terms = {
-        "ansi", "color", "console", "cygwin", "gnome", "konsole", "kterm", "linux", "msys", "putty", "rxvt", "screen", "vt100", "xterm"};
+    static constexpr std::array<const char *, 14> Terms{
+        {"ansi", "color", "console", "cygwin", "gnome", "konsole", "kterm", "linux", "msys", "putty", "rxvt", "screen", "vt100", "xterm"}};
 
     const char *env_p = std::getenv("TERM");
     if (env_p == nullptr)

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -152,7 +152,7 @@ static int to12h(const tm &t)
 }
 
 // Abbreviated weekday name
-static std::array<const char *, 7> days{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+static std::array<const char *, 7> days{{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}};
 
 template<typename ScopedPadder>
 class a_formatter : public flag_formatter
@@ -171,7 +171,7 @@ public:
 };
 
 // Full weekday name
-static std::array<const char *, 7> full_days{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+static std::array<const char *, 7> full_days{{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}};
 
 template<typename ScopedPadder>
 class A_formatter : public flag_formatter
@@ -190,7 +190,7 @@ public:
 };
 
 // Abbreviated month
-static const std::array<const char *, 12> months{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"};
+static const std::array<const char *, 12> months{{"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"}};
 
 template<typename ScopedPadder>
 class b_formatter : public flag_formatter
@@ -210,7 +210,7 @@ public:
 
 // Full month name
 static const std::array<const char *, 12> full_months{
-    "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
+    {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"}};
 
 template<typename ScopedPadder>
 class B_formatter : public flag_formatter

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -962,7 +962,8 @@ class arg_map {
     // The list is unsorted, so just return the first matching name.
     for (entry *it = map_, *end = map_ + size_; it != end; ++it) {
       if (it->name == name) {
-        return it->arg; }
+        return it->arg;
+      }
     }
     return {};
   }

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -81,7 +81,7 @@
 #endif
 
 #ifndef FMT_OVERRIDE
-# if FMT_HAS_FEATURE(cxx_override) || \
+# if FMT_HAS_FEATURE(cxx_override) || (__cplusplus >= 201402L) ||\
      (FMT_GCC_VERSION >= 408 && FMT_HAS_GXX_CXX11) || FMT_MSC_VER >= 1900
 #  define FMT_OVERRIDE override
 # else
@@ -167,7 +167,7 @@
 #endif
 
 #ifndef FMT_ASSERT
-# define FMT_ASSERT(condition, message) assert((condition) && message)
+# define FMT_ASSERT(condition, message) assert((condition) && (message))
 #endif
 
 // libc++ supports string_view in pre-c++17.
@@ -961,8 +961,8 @@ class arg_map {
   basic_format_arg<Context> find(basic_string_view<char_type> name) const {
     // The list is unsorted, so just return the first matching name.
     for (entry *it = map_, *end = map_ + size_; it != end; ++it) {
-      if (it->name == name)
-        return it->arg;
+      if (it->name == name) {
+        return it->arg; }
     }
     return {};
   }

--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -482,7 +482,7 @@ class basic_memory_buffer: private Allocator, public internal::basic_buffer<T> {
       : Allocator(alloc) {
     this->set(store_, SIZE);
   }
-  ~basic_memory_buffer() { deallocate(); }
+  ~basic_memory_buffer() FMT_OVERRIDE { deallocate(); }
 
  private:
   // Move data from other to this buffer.

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -22,6 +22,6 @@
 #include "bundled/core.h"
 #include "bundled/format.h"
 #else // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
-#include "fmt/core.h"
-#include "fmt/format.h"
+      //FIXME: libfmt @4.1.0 FMT_STRING_VIEW missing! CK  #include <fmt/core.h>
+#include <fmt/format.h>
 #endif

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -97,7 +97,7 @@ public:
         log(source_loc{}, lvl, fmt, args...);
     }
 
-    void log(source_loc loc, level::level_enum lvl, const string_view_t msg);
+    void log(source_loc loc, level::level_enum lvl, string_view_t msg);
     void log(level::level_enum lvl, string_view_t msg);
 
     template<typename... Args>

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -20,15 +20,15 @@ class syslog_sink : public base_sink<Mutex>
 {
 
 public:
-    syslog_sink(std::string ident, int syslog_option, int syslog_facility, bool enable_formatting)
+    syslog_sink(std::string  ident, int syslog_option, int syslog_facility, bool enable_formatting)
         : enable_formatting_{enable_formatting}
-        , syslog_levels_{/* spdlog::level::trace      */ LOG_DEBUG,
+        , syslog_levels_{{/* spdlog::level::trace      */ LOG_DEBUG,
               /* spdlog::level::debug      */ LOG_DEBUG,
               /* spdlog::level::info       */ LOG_INFO,
               /* spdlog::level::warn       */ LOG_WARNING,
               /* spdlog::level::err        */ LOG_ERR,
               /* spdlog::level::critical   */ LOG_CRIT,
-              /* spdlog::level::off        */ LOG_INFO}
+              /* spdlog::level::off        */ LOG_INFO}}
         , ident_{std::move(ident)}
     {
         // set ident to be program name if empty
@@ -44,7 +44,7 @@ public:
     syslog_sink &operator=(const syslog_sink &) = delete;
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const details::log_msg & msg) override
     {
         string_view_t payload;
 
@@ -83,7 +83,7 @@ private:
     //
     int syslog_prio_from_level(const details::log_msg &msg) const
     {
-        return syslog_levels_.at(static_cast<int>(msg.level));
+        return syslog_levels_.at(msg.level);
     }
 };
 

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -20,7 +20,7 @@ class syslog_sink : public base_sink<Mutex>
 {
 
 public:
-    syslog_sink(std::string  ident, int syslog_option, int syslog_facility, bool enable_formatting)
+    syslog_sink(std::string ident, int syslog_option, int syslog_facility, bool enable_formatting)
         : enable_formatting_{enable_formatting}
         , syslog_levels_{{/* spdlog::level::trace      */ LOG_DEBUG,
               /* spdlog::level::debug      */ LOG_DEBUG,
@@ -44,7 +44,7 @@ public:
     syslog_sink &operator=(const syslog_sink &) = delete;
 
 protected:
-    void sink_it_(const details::log_msg & msg) override
+    void sink_it_(const details::log_msg &msg) override
     {
         string_view_t payload;
 

--- a/scripts/.clang-tidy
+++ b/scripts/.clang-tidy
@@ -1,10 +1,10 @@
 Checks: 'modernize-*,modernize-use-override,google-*,-google-runtime-references,misc-*,clang-analyzer-*,-misc-non-private-member-variables-in-classes'
 WarningsAsErrors: ''
-HeaderFilterRegex: 'async.h|async_logger.h|common.h|details|formatter.h|logger.h|sinks|spdlog.h|tweakme.h|version.h'
+HeaderFilterRegex: 'async.h|async_logger.h|common.h|details/.*|formatter.h|logger.h|sinks/.*|spdlog.h|tweakme.h|version.h'
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 
-CheckOptions:    
+CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold

--- a/tests/catch.hpp
+++ b/tests/catch.hpp
@@ -132,7 +132,7 @@ namespace Catch {
 
 #endif
 
-#if defined(CATCH_CPP17_OR_GREATER)
+#if defined(CATCH_CPP17_OR_GREATER) && !defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__)
 #  define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
 #endif
 

--- a/tests/test_errors.cpp
+++ b/tests/test_errors.cpp
@@ -108,7 +108,9 @@ TEST_CASE("async_error_handler2", "[errors]]")
         logger->set_error_handler([=](const std::string &) {
             std::ofstream ofs("logs/custom_err2.txt");
             if (!ofs)
+            {
                 throw std::runtime_error("Failed open logs/custom_err2.txt");
+            }
             ofs << err_msg;
         });
         logger->info("Hello failure");

--- a/tests/test_file_helper.cpp
+++ b/tests/test_file_helper.cpp
@@ -4,7 +4,6 @@
 #include "includes.h"
 
 using spdlog::details::file_helper;
-using spdlog::details::log_msg;
 
 static const std::string target_filename = "logs/file_helper_test.txt";
 
@@ -76,7 +75,7 @@ static void test_split_ext(const char *fname, const char *expect_base, const cha
     spdlog::filename_t expected_base(expect_base);
     spdlog::filename_t expected_ext(expect_ext);
 
-#ifdef _WIN32 // replace folder sep
+#ifdef _MSC_VER // replace folder sep
     std::replace(filename.begin(), filename.end(), '/', '\\');
     std::replace(expected_base.begin(), expected_base.end(), '/', '\\');
 #endif

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -51,8 +51,7 @@ TEST_CASE("rotating_file_logger1", "[rotating_logger]]")
     }
 
     logger->flush();
-    auto filename = basename;
-    REQUIRE(count_lines(filename) == 10);
+    REQUIRE(count_lines(basename) == 10);
 }
 
 TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
@@ -80,8 +79,7 @@ TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
     }
 
     logger->flush();
-    auto filename = basename;
-    REQUIRE(count_lines(filename) == 10);
+    REQUIRE(count_lines(basename) == 10);
     for (int i = 0; i < 1000; i++)
     {
 
@@ -89,7 +87,7 @@ TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
     }
 
     logger->flush();
-    REQUIRE(get_filesize(filename) <= max_size);
+    REQUIRE(get_filesize(basename) <= max_size);
     auto filename1 = basename + ".1";
     REQUIRE(get_filesize(filename1) <= max_size);
 }

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -36,8 +36,8 @@ TEST_CASE("basic_logging ", "[basic_logging]")
 
 TEST_CASE("log_levels", "[log_levels]")
 {
-    REQUIRE(log_info("Hello", spdlog::level::err) == "");
-    REQUIRE(log_info("Hello", spdlog::level::critical) == "");
+    REQUIRE(log_info("Hello", spdlog::level::err).empty());
+    REQUIRE(log_info("Hello", spdlog::level::critical).empty());
     REQUIRE(log_info("Hello", spdlog::level::info) == "Hello");
     REQUIRE(log_info("Hello", spdlog::level::debug) == "Hello");
     REQUIRE(log_info("Hello", spdlog::level::trace) == "Hello");

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -10,7 +10,7 @@ static std::string log_to_str(const std::string &msg, const Args &... args)
     spdlog::logger oss_logger("pattern_tester", oss_sink);
     oss_logger.set_level(spdlog::level::info);
 
-    oss_logger.set_formatter(std::unique_ptr<spdlog::formatter>(new spdlog::pattern_formatter(args...)));
+    oss_logger.set_formatter(std::unique_ptr<spdlog::formatter>(new spdlog::pattern_formatter(args ...)));
 
     oss_logger.info(msg);
     return oss.str();
@@ -254,10 +254,10 @@ TEST_CASE("clone-formatter-2", "[pattern_formatter]")
 // Test source location formatting
 //
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 static const char *test_path = "\\a\\b\\myfile.cpp";
 #else
-static const char *test_path = "/a/b//myfile.cpp";
+static const char *test_path = "/a/b/myfile.cpp";
 #endif
 
 TEST_CASE("short filename formatter-1", "[pattern_formatter]")

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -3,7 +3,7 @@
 void prepare_logdir()
 {
     spdlog::drop_all();
-#ifdef _WIN32
+#ifdef _MSC_VER
     system("if not exist logs mkdir logs");
     system("del /F /Q logs\\*");
 #else
@@ -41,7 +41,9 @@ std::size_t count_lines(const std::string &filename)
     std::string line;
     size_t counter = 0;
     while (std::getline(ifs, line))
+    {
         counter++;
+    }
     return counter;
 }
 


### PR DESCRIPTION
Note:  there is still an issue:

with libfmt @4.1.0 FMT_STRING_VIEW and header is missing! CK  #include <fmt/core.h>