### PR TITLE
Fix windows compile error where std::max is overriden by a macro (#1251)

### DIFF
--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -878,7 +878,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        auto delta = std::max(msg.time - last_message_time_, log_clock::duration::zero());
+        auto delta = (std::max)(msg.time - last_message_time_, log_clock::duration::zero());
         auto delta_units = std::chrono::duration_cast<DurationUnits>(delta);
         last_message_time_ = msg.time;
         ScopedPadder p(6, padinfo_, dest);


### PR DESCRIPTION
See https://github.com/gabime/spdlog/issues/1251

Stack Overflow says that putting parenthesis around std::max is a way to fix it, and I've seen this pattern used twice in the code base (actually in fmt library).

```
include/spdlog/fmt/bundled/printf.h
47:    return (std::max)(static_cast<int>(value), 0);

include/spdlog/fmt/bundled/format.h
1041:    int num_zeros = (std::max)(params.num_digits - full_exp, 1);
```

The type of the objects wasn't super clear so I went with the parenthesis option.