### PR TITLE
Fix #1239, Remove basic_string_view_t

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -107,7 +107,7 @@ using memory_buf_t = fmt::basic_memory_buffer<char, 250>;
 #ifndef _WIN32
 #error SPDLOG_WCHAR_TO_UTF8_SUPPORT only supported on windows
 #else
-using wstring_view_t = basic_string_view_t<wchar_t>;
+using wstring_view_t = fmt::basic_string_view<wchar_t>;
 
 template<typename T>
 struct is_convertible_to_wstring_view : std::is_convertible<T, wstring_view_t>

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -424,7 +424,7 @@ SPDLOG_INLINE bool in_terminal(FILE *file) SPDLOG_NOEXCEPT
 }
 
 #if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
-SPDLOG_INLINE void wstr_to_utf8buf(basic_string_view_t<wchar_t> wstr, memory_buf_t &target)
+SPDLOG_INLINE void wstr_to_utf8buf(wstring_view_t wstr, memory_buf_t &target)
 {
     if (wstr.size() > static_cast<size_t>(std::numeric_limits<int>::max()))
     {

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -86,7 +86,7 @@ bool is_color_terminal() SPDLOG_NOEXCEPT;
 bool in_terminal(FILE *file) SPDLOG_NOEXCEPT;
 
 #if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
-void wstr_to_utf8buf(basic_string_view_t<wchar_t> wstr, memory_buf_t &target);
+void wstr_to_utf8buf(wstring_view_t wstr, memory_buf_t &target);
 #endif
 
 } // namespace os


### PR DESCRIPTION
Definition of `wstring_view_t` no longer depends on `basic_string_view_t`
