### PR TITLE
Add more overloads to spdlog::log and spdlog::logger::log

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -95,7 +95,13 @@ using string_view_t = basic_string_view_t<char>;
 #error SPDLOG_WCHAR_TO_UTF8_SUPPORT only supported on windows
 #else
 using wstring_view_t = basic_string_view_t<wchar_t>;
+
+template<typename T>
+struct is_convertible_to_wstring_view : std::is_convertible<T, wstring_view_t> { };
 #endif // _WIN32
+#else
+template<typename>
+struct is_convertible_to_wstring_view : std::false_type { };
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
 #if defined(SPDLOG_NO_ATOMIC_LEVELS)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -155,8 +155,8 @@ public:
         sink_it_(log_msg);
     }
 
-    // T cannot be statically converted to string_view
-    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value, T>::type * = nullptr>
+    // T cannot be statically converted to string_view or wstring_view
+    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value && !is_convertible_to_wstring_view<const T &>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         if (!should_log(lvl))
@@ -279,7 +279,7 @@ public:
     }
 
     // T can be statically converted to wstring_view
-    template<class T, typename std::enable_if<std::is_convertible<const T &, spdlog::wstring_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<is_convertible_to_wstring_view<const T &>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         if (!should_log(lvl))
@@ -292,7 +292,7 @@ public:
             fmt::memory_buffer buf;
             details::os::wstr_to_utf8buf(msg, buf);
 
-            details::log_msg log_msg(loc, name_, lvl, buf);
+            details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             sink_it_(log_msg);
         }
         SPDLOG_LOGGER_CATCH()

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -143,7 +143,7 @@ public:
     }
 
     // T can be statically converted to string_view
-    template<class T, typename std::enable_if<std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<std::is_convertible<const T &, spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         if (!should_log(lvl))
@@ -156,7 +156,7 @@ public:
     }
 
     // T cannot be statically converted to string_view
-    template<class T, typename std::enable_if<!std::is_convertible<T, spdlog::string_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         if (!should_log(lvl))
@@ -279,7 +279,7 @@ public:
     }
 
     // T can be statically converted to wstring_view
-    template<class T, typename std::enable_if<std::is_convertible<T, spdlog::wstring_view_t>::value, T>::type * = nullptr>
+    template<class T, typename std::enable_if<std::is_convertible<const T &, spdlog::wstring_view_t>::value, T>::type * = nullptr>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         if (!should_log(lvl))

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -163,6 +163,12 @@ inline void critical(string_view_t fmt, const Args &... args)
 }
 
 template<typename T>
+inline void log(source_loc source, level::level_enum lvl, const T &msg)
+{
+    default_logger_raw()->log(source, lvl, msg);
+}
+
+template<typename T>
 inline void log(level::level_enum lvl, const T &msg)
 {
     default_logger_raw()->log(lvl, msg);
@@ -205,6 +211,12 @@ inline void critical(const T &msg)
 }
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+template<typename... Args>
+inline void log(source_loc source, level::level_enum lvl, wstring_view_t fmt, const Args &... args)
+{
+    default_logger_raw()->log(source, lvl, fmt, args...);
+}
+
 template<typename... Args>
 inline void log(level::level_enum lvl, wstring_view_t fmt, const Args &... args)
 {


### PR DESCRIPTION
This adds a couple more overloads:
- One in `spdlog::log` which allows to pass a `source_loc` when passing an arbitrary `T` object
- One in `spdlog::log` which allows to pass a `source_loc` when using a wide character format string
- One in `spdlog::logger::log` which allows spdlog to avoid going through fmtlib when the type it is receiving is statically convertible to `wstring_view_t`.