### PR TITLE
CMakeLists.txt: removed spdlog subdir from library install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if (SPDLOG_INSTALL)
     # Include files
     #---------------------------------------------------------------------------------------
     install(DIRECTORY include/ DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" PATTERN "fmt/bundled" EXCLUDE)
-    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}/spdlog")
+    install(TARGETS spdlog spdlog_header_only EXPORT spdlog DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
     if(NOT SPDLOG_FMT_EXTERNAL)
         install(DIRECTORY include/${PROJECT_NAME}/fmt/bundled/


### PR DESCRIPTION
The library gets installed into ${CMAKE_INSTALL_LIBDIR}/spdlog, which
is for unix / linux a rather strange place, hence, put it where the linker
is more likely to find it.

Signed-off-by: Matthias Schoepfer <matthias.schoepfer@ithinx.io>