### PR TITLE
Windows color file sink: Use WriteFile rather than WriteConsole

### DIFF
--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -104,7 +104,7 @@ private:
     void _print_range(const details::log_msg &msg, size_t start, size_t end)
     {
         DWORD size = static_cast<DWORD>(end - start);
-        WriteConsoleA(out_handle_, msg.formatted.data() + start, size, nullptr, nullptr);
+        WriteFile(out_handle_, msg.formatted.data() + start, size, nullptr, nullptr);
     }
 };
 


### PR DESCRIPTION
`WriteConsole` can only be used with console handles whereas `WriteFile` can be used with other handles (such as files or pipes).

The reason this is useful is for the case when the C++ application making use of `spdlog` is being run as a subprocess in a larger system, eg using [Python's subprocess module](https://docs.python.org/3/library/subprocess.html) and you want the higher level process to receive the C++ application's stdout/stderr including `spdlog` output via a pipe.
When a pipe is used with `WriteConsole`, the call silently fails and no output is received by the calling process. With `WriteFile` the output is piped through as expected, and when running standalone, coloured output is written to the console as previously.

For further detail see:
https://stackoverflow.com/a/47041058
https://docs.microsoft.com/en-us/windows/console/high-level-console-input-and-output-functions
https://docs.microsoft.com/en-us/windows/console/console-handles

Tested on Windows 10