### PR TITLE
Unbreak on more BSDs

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -230,7 +230,7 @@ SPDLOG_INLINE size_t filesize(FILE *f)
 #else // unix
     int fd = fileno(f);
 // 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
-#if !defined(__FreeBSD__) && !defined(__APPLE__) && (defined(__x86_64__) || defined(__ppc64__)) && !defined(__CYGWIN__)
+#if (defined(__linux__) || defined(__sun) || defined(_AIX)) && (defined(__LP64__) || defined(_LP64))
     struct stat64 st;
     if (::fstat64(fd, &st) == 0)
     {


### PR DESCRIPTION
Upstreaming https://github.com/DragonFlyBSD/DeltaPorts/blob/c9622be6d398/ports/devel/spdlog/dragonfly/patch-include_spdlog_details_os.h

Instead of `lwp_gettid` let's use `pthread_getthreadid_np` which is available on [AIX](https://www.ibm.com/support/knowledgecenter/en/ssw_ibm_i_74/apis/users_22.htm), [DragonFly](https://www.dragonflybsd.org/cgi/web-man?command=pthread_getthreadid_np&section=3), [FreeBSD](https://man.freebsd.org/pthread_getthreadid_np/3)
