### PR TITLE
Fix some spelling errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 
 
 #---------------------------------------------------------------------------------------
-# Use fmt package if using exertnal fmt
+# Use fmt package if using external fmt
 #---------------------------------------------------------------------------------------
 if(SPDLOG_FMT_EXTERNAL)
     if (NOT TARGET fmt::fmt)
@@ -133,7 +133,7 @@ if(SPDLOG_FMT_EXTERNAL)
     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)
     target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
 
-    set(PKG_CONFIG_REQUIRES fmt) # add dependecy to pkg-config
+    set(PKG_CONFIG_REQUIRES fmt) # add dependency to pkg-config
 endif()
 
 if(SPDLOG_WCHAR_SUPPORT)

--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -6,7 +6,7 @@
 //
 // Async logging using global thread pool
 // All loggers created here share same global thread pool.
-// Each log message is pushed to a queue along withe a shared pointer to the
+// Each log message is pushed to a queue along with a shared pointer to the
 // logger.
 // If a logger deleted while having pending messages in the queue, it's actual
 // destruction will defer

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -1,7 +1,7 @@
 // Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-// cirucal q view of std::vector.
+// circular q view of std::vector.
 #pragma once
 
 #include <vector>

--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -119,7 +119,7 @@ SPDLOG_INLINE std::tuple<filename_t, filename_t> file_helper::split_by_extension
         return std::make_tuple(fname, filename_t());
     }
 
-    // treat casese like "/etc/rc.d/somelogfile or "/abc/.hiddenfile"
+    // treat cases like "/etc/rc.d/somelogfile or "/abc/.hiddenfile"
     auto folder_index = fname.rfind(details::os::folder_sep);
     if (folder_index != filename_t::npos && folder_index >= ext_index - 1)
     {

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -81,7 +81,7 @@ int pid() SPDLOG_NOEXCEPT;
 // Source: https://github.com/agauniyal/rang/
 bool is_color_terminal() SPDLOG_NOEXCEPT;
 
-// Detrmine if the terminal attached
+// Determine if the terminal attached
 // Source: https://github.com/agauniyal/rang/
 bool in_terminal(FILE *file) SPDLOG_NOEXCEPT;
 

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -596,7 +596,7 @@ public:
 #ifdef _WIN32
         int total_minutes = get_cached_offset(msg, tm_time);
 #else
-        // No need to chache under gcc,
+        // No need to cache under gcc,
         // it is very fast (already stored in tm.tm_gmtoff)
         (void)(msg);
         int total_minutes = os::utc_minutes_offset(tm_time);

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -254,10 +254,10 @@ SPDLOG_INLINE std::recursive_mutex &registry::tp_mutex()
     return tp_mutex_;
 }
 
-SPDLOG_INLINE void registry::set_automatic_registration(bool automatic_regsistration)
+SPDLOG_INLINE void registry::set_automatic_registration(bool automatic_registration)
 {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);
-    automatic_registration_ = automatic_regsistration;
+    automatic_registration_ = automatic_registration;
 }
 
 SPDLOG_INLINE registry &registry::instance()

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -77,7 +77,7 @@ public:
 
     std::recursive_mutex &tp_mutex();
 
-    void set_automatic_registration(bool automatic_regsistration);
+    void set_automatic_registration(bool automatic_registration);
 
     static registry &instance();
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -90,7 +90,7 @@ SPDLOG_INLINE const std::string &logger::name() const
 }
 
 // set formatting for the sinks in this logger.
-// each sink will get a seperate instance of the formatter object.
+// each sink will get a separate instance of the formatter object.
 SPDLOG_INLINE void logger::set_formatter(std::unique_ptr<formatter> f)
 {
     for (auto it = sinks_.begin(); it != sinks_.end(); ++it)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -303,7 +303,7 @@ public:
     const std::string &name() const;
 
     // set formatting for the sinks in this logger.
-    // each sink will get a seperate instance of the formatter object.
+    // each sink will get a separate instance of the formatter object.
     void set_formatter(std::unique_ptr<formatter> f);
 
     void set_pattern(std::string pattern, pattern_time_type time_type = pattern_time_type::local);

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -95,7 +95,7 @@ protected:
         base_sink<Mutex>::formatter_->format(msg, formatted);
         file_helper_.write(formatted);
 
-        // Do the cleaning ony at the end because it might throw on failure.
+        // Do the cleaning only at the end because it might throw on failure.
         if (should_rotate && max_files_ > 0)
         {
             delete_old_();

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -92,9 +92,9 @@ SPDLOG_INLINE void shutdown()
     details::registry::instance().shutdown();
 }
 
-SPDLOG_INLINE void set_automatic_registration(bool automatic_registation)
+SPDLOG_INLINE void set_automatic_registration(bool automatic_registration)
 {
-    details::registry::instance().set_automatic_registration(automatic_registation);
+    details::registry::instance().set_automatic_registration(automatic_registration);
 }
 
 SPDLOG_INLINE std::shared_ptr<spdlog::logger> default_logger()

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -100,7 +100,7 @@ void drop_all();
 void shutdown();
 
 // Automatic registration of loggers when using spdlog::create() or spdlog::create_async
-void set_automatic_registration(bool automatic_registation);
+void set_automatic_registration(bool automatic_registration);
 
 // API for using default logger (stdout_color_mt),
 // e.g: spdlog::info("Message {}", 1);

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ dep_list += dependency('threads')
 # Check for FMT
 if get_option('external_fmt')
   if not meson.version().version_compare('>=0.49.0')
-    warning('Finding fmt can fail wit meson versions before 0.49.0')
+    warning('Finding fmt can fail with meson versions before 0.49.0')
   endif
   dep_list     += dependency('fmt')
   compile_args += '-DSPDLOG_FMT_EXTERNAL'

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -40,7 +40,7 @@ TEST_CASE("disable param evaluation", "[macros]")
     SPDLOG_TRACE("Test message {}", throw std::runtime_error("Should not be evaluated"));
 }
 
-// ensure that even if right macro level is on- don't eavluate if the logger's level is not high enough
+// ensure that even if right macro level is on- don't evaluate if the logger's level is not high enough
 TEST_CASE("disable param evaluation2", "[macros]")
 {
     auto logger = std::make_shared<spdlog::logger>("test-macro");

--- a/tests/test_registry.cpp
+++ b/tests/test_registry.cpp
@@ -9,7 +9,7 @@ TEST_CASE("register_drop", "[registry]")
     spdlog::drop_all();
     spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name);
     REQUIRE(spdlog::get(tested_logger_name) != nullptr);
-    // Throw if registring existing name
+    // Throw if registering existing name
     REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), spdlog::spdlog_ex);
 }
 
@@ -19,7 +19,7 @@ TEST_CASE("explicit register", "[registry]")
     auto logger = std::make_shared<spdlog::logger>(tested_logger_name, std::make_shared<spdlog::sinks::null_sink_st>());
     spdlog::register_logger(logger);
     REQUIRE(spdlog::get(tested_logger_name) != nullptr);
-    // Throw if registring existing name
+    // Throw if registering existing name
     REQUIRE_THROWS_AS(spdlog::create<spdlog::sinks::null_sink_mt>(tested_logger_name), spdlog::spdlog_ex);
 }
 #endif


### PR DESCRIPTION
casese -> cases (1)
chache -> cache (1)
cirucal -> circular (1)
dependecy -> dependency (1)
detrmine -> determine (2)
eavluate -> evaluate (1)
exertnal -> external (1)
ony -> only (1)
registation -> registration (3)
registring -> registering (2)
regsistration -> registration (3)
seperate -> separate (2)
wit -> with (1)
withe -> with (1)