### PR TITLE
Use _FILE_OFFSET_BITS=64 when building on Linux 32-bit systems

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,13 @@ function(spdlog_prepare_test test_target spdlog_lib)
 	if(SPDLOG_SANITIZE_ADDRESS)
 		spdlog_enable_sanitizer(${test_target})
 	endif()
-    add_test(NAME ${test_target} COMMAND ${test_target})   
+    add_test(NAME ${test_target} COMMAND ${test_target})
+
+    if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+        if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+            target_compile_definitions(${test_target} PRIVATE _FILE_OFFSET_BITS=64)
+        endif()
+    endif()
 endfunction()
 
 # The compiled library tests


### PR DESCRIPTION
When cross-compiling spdlog from `x86-64` to `armhf`, I ran spdlog-utests via qemu-arm and noticed that the `daily_logger rotate` test was failing because `count_files` always returned zero.

Investigation of `count_files` revealed that `readdir` was returning nullptr immediately and setting errno to 75, i.e. "value too large for defined data type".  I suspected this had something to do with some 64 vs. 32-bit thing, so I added `_FILE_OFFSET_BITS=64` to the build and that seems to have made `readdir` (and the test) happy.

It might be safe to add `_FILE_OFFSET_BITS=64` for all Linux builds, but it only seems to be necessary for the 32-bit case (which is admittedly a fairly small audience -- I'm only building for armhf to target a Raspberry Pi 3 running Raspbian, which runs in 32-bit mode).  The method used in this PR does preclude someone wanting 32-bit file access on a 32-bit system, but I don't think that's very common these days.

It might also be okay to just add `_FILE_OFFSET_BITS=64` to just the test suite; doing that makes the test in question pass in my setup.  However, as both spdlog's file sink and the `daily_logger rotate` test both do file operations, it seems prudent to me to be consistent.