### PR TITLE
Improve log macros

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -288,8 +288,8 @@ inline void critical(wstring_view_t fmt, const Args &... args)
 #define SPDLOG_LOGGER_CALL(logger, level, ...)                                                                                             \
     do                                                                                                                                     \
     {                                                                                                                                      \
-        if (logger->should_log(level) || logger->should_backtrace())                                                                       \
-            logger->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__);                                      \
+        if ((logger)->should_log(level) || (logger)->should_backtrace())                                                                   \
+            (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__);                                    \
     } while (0)
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -40,6 +40,14 @@ TEST_CASE("disable param evaluation", "[macros]")
     SPDLOG_TRACE("Test message {}", throw std::runtime_error("Should not be evaluated"));
 }
 
+TEST_CASE("compile with reference to logger", "[macros]")
+{
+    auto logger = spdlog::create<spdlog::sinks::null_sink_mt>("refmacro");
+    auto& ref = *logger;
+    SPDLOG_LOGGER_TRACE(&ref, "Test message 1");
+    SPDLOG_LOGGER_DEBUG(&ref, "Test message 2");
+}
+
 // ensure that even if right macro level is on- don't evaluate if the logger's level is not high enough
 TEST_CASE("disable param evaluation2", "[macros]")
 {


### PR DESCRIPTION
Hello. I think the log macros should be changed to compile with "&my_logger" expressions. Thanks.