### PR TITLE
improve systemd journald support

### DIFF
--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -8,6 +8,9 @@
 #include "spdlog/details/synchronous_factory.h"
 
 #include <array>
+#ifndef SD_JOURNAL_SUPPRESS_LOCATION
+#define SD_JOURNAL_SUPPRESS_LOCATION
+#endif
 #include <systemd/sd-journal.h>
 
 namespace spdlog {
@@ -63,7 +66,7 @@ protected:
         else
         {
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), msg.payload.data(), "PRIORITY=%d", syslog_level(msg.level),
-                "SOURCE_FILE=%s", msg.source.filename, "SOURCE_LINE=%d", msg.source.line, "SOURCE_FUNC=%s", msg.source.funcname, nullptr);
+                "CODE_FILE=%s", msg.source.filename, "CODE_LINE=%d", msg.source.line, "CODE_FUNC=%s", msg.source.funcname, nullptr);
         }
 
         if (err)

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -61,11 +61,13 @@ protected:
         {
             // Note: function call inside '()' to avoid macro expansion
             err = (sd_journal_send)(
-                "MESSAGE=%.*s", static_cast<int>(length), msg.payload.data(), "PRIORITY=%d", syslog_level(msg.level), nullptr);
+                "MESSAGE=%.*s", static_cast<int>(length), msg.payload.data(), "PRIORITY=%d", syslog_level(msg.level),
+                "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(msg.logger_name.size()), msg.logger_name.data(), nullptr);
         }
         else
         {
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), msg.payload.data(), "PRIORITY=%d", syslog_level(msg.level),
+                "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(msg.logger_name.size()), msg.logger_name.data(),
                 "CODE_FILE=%s", msg.source.filename, "CODE_LINE=%d", msg.source.line, "CODE_FUNC=%s", msg.source.funcname, nullptr);
         }
 


### PR DESCRIPTION
These three patches which make it easier to use `systemd`/`journald`'s structured logging. When everything is in place, one can, for example, watch the log stream via this user-friendly :) command:

```
journlctl -f -u my-app.service \
  PRIORITY=1 PRIORITY=2 PRIORITY=3 PRIORITY=4 \
    SYSLOG_IDENTIFIER=only-important-messages-are-shown-now \
 + \
 PRIORITY=1 PRIORITY=2 PRIORITY=3 PRIORITY=4 PRIORITY=5 PRIORITY=6 PRIORITY=7 \
    SYSLOG_IDENTIFIER=I-want-details-from-this
```
That command will follow journal stream from the `my-app.service`. The logger whose name is `only-important-messages-are-shown-now` is rather heavily filtered, but everything from a logger called `I-want-details-from-this` is shown. These options are [documented](https://www.freedesktop.org/software/systemd/man/journalctl.html) in `journalctl`'s manpage. Sadly, there is neither range-checking nor [negative matching](https://github.com/systemd/systemd/issues/2720) in there.

I'm doing this mostly for use cases described in #1290 ...

##  ~~journald: wider range of log severities~~

~~The previous code made it impossible to distinguish between the `debug` and `trace` severities. So instead of trying hard to preserve the equivalence of `spdlog::level::debug` with `LOG_DEBUG`, which is -- in the end -- just an arbitrary name, make sure that functionality is not lost.~~

[Removed per explicit request]( https://github.com/gabime/spdlog/pull/1292#discussion_r340777258); here's how to implement this:
```c++
#include <spdlog/sinks/systemd_sink.h>

template<typename Mutex>
class journald_sink : public spdlog::sinks::systemd_sink<Mutex> {
public:
    journald_sink()
    {
        this->syslog_levels_ = {/* spdlog::level::trace      */ LOG_DEBUG,
              /* spdlog::level::debug      */ LOG_INFO,
              /* spdlog::level::info       */ LOG_NOTICE,
              /* spdlog::level::warn       */ LOG_WARNING,
              /* spdlog::level::err        */ LOG_ERR,
              /* spdlog::level::critical   */ LOG_CRIT,
              /* spdlog::level::off        */ LOG_ALERT};
    }
};
```

##  journald: structured output for logger's name

Previously, the logger name was effectively lost. There were two choices on how to add it:

- Via a formatter, which would mean that `journalctl` would not be able to filter against that. That would be suboptimal.

- As a "syslog identifier". This means that `journalctl` will, by default, stop showing the daemon's executable name and replace that via the logger name. The PID is still shown, and if one would like to go back to the previous behavior, it is still possible via `journalctl -o with-unit`.

I think that the second option is strictly better than the first one.

fixes #1289

##  journald: fix source file location

This is what my manpage says, and what the [original blog post](http://0pointer.de/blog/projects/journal-submit.html) says as well.