### PR TITLE
cmake: Add FMT_HEADER_ONLY to the pkgconfig file with an external fmt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(SPDLOG_FMT_EXTERNAL)
         find_package(fmt REQUIRED)
     endif ()
 
-    set(SPDLOG_CFLAGS "${SPDLOG_CFLAGS} -DSPDLOG_FMT_EXTERNAL")
+    set(SPDLOG_CFLAGS "${SPDLOG_CFLAGS} -DSPDLOG_FMT_EXTERNAL -DFMT_HEADER_ONLY")
 
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_link_libraries(spdlog PUBLIC fmt::fmt)


### PR DESCRIPTION
When compiling `libixion` using `gcc` and when `spdlog` has been built with `SPDLOG_FMT_EXTERNAL` defined it will fail.

For example with `gcc-5.5.0` on `Slackware-14.2`.
```
  CXXLD    ixion-sorter
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::format_error::~format_error()'
libixion/.libs/libixion-0.15.so: undefined reference to `typeinfo for fmt::v6::format_error'
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::internal::error_handler::on_error(char const*)'
libixion/.libs/libixion-0.15.so: undefined reference to `char fmt::v6::internal::thousands_sep_impl<char>(fmt::v6::internal::locale_ref)'
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::internal::basic_data<void>::hex_digits'
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::internal::basic_data<void>::digits'
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::internal::basic_data<void>::zero_or_powers_of_10_32'
libixion/.libs/libixion-0.15.so: undefined reference to `fmt::v6::internal::basic_data<void>::zero_or_powers_of_10_64'
libixion/.libs/libixion-0.15.so: undefined reference to `char* fmt::v6::internal::sprintf_format<double>(double, fmt::v6::internal::buffer<char>&, fmt::v6::internal::sprintf_specs)'
libixion/.libs/libixion-0.15.so: undefined reference to `char fmt::v6::internal::decimal_point_impl<char>(fmt::v6::internal::locale_ref)'
libixion/.libs/libixion-0.15.so: undefined reference to `vtable for fmt::v6::format_error'
libixion/.libs/libixion-0.15.so: undefined reference to `char* fmt::v6::internal::sprintf_format<long double>(long double, fmt::v6::internal::buffer<char>&, fmt::v6::internal::sprintf_specs)'
collect2: error: ld returned 1 exit status
Makefile:760: recipe for target 'ixion-sorter' failed
make[3]: *** [ixion-sorter] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/tmp/SBo/libixion-0.15.0/src'
Makefile:811: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/tmp/SBo/libixion-0.15.0/src'
Makefile:571: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/tmp/SBo/libixion-0.15.0'
Makefile:478: recipe for target 'all' failed
make: *** [all] Error 2
```
I didn't notice this before because I neglected to test with `gcc` and only used `clang` which does not have this problem. This also does not occur when `SPDLOG_FMT_EXTERNAL` is not defined.

It seems this can be fixed by linking libixion with `-lfmt` or as done in this PR by adding `-DFMT_HEADER_ONLY` to the new pkgconfig file when using an external fmt. With this libixion builds with both `gcc` and `clang`, but I'm not sure if you have a better idea?