### PR TITLE
"#include" <spdlog/.*> instead of "spdlog/.*"

### DIFF
--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -14,9 +14,9 @@
 // This is because each message in the queue holds a shared_ptr to the
 // originating logger.
 
-#include "spdlog/async_logger.h"
-#include "spdlog/details/registry.h"
-#include "spdlog/details/thread_pool.h"
+#include <spdlog/async_logger.h>
+#include <spdlog/details/registry.h>
+#include <spdlog/details/thread_pool.h>
 
 #include <memory>
 #include <mutex>

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/async_logger.h"
+#include <spdlog/async_logger.h>
 #endif
 
-#include "spdlog/sinks/sink.h"
-#include "spdlog/details/thread_pool.h"
+#include <spdlog/sinks/sink.h>
+#include <spdlog/details/thread_pool.h>
 
 #include <memory>
 #include <string>

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -14,7 +14,7 @@
 // Upon destruction, logs all remaining messages in the queue before
 // destructing..
 
-#include "spdlog/logger.h"
+#include <spdlog/logger.h>
 
 namespace spdlog {
 

--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 #endif
 
 namespace spdlog {

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/tweakme.h"
-#include "spdlog/details/null_mutex.h"
+#include <spdlog/tweakme.h>
+#include <spdlog/details/null_mutex.h>
 
 #include <atomic>
 #include <chrono>
@@ -35,7 +35,7 @@
 #define SPDLOG_INLINE inline
 #endif
 
-#include "spdlog/fmt/fmt.h"
+#include <spdlog/fmt/fmt.h>
 
 // visual studio upto 2013 does not support noexcept nor constexpr
 #if defined(_MSC_VER) && (_MSC_VER < 1900)

--- a/include/spdlog/details/backtracer-inl.h
+++ b/include/spdlog/details/backtracer-inl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/backtracer.h"
+#include <spdlog/details/backtracer.h>
 #endif
 namespace spdlog {
 namespace details {

--- a/include/spdlog/details/backtracer.h
+++ b/include/spdlog/details/backtracer.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg_buffer.h"
-#include "spdlog/details/circular_q.h"
+#include <spdlog/details/log_msg_buffer.h>
+#include <spdlog/details/circular_q.h>
 
 #include <atomic>
 #include <mutex>

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "spdlog/details/null_mutex.h"
+#include <spdlog/details/null_mutex.h>
 #include <mutex>
 
 namespace spdlog {

--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/file_helper.h"
+#include <spdlog/details/file_helper.h>
 #endif
 
-#include "spdlog/details/os.h"
-#include "spdlog/common.h"
+#include <spdlog/details/os.h>
+#include <spdlog/common.h>
 
 #include <cerrno>
 #include <chrono>

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 #include <tuple>
 
 namespace spdlog {

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -4,8 +4,8 @@
 
 #include <chrono>
 #include <type_traits>
-#include "spdlog/fmt/fmt.h"
-#include "spdlog/common.h"
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/common.h>
 
 // Some fmt helpers to efficiently format and pad ints and strings
 namespace spdlog {

--- a/include/spdlog/details/log_msg-inl.h
+++ b/include/spdlog/details/log_msg-inl.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/log_msg.h"
+#include <spdlog/details/log_msg.h>
 #endif
 
-#include "spdlog/details/os.h"
+#include <spdlog/details/os.h>
 
 namespace spdlog {
 namespace details {

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 #include <string>
 
 namespace spdlog {

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/log_msg_buffer.h"
+#include <spdlog/details/log_msg_buffer.h>
 #endif
 
 namespace spdlog {

--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg.h"
+#include <spdlog/details/log_msg.h>
 
 namespace spdlog {
 namespace details {

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -10,7 +10,7 @@
 // dequeue_for(..) - will block until the queue is not empty or timeout have
 // passed.
 
-#include "spdlog/details/circular_q.h"
+#include <spdlog/details/circular_q.h>
 
 #include <condition_variable>
 #include <mutex>

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/os.h"
+#include <spdlog/details/os.h>
 #endif
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 
 #include <algorithm>
 #include <chrono>

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 #include <ctime> // std::time_t
 
 namespace spdlog {

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -4,14 +4,14 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/details/pattern_formatter.h>
 #endif
 
-#include "spdlog/details/fmt_helper.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/os.h"
-#include "spdlog/fmt/fmt.h"
-#include "spdlog/formatter.h"
+#include <spdlog/details/fmt_helper.h>
+#include <spdlog/details/log_msg.h>
+#include <spdlog/details/os.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/formatter.h>
 
 #include <array>
 #include <chrono>

--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/os.h"
-#include "spdlog/formatter.h"
+#include <spdlog/common.h>
+#include <spdlog/details/log_msg.h>
+#include <spdlog/details/os.h>
+#include <spdlog/formatter.h>
 
 #include <chrono>
 #include <ctime>

--- a/include/spdlog/details/periodic_worker-inl.h
+++ b/include/spdlog/details/periodic_worker-inl.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/periodic_worker.h"
+#include <spdlog/details/periodic_worker.h>
 #endif
 
 namespace spdlog {

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -4,20 +4,20 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/registry.h"
+#include <spdlog/details/registry.h>
 #endif
 
-#include "spdlog/common.h"
-#include "spdlog/details/periodic_worker.h"
-#include "spdlog/logger.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/common.h>
+#include <spdlog/details/periodic_worker.h>
+#include <spdlog/logger.h>
+#include <spdlog/details/pattern_formatter.h>
 
 #ifndef SPDLOG_DISABLE_DEFAULT_LOGGER
 // support for the default stdout color logger
 #ifdef _WIN32
-#include "spdlog/sinks/wincolor_sink.h"
+#include <spdlog/sinks/wincolor_sink.h>
 #else
-#include "spdlog/sinks/ansicolor_sink.h"
+#include <spdlog/sinks/ansicolor_sink.h>
 #endif
 #endif // SPDLOG_DISABLE_DEFAULT_LOGGER
 

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -8,7 +8,7 @@
 // If user requests a non existing logger, nullptr will be returned
 // This class is thread safe
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 
 #include <chrono>
 #include <functional>

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/details/thread_pool.h"
+#include <spdlog/details/thread_pool.h>
 #endif
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 
 namespace spdlog {
 namespace details {

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg_buffer.h"
-#include "spdlog/details/mpmc_blocking_q.h"
-#include "spdlog/details/os.h"
+#include <spdlog/details/log_msg_buffer.h>
+#include <spdlog/details/mpmc_blocking_q.h>
+#include <spdlog/details/os.h>
 
 #include <chrono>
 #include <memory>
@@ -27,7 +27,7 @@ enum class async_msg_type
     terminate
 };
 
-#include "spdlog/details/log_msg_buffer.h"
+#include <spdlog/details/log_msg_buffer.h>
 // Async msg to move to/from the queue
 // Movable only. should never be copied
 struct async_msg : log_msg_buffer

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -22,6 +22,6 @@
 #include "bundled/core.h"
 #include "bundled/format.h"
 #else // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
-#include "fmt/core.h"
-#include "fmt/format.h"
+#include <fmt/core.h>
+#include <fmt/format.h>
 #endif

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "fmt/fmt.h"
-#include "spdlog/details/log_msg.h"
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/details/log_msg.h>
 
 namespace spdlog {
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -4,12 +4,12 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/logger.h"
+#include <spdlog/logger.h>
 #endif
 
-#include "spdlog/sinks/sink.h"
-#include "spdlog/details/backtracer.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/sinks/sink.h>
+#include <spdlog/details/backtracer.h>
+#include <spdlog/details/pattern_formatter.h>
 
 #include <cstdio>
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -14,12 +14,12 @@
 // The use of private formatter per sink provides the opportunity to cache some
 // formatted data, and support for different format per sink.
 
-#include "spdlog/common.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/backtracer.h"
+#include <spdlog/common.h>
+#include <spdlog/details/log_msg.h>
+#include <spdlog/details/backtracer.h>
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
-#include "spdlog/details/os.h"
+#include <spdlog/details/os.h>
 #endif
 
 #include <vector>

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -5,11 +5,11 @@
 
 #ifdef __ANDROID__
 
-#include "spdlog/details/fmt_helper.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/os.h"
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/details/fmt_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/os.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <android/log.h>
 #include <chrono>

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/ansicolor_sink.h"
+#include <spdlog/sinks/ansicolor_sink.h>
 #endif
 
-#include "spdlog/details/pattern_formatter.h"
-#include "spdlog/details/os.h"
+#include <spdlog/details/pattern_formatter.h>
+#include <spdlog/details/os.h>
 
 namespace spdlog {
 namespace sinks {

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "spdlog/details/console_globals.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/sink.h"
+#include <spdlog/details/console_globals.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/sink.h>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/include/spdlog/sinks/base_sink-inl.h
+++ b/include/spdlog/sinks/base_sink-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/base_sink.h"
+#include <spdlog/sinks/base_sink.h>
 #endif
 
-#include "spdlog/common.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/common.h>
+#include <spdlog/details/pattern_formatter.h>
 
 #include <memory>
 

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -9,9 +9,9 @@
 // implementers..
 //
 
-#include "spdlog/common.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/sinks/sink.h"
+#include <spdlog/common.h>
+#include <spdlog/details/log_msg.h>
+#include <spdlog/sinks/sink.h>
 
 namespace spdlog {
 namespace sinks {

--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/basic_file_sink.h"
+#include <spdlog/sinks/basic_file_sink.h>
 #endif
 
-#include "spdlog/common.h"
-#include "spdlog/details/os.h"
+#include <spdlog/common.h>
+#include <spdlog/details/os.h>
 
 namespace spdlog {
 namespace sinks {

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "spdlog/details/file_helper.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <mutex>
 #include <string>

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/details/file_helper.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/fmt/fmt.h"
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/os.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/common.h>
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/fmt/fmt.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/os.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <chrono>
 #include <cstdio>

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include "base_sink.h"
-#include "spdlog/details/log_msg.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/details/log_msg.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/pattern_formatter.h>
 
 #include <algorithm>
 #include <memory>

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include "dist_sink.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/log_msg.h"
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/log_msg.h>
 
 #include <mutex>
 #include <string>
@@ -16,7 +16,7 @@
 //
 // Example:
 //
-//     #include "spdlog/sinks/dup_filter_sink.h"
+//     #include <spdlog/sinks/dup_filter_sink.h>
 //
 //     int main() {
 //         auto dup_filter = std::make_shared<dup_filter_sink_st>(std::chrono::seconds(5));

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -5,8 +5,8 @@
 
 #if defined(_WIN32)
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
 
 #include <winbase.h>
 

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <mutex>
 

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/base_sink.h"
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
 
 #include <mutex>
 #include <ostream>

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -4,14 +4,14 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/rotating_file_sink.h"
+#include <spdlog/sinks/rotating_file_sink.h>
 #endif
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 
-#include "spdlog/details/file_helper.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/fmt/fmt.h"
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/fmt/fmt.h>
 
 #include <cerrno>
 #include <chrono>

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/file_helper.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <chrono>
 #include <mutex>

--- a/include/spdlog/sinks/sink-inl.h
+++ b/include/spdlog/sinks/sink-inl.h
@@ -4,10 +4,10 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/sink.h"
+#include <spdlog/sinks/sink.h>
 #endif
 
-#include "spdlog/common.h"
+#include <spdlog/common.h>
 
 SPDLOG_INLINE bool spdlog::sinks::sink::should_log(spdlog::level::level_enum msg_level) const
 {

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/details/log_msg.h"
-#include "spdlog/formatter.h"
+#include <spdlog/details/log_msg.h>
+#include <spdlog/formatter.h>
 
 namespace spdlog {
 

--- a/include/spdlog/sinks/stdout_color_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_color_sinks-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/sinks/stdout_color_sinks.h>
 #endif
 
-#include "spdlog/logger.h"
-#include "spdlog/common.h"
+#include <spdlog/logger.h>
+#include <spdlog/common.h>
 
 namespace spdlog {
 

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -4,12 +4,12 @@
 #pragma once
 
 #ifdef _WIN32
-#include "spdlog/sinks/wincolor_sink.h"
+#include <spdlog/sinks/wincolor_sink.h>
 #else
-#include "spdlog/sinks/ansicolor_sink.h"
+#include <spdlog/sinks/ansicolor_sink.h>
 #endif
 
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/details/synchronous_factory.h>
 
 namespace spdlog {
 namespace sinks {

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/stdout_sinks.h"
+#include <spdlog/sinks/stdout_sinks.h>
 #endif
 
-#include "spdlog/details/console_globals.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/details/console_globals.h>
+#include <spdlog/details/pattern_formatter.h>
 #include <memory>
 
 namespace spdlog {

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "spdlog/details/console_globals.h"
-#include "spdlog/details/synchronous_factory.h"
-#include "spdlog/sinks/sink.h"
+#include <spdlog/details/console_globals.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/sink.h>
 #include <cstdio>
 
 namespace spdlog {

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/null_mutex.h>
 
 #include <array>
 #include <string>

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include "spdlog/sinks/base_sink.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <array>
 #ifndef SD_JOURNAL_SUPPRESS_LOCATION

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/sinks/wincolor_sink.h"
+#include <spdlog/sinks/wincolor_sink.h>
 #endif
 
-#include "spdlog/common.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/common.h>
+#include <spdlog/details/pattern_formatter.h>
 
 namespace spdlog {
 namespace sinks {

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/details/console_globals.h"
-#include "spdlog/details/null_mutex.h"
-#include "spdlog/sinks/sink.h"
+#include <spdlog/common.h>
+#include <spdlog/details/console_globals.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/sink.h>
 
 #include <memory>
 #include <mutex>

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #ifndef SPDLOG_HEADER_ONLY
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 #endif
 
-#include "spdlog/common.h"
-#include "spdlog/details/pattern_formatter.h"
+#include <spdlog/common.h>
+#include <spdlog/details/pattern_formatter.h>
 
 namespace spdlog {
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include "spdlog/common.h"
-#include "spdlog/details/registry.h"
-#include "spdlog/logger.h"
-#include "spdlog/version.h"
-#include "spdlog/details/synchronous_factory.h"
+#include <spdlog/common.h>
+#include <spdlog/details/registry.h>
+#include <spdlog/logger.h>
+#include <spdlog/version.h>
+#include <spdlog/details/synchronous_factory.h>
 
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
The meaning of using quotes to #include is implementation defined, so it
may or not may be what we want. At least POSIX
(https://pubs.opengroup.org/onlinepubs/9699919799/utilities/c99.html)
says: "headers whose names are enclosed in double-quotes ( "" ) shall be
searched for first in the directory of the file with the #include line",
so not what we want since "spdlog" ends up twice in the path.

For example, in my Fedora 31 system:
```
$ cat test.cpp
#include <spdlog/spdlog.h>
$ strace -f -e file g++ -c -o /dev/null test.cpp -Ilocal/include/ 2>&1 | grep 'spdlog/common.h'
[pid 14210] openat(AT_FDCWD, "local/include/spdlog/spdlog/common.h", O_RDONLY|O_NOCTTY) = -1 ENOENT (No such file or directory)
[pid 14210] openat(AT_FDCWD, "local/include/spdlog/common.h", O_RDONLY|O_NOCTTY) = 4
[pid 14210] openat(AT_FDCWD, "local/include/spdlog/details/spdlog/common.h", O_RDONLY|O_NOCTTY) = -1 ENOENT (No such file or directory)
[pid 14210] openat(AT_FDCWD, "local/include/spdlog/sinks/spdlog/common.h", O_RDONLY|O_NOCTTY) = -1 ENOENT (No such file or directory)
$
```