### PR TITLE
CMake: Add C++11 requirement for spdlog target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 
 add_library(spdlog::spdlog ALIAS spdlog)
 
+target_compile_features(spdlog PUBLIC cxx_std_11)
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
 target_include_directories(spdlog PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"


### PR DESCRIPTION
Suppose we have a CMake-build-oriented parent project that includes spdlog as an external library through `add_subdirectory` command and links one of its libraries/executables to `spdlog` target.

If that parent project source files include <spdlog/spdlog.h> **and** the CMakeLists.txt of that parent project does not enforce the usage of C++11 standard, the compilation of that project will fail, because the `spdlog.h` header requires that standard to compile.


This PR adds a CMake's `target_compile_features` command applied to `spdlog` target which ensures that all targets that link to that target will be compiled using at least C++11 standard, thus, resolving the problem.