### PR TITLE
Correctly guard SetHandleInformation API call

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -130,7 +130,7 @@ SPDLOG_INLINE void prevent_child_fd(FILE *f)
 {
 
 #ifdef _WIN32
-#if !defined(__cplusplus_winrt)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
     auto file_handle = reinterpret_cast<HANDLE>(_get_osfhandle(::_fileno(f)));
     if (!::SetHandleInformation(file_handle, HANDLE_FLAG_INHERIT, 0))
         SPDLOG_THROW(spdlog_ex("SetHandleInformation failed", errno));


### PR DESCRIPTION
`__cplusplus_winrt` only detected C++/CX (which can be used without compiling for UWP, SetHandleInformation would be available in those cases), and did not detect native UWP C++. This patch fixes that by using the WINAPI_FAMILY_PARTITION macro in the Windows SDK headers in the same way those headers remove SetHandleInformation in UWP builds.