### PR TITLE
Added ARCH_INDEPENDENT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,11 @@ if (SPDLOG_INSTALL)
 
     include(CMakePackageConfigHelpers)
     configure_file("${project_config_in}" "${project_config_out}" @ONLY)
-    write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+    if(${CMAKE_VERSION} VERSION_GREATER 3.13)
+        write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+    else()
+        write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion)
+    endif()
     install(FILES
             "${project_config_out}"
             "${version_config_file}" DESTINATION "${export_dest_dir}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright(c) 2019 spdlog authors
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.14)
 
 #---------------------------------------------------------------------------------------
 # Start spdlog project
@@ -197,7 +197,7 @@ if (SPDLOG_INSTALL)
 
     include(CMakePackageConfigHelpers)
     configure_file("${project_config_in}" "${project_config_out}" @ONLY)
-    write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion)
+    write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
     install(FILES
             "${project_config_out}"
             "${version_config_file}" DESTINATION "${export_dest_dir}")


### PR DESCRIPTION
Fixes #722 as CMake has added an option to disable enforcing 32/64-bitness parity for header-only libraries.