### PR TITLE
cmake: Use DATAROOTDIR for pkg-config and cmake files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,13 +160,13 @@ if (SPDLOG_INSTALL)
     set(project_config_out "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfig.cmake")
     set(config_targets_file "spdlogConfigTargets.cmake")
     set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfigVersion.cmake")
-    set(export_dest_dir "${CMAKE_INSTALL_LIBDIR}/spdlog/cmake")
+    set(export_dest_dir "${CMAKE_INSTALL_DATAROOTDIR}/spdlog/cmake")
 
     #---------------------------------------------------------------------------------------
     # Include files
     #---------------------------------------------------------------------------------------
     install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
+    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/spdlog")
 
     #---------------------------------------------------------------------------------------
     # Package and version files


### PR DESCRIPTION
Please correct me if I am mistaken, but spdlog does not install any architecture independent binary files?

 If so these files do not have any architecture independent data and only headers are installed so it is better to use architecture independent install paths like `/usr/share`.

On my system without setting any paths via cmake these files are now installed.
```
usr/share/
usr/share/cmake/
usr/share/cmake/spdlog/
usr/share/cmake/spdlog/spdlogConfig.cmake
usr/share/cmake/spdlog/spdlogConfigVersion.cmake
usr/share/cmake/spdlog/spdlogTargets.cmake
usr/share/pkgconfig/
usr/share/pkgconfig/spdlog.pc
```
This will allow distros to set spdlog to `noarch` or similar instead of `x86_64,` `i686` or etc.

Again please correct me if I made any wrong assumptions.

I was also able to confirm that at least one project (`libixion`) was still able to build with spdlog and this change.