### PR TITLE
Fix build failure on clang 7 with libc++

### DIFF
--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -7,6 +7,7 @@
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/details/synchronous_factory.h"
 
+#include <array>
 #include <systemd/sd-journal.h>
 
 namespace spdlog {


### PR DESCRIPTION
Unlike the GNU C++ STL, there's no implicit include for <array> in this one, apparently.