### PR TITLE
Add option to selection MSVC runtime when compiling spdlog as a library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,8 @@ endif()
 add_library(spdlog::spdlog ALIAS spdlog)
 
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
-target_compile_options(spdlog PRIVATE /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(spdlog PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 target_include_directories(spdlog PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ if(NOT WIN32)
     option(SPDLOG_BUILD_SHARED "Build shared library" OFF)
 endif()
 
+if (NOT DEFINED SPDLOG_MSVC_RUNTIME_LIBRARY)
+    set(SPDLOG_MSVC_RUNTIME_LIBRARY "MT")
+endif()
+
 # example options
 option(SPDLOG_BUILD_EXAMPLE "Build example" ${SPDLOG_MASTER_PROJECT})
 option(SPDLOG_BUILD_EXAMPLE_HO "Build header only example" OFF)
@@ -100,6 +104,7 @@ endif()
 add_library(spdlog::spdlog ALIAS spdlog)
 
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
+target_compile_options(spdlog PRIVATE /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 target_include_directories(spdlog PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -7,22 +7,34 @@ project(spdlog_bench CXX)
 if(NOT TARGET spdlog)
   # Stand-alone build
   find_package(spdlog CONFIG REQUIRED)
+  
+  if (NOT DEFINED SPDLOG_MSVC_RUNTIME_LIBRARY)
+    set(SPDLOG_MSVC_RUNTIME_LIBRARY "MT")
+  endif()
 endif()
 
 find_package(Threads REQUIRED)
 find_package(benchmark CONFIG REQUIRED)
 
 add_executable(bench bench.cpp)
+target_compile_options(bench PRIVATE 
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 spdlog_enable_warnings(bench)
 target_link_libraries(bench PRIVATE spdlog::spdlog)
 
 add_executable(async_bench async_bench.cpp)
+target_compile_options(async_bench PRIVATE 
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 target_link_libraries(async_bench PRIVATE spdlog::spdlog)
 
 add_executable(latency latency.cpp)
+target_compile_options(latency PRIVATE 
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 target_link_libraries(latency PRIVATE benchmark::benchmark spdlog::spdlog)
 
 add_executable(formatter-bench formatter-bench.cpp)
+target_compile_options(formatter-bench PRIVATE 
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 target_link_libraries(formatter-bench PRIVATE benchmark::benchmark spdlog::spdlog)
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -17,24 +17,24 @@ find_package(Threads REQUIRED)
 find_package(benchmark CONFIG REQUIRED)
 
 add_executable(bench bench.cpp)
-target_compile_options(bench PRIVATE 
-    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(bench PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 spdlog_enable_warnings(bench)
 target_link_libraries(bench PRIVATE spdlog::spdlog)
 
 add_executable(async_bench async_bench.cpp)
-target_compile_options(async_bench PRIVATE 
-    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(async_bench PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 target_link_libraries(async_bench PRIVATE spdlog::spdlog)
 
 add_executable(latency latency.cpp)
-target_compile_options(latency PRIVATE 
-    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(latency PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 target_link_libraries(latency PRIVATE benchmark::benchmark spdlog::spdlog)
 
 add_executable(formatter-bench formatter-bench.cpp)
-target_compile_options(formatter-bench PRIVATE 
-    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(formatter-bench PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 target_link_libraries(formatter-bench PRIVATE benchmark::benchmark spdlog::spdlog)
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/logs")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,12 +7,18 @@ project(spdlog_examples CXX)
 if(NOT TARGET spdlog)
     # Stand-alone build
     find_package(spdlog REQUIRED)
+    
+    if (NOT DEFINED SPDLOG_MSVC_RUNTIME_LIBRARY)
+        set(SPDLOG_MSVC_RUNTIME_LIBRARY "MT")
+    endif()
 endif()
 
 #---------------------------------------------------------------------------------------
 # Example of using pre-compiled library
 #---------------------------------------------------------------------------------------
 add_executable(example example.cpp)
+target_compile_options(example PRIVATE 
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 spdlog_enable_warnings(example)
 target_link_libraries(example PRIVATE spdlog::spdlog)
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -17,8 +17,8 @@ endif()
 # Example of using pre-compiled library
 #---------------------------------------------------------------------------------------
 add_executable(example example.cpp)
-target_compile_options(example PRIVATE 
-    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+target_compile_options(example PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+    /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 spdlog_enable_warnings(example)
 target_link_libraries(example PRIVATE spdlog::spdlog)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,8 +45,8 @@ enable_testing()
 # The compiled library tests
 if(SPDLOG_BUILD_TESTS)
     add_executable(spdlog-utests ${SPDLOG_UTESTS_SOURCES})
-    target_compile_options(spdlog-utests PRIVATE 
-        /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
+    target_compile_options(spdlog-utests PRIVATE $<$<CXX_COMPILER_ID:MSVC>:
+        /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>>)
 	spdlog_enable_warnings(spdlog-utests)
     target_link_libraries(spdlog-utests PRIVATE spdlog)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,10 @@ if(PkgConfig_FOUND)
 	pkg_check_modules(systemd libsystemd)
 endif()
 
+if (NOT DEFINED SPDLOG_MSVC_RUNTIME_LIBRARY)
+    set(SPDLOG_MSVC_RUNTIME_LIBRARY "MT")
+endif()
+
 set(SPDLOG_UTESTS_SOURCES
     test_file_helper.cpp
     test_file_logging.cpp
@@ -41,6 +45,8 @@ enable_testing()
 # The compiled library tests
 if(SPDLOG_BUILD_TESTS)
     add_executable(spdlog-utests ${SPDLOG_UTESTS_SOURCES})
+    target_compile_options(spdlog-utests PRIVATE 
+        /${SPDLOG_MSVC_RUNTIME_LIBRARY}$<$<CONFIG:Debug>:d>)
 	spdlog_enable_warnings(spdlog-utests)
     target_link_libraries(spdlog-utests PRIVATE spdlog)
 


### PR DESCRIPTION
When compiling spdlog to use as a library, there is currently no way to select what MSVC runtime to use. A project that links against the MSVC static runtime will be forced to use spdlog as a header only lib. This pull request creates a new CMake variable, SPDLOG_MSVC_RUNTIME_LIBRARY, which doesn't change default behavior.

Unfortunately, CMake has no built-in support for the runtime library flag until version 3.15.