### PR TITLE
cmake: Only install fmt headers when SPDLOG_FMT_EXTERNAL is not defined.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,8 +184,13 @@ if (SPDLOG_INSTALL)
     #---------------------------------------------------------------------------------------
     # Include files
     #---------------------------------------------------------------------------------------
-    install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" PATTERN "fmt/bundled" EXCLUDE)
     install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
+
+    if(NOT SPDLOG_FMT_EXTERNAL)
+        install(DIRECTORY include/${PROJECT_NAME}/fmt/bundled/
+                DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/fmt/bundled/")
+    endif()
 
     #---------------------------------------------------------------------------------------
     # Package and version files


### PR DESCRIPTION
This PR will change `make install` to skip the bundled fmt headers when `SPDLOG_FMT_EXTERNAL` is defined. This ensures that other projects will not silently use the bundled headers instead of the intended system fmt headers when including `fmt.h`. Also it avoids installing useless files when using the system fmt.

When `SPDLOG_FMT_EXTERNAL` is defined only these fmt headers will be installed.
```
usr/include/spdlog/fmt/
usr/include/spdlog/fmt/bin_to_hex.h
usr/include/spdlog/fmt/fmt.h
usr/include/spdlog/fmt/ostr.h
```
When `SPDLOG_FMT_EXTERNAL` is not defined these fmt headers will be installed.
```
usr/include/spdlog/fmt/
usr/include/spdlog/fmt/bin_to_hex.h
usr/include/spdlog/fmt/bundled/
usr/include/spdlog/fmt/bundled/LICENSE.rst
usr/include/spdlog/fmt/bundled/chrono.h
usr/include/spdlog/fmt/bundled/color.h
usr/include/spdlog/fmt/bundled/compile.h
usr/include/spdlog/fmt/bundled/core.h
usr/include/spdlog/fmt/bundled/format-inl.h
usr/include/spdlog/fmt/bundled/format.h
usr/include/spdlog/fmt/bundled/locale.h
usr/include/spdlog/fmt/bundled/ostream.h
usr/include/spdlog/fmt/bundled/posix.h
usr/include/spdlog/fmt/bundled/printf.h
usr/include/spdlog/fmt/bundled/ranges.h
usr/include/spdlog/fmt/bundled/safe-duration-cast.h
usr/include/spdlog/fmt/fmt.h
usr/include/spdlog/fmt/ostr.h
```