### PR TITLE
cmake: Add a new spdlog.pc pkgconfig file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SPDLOG_SRCS
         src/file_sinks.cpp
         src/async.cpp)
 
+set(SPDLOG_CFLAGS "${PROJECT_NAME}")
 
 if (SPDLOG_BUILD_SHARED)
     if(WIN32)
@@ -127,6 +128,8 @@ if(SPDLOG_FMT_EXTERNAL)
     if (NOT TARGET fmt::fmt)
         find_package(fmt REQUIRED)
     endif ()
+
+    set(SPDLOG_CFLAGS "${SPDLOG_CFLAGS} -DSPDLOG_FMT_EXTERNAL")
 
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_link_libraries(spdlog PUBLIC fmt::fmt)
@@ -180,6 +183,8 @@ if (SPDLOG_INSTALL)
     set(config_targets_file "spdlogConfigTargets.cmake")
     set(version_config_file "${CMAKE_CURRENT_BINARY_DIR}/spdlogConfigVersion.cmake")
     set(export_dest_dir "${CMAKE_INSTALL_LIBDIR}/spdlog/cmake")
+    set(pkgconfig_install_dir "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+    set(pkg_config "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc")
 
     #---------------------------------------------------------------------------------------
     # Include files
@@ -190,6 +195,9 @@ if (SPDLOG_INSTALL)
     #---------------------------------------------------------------------------------------
     # Package and version files
     #---------------------------------------------------------------------------------------
+    configure_file("cmake/${PROJECT_NAME}.pc.in" "${pkg_config}" @ONLY)
+    install(FILES "${pkg_config}" DESTINATION "${pkgconfig_install_dir}")
+
     install(EXPORT spdlog
             DESTINATION ${export_dest_dir}
             NAMESPACE spdlog::

--- a/cmake/spdlog.pc.in
+++ b/cmake/spdlog.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: lib@PROJECT_NAME@
+Description: Fast C++ logging library.
+URL: https://github.com/gabime/@PROJECT_NAME@
+Version: @SPDLOG_VERSION@
+CFlags: -I${includedir}/@SPDLOG_CFLAGS@
+Libs: -L${libdir}/@PROJECT_NAME@ -l@PROJECT_NAME@


### PR DESCRIPTION
Fixes https://github.com/gabime/spdlog/issues/1237.

Some things to note.

* I only tested this with the shared library, I am not sure if anything more needs to be done with the static library version or the header only version.
* The pkgconfig file expects `CMAKE_INSTALL_LIBDIR` to be a relative path, I am not sure there is a better way to handle this. It is important to retain the `{exec_prefix}/` and only append the relative library directory (i.e. `lib64`) for cross compiling.
* Its important to add `-DSPDLOG_FMT_EXTERNAL` to the `CFlags` when using an external fmt so that other projects that use `spdlog` find the correct headers when including `fmt.h`.
* This is enough to fix the `libixion` build, but currently they use the `spdlog.pc` file, the headers and not the library.

This is the generated pkgconfig file on my system.
```
prefix=/usr
exec_prefix=${prefix}
includedir=${prefix}/include
libdir=${exec_prefix}/lib64

Name: libspdlog
Description: Fast C++ logging library.
URL: https://github.com/gabime/spdlog
Version: 1.4.0
CFlags: -I${includedir}/spdlog -DSPDLOG_FMT_EXTERNAL
Libs: -L${libdir}/spdlog -lspdlog
```
Please review in case I missed anything, thanks!