### PR TITLE
prevent clang-tidy warnings while build

### DIFF
--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -15,12 +15,12 @@ static const char *short_level_names[] SPDLOG_SHORT_LEVEL_NAMES;
 
 SPDLOG_INLINE string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT
 {
-    return level_string_views[l];
+    return level_string_views[l];   // NOLINT
 }
 
 SPDLOG_INLINE const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT
 {
-    return short_level_names[l];
+    return short_level_names[l];    // NOLINT
 }
 
 SPDLOG_INLINE spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -62,7 +62,7 @@
 #endif
 
 #ifndef SPDLOG_FUNCTION
-#define SPDLOG_FUNCTION __FUNCTION__
+#define SPDLOG_FUNCTION static_cast<const char *>(__FUNCTION__) // NOLINT
 #endif
 
 #ifdef SPDLOG_NO_EXCEPTIONS

--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -29,6 +29,7 @@ SPDLOG_INLINE void file_helper::open(const filename_t &fname, bool truncate)
 {
     close();
     filename_ = fname;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     auto *mode = truncate ? SPDLOG_FILENAME_T("wb") : SPDLOG_FILENAME_T("ab");
 
     for (int tries = 0; tries < open_tries_; ++tries)
@@ -64,7 +65,7 @@ SPDLOG_INLINE void file_helper::close()
 {
     if (fd_ != nullptr)
     {
-        std::fclose(fd_);
+        std::fclose(fd_);   // NOLINT(cppcoreguidelines-owning-memory)
         fd_ = nullptr;
     }
 }

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -22,7 +22,7 @@ inline void append_string_view(spdlog::string_view_t view, memory_buf_t &dest)
     auto *buf_ptr = view.data();
     if (buf_ptr != nullptr)
     {
-        dest.append(buf_ptr, buf_ptr + view.size());
+        dest.append(buf_ptr, buf_ptr + view.size());    // NOLINT
     }
 }
 
@@ -30,7 +30,7 @@ template<typename T>
 inline void append_int(T n, memory_buf_t &dest)
 {
     fmt::format_int i(n);
-    dest.append(i.data(), i.data() + i.size());
+    dest.append(i.data(), i.data() + i.size()); // NOLINT
 }
 
 template<typename T>
@@ -70,7 +70,7 @@ inline void pad_uint(T n, unsigned int width, memory_buf_t &dest)
     if (width > digits)
     {
         const char *zeroes = "0000000000000000000";
-        dest.append(zeroes, zeroes + width - digits);
+        dest.append(zeroes, zeroes + width - digits);   // NOLINT
     }
     append_int(n, dest);
 }

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -37,7 +37,7 @@ SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg_buffer &ot
 {
     log_msg::operator=(other);
     buffer.clear();
-    buffer.append(other.buffer.data(), other.buffer.data() + other.buffer.size());
+    buffer.append(other.buffer.data(), other.buffer.data() + other.buffer.size());  // NOLINT
     update_string_views();
     return *this;
 }
@@ -53,7 +53,7 @@ SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(log_msg_buffer &&other)
 SPDLOG_INLINE void log_msg_buffer::update_string_views()
 {
     logger_name = string_view_t{buffer.data(), logger_name.size()};
-    payload = string_view_t{buffer.data() + logger_name.size(), payload.size()};
+    payload = string_view_t{buffer.data() + logger_name.size(), payload.size()};    // NOLINT
 }
 
 } // namespace details

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -91,11 +91,10 @@ SPDLOG_INLINE spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT
 SPDLOG_INLINE std::tm localtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT
 {
 
+    std::tm tm = {};
 #ifdef _WIN32
-    std::tm tm;
     ::localtime_s(&tm, &time_tt);
 #else
-    std::tm tm;
     ::localtime_r(&time_tt, &tm);
 #endif
     return tm;
@@ -110,11 +109,10 @@ SPDLOG_INLINE std::tm localtime() SPDLOG_NOEXCEPT
 SPDLOG_INLINE std::tm gmtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT
 {
 
+    std::tm tm = {};
 #ifdef _WIN32
-    std::tm tm;
     ::gmtime_s(&tm, &time_tt);
 #else
-    std::tm tm;
     ::gmtime_r(&time_tt, &tm);
 #endif
     return tm;
@@ -153,6 +151,7 @@ SPDLOG_INLINE bool fopen_s(FILE **fp, const filename_t &filename, const filename
     *fp = ::_fsopen((filename.c_str()), mode.c_str(), _SH_DENYNO);
 #endif
 #else // unix
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     *fp = ::fopen((filename.c_str()), mode.c_str());
 #endif
 
@@ -200,7 +199,7 @@ SPDLOG_INLINE bool path_exists(const filename_t &filename) SPDLOG_NOEXCEPT
 #endif
     return attribs != INVALID_FILE_ATTRIBUTES;
 #else // common linux/unix all have the stat system call
-    struct stat buffer;
+    struct stat buffer = {};
     return (::stat(filename.c_str(), &buffer) == 0);
 #endif
 }
@@ -233,13 +232,13 @@ SPDLOG_INLINE size_t filesize(FILE *f)
     int fd = ::fileno(f);
 // 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
 #if (defined(__linux__) || defined(__sun) || defined(_AIX)) && (defined(__LP64__) || defined(_LP64))
-    struct stat64 st;
+    struct stat64 st = {};
     if (::fstat64(fd, &st) == 0)
     {
         return static_cast<size_t>(st.st_size);
     }
 #else // unix 32 bits or cygwin
-    struct stat st;
+    struct stat st = {};
 
     if (::fstat(fd, &st) == 0)
     {

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -73,6 +73,7 @@ private:
     void pad_it(size_t count)
     {
         // count = std::min(count, spaces_.size());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(count <= spaces_.size());
         fmt_helper::append_string_view(string_view_t(spaces_.data(), count), dest_);
     }
@@ -143,7 +144,7 @@ public:
 
 static const char *ampm(const tm &t)
 {
-    return t.tm_hour >= 12 ? "PM" : "AM";
+    return t.tm_hour >= 12 ? "PM" : "AM";   // NOLINT
 }
 
 static int to12h(const tm &t)
@@ -164,7 +165,7 @@ public:
 
     void format(const details::log_msg &, const std::tm &tm_time, memory_buf_t &dest) override
     {
-        string_view_t field_value{days[static_cast<size_t>(tm_time.tm_wday)]};
+        string_view_t field_value{days[static_cast<size_t>(tm_time.tm_wday)]};  // NOLINT
         ScopedPadder p(field_value.size(), padinfo_, dest);
         fmt_helper::append_string_view(field_value, dest);
     }
@@ -183,7 +184,7 @@ public:
 
     void format(const details::log_msg &, const std::tm &tm_time, memory_buf_t &dest) override
     {
-        string_view_t field_value{full_days[static_cast<size_t>(tm_time.tm_wday)]};
+        string_view_t field_value{full_days[static_cast<size_t>(tm_time.tm_wday)]}; // NOLINT
         ScopedPadder p(field_value.size(), padinfo_, dest);
         fmt_helper::append_string_view(field_value, dest);
     }
@@ -202,7 +203,7 @@ public:
 
     void format(const details::log_msg &, const std::tm &tm_time, memory_buf_t &dest) override
     {
-        string_view_t field_value{months[static_cast<size_t>(tm_time.tm_mon)]};
+        string_view_t field_value{months[static_cast<size_t>(tm_time.tm_mon)]}; // NOLINT
         ScopedPadder p(field_value.size(), padinfo_, dest);
         fmt_helper::append_string_view(field_value, dest);
     }
@@ -222,7 +223,7 @@ public:
 
     void format(const details::log_msg &, const std::tm &tm_time, memory_buf_t &dest) override
     {
-        string_view_t field_value{full_months[static_cast<size_t>(tm_time.tm_mon)]};
+        string_view_t field_value{full_months[static_cast<size_t>(tm_time.tm_mon)]};    // NOLINT
         ScopedPadder p(field_value.size(), padinfo_, dest);
         fmt_helper::append_string_view(field_value, dest);
     }
@@ -242,9 +243,9 @@ public:
         const size_t field_size = 24;
         ScopedPadder p(field_size, padinfo_, dest);
 
-        fmt_helper::append_string_view(days[static_cast<size_t>(tm_time.tm_wday)], dest);
+        fmt_helper::append_string_view(days[static_cast<size_t>(tm_time.tm_wday)], dest);   // NOLINT
         dest.push_back(' ');
-        fmt_helper::append_string_view(months[static_cast<size_t>(tm_time.tm_mon)], dest);
+        fmt_helper::append_string_view(months[static_cast<size_t>(tm_time.tm_mon)], dest);  // NOLINT
         dest.push_back(' ');
         fmt_helper::append_int(tm_time.tm_mday, dest);
         dest.push_back(' ');
@@ -805,7 +806,7 @@ public:
     static const char *basename(const char *filename)
     {
         const char *rv = std::strrchr(filename, os::folder_sep);
-        return rv != nullptr ? rv + 1 : filename;
+        return rv != nullptr ? rv + 1 : filename;   // NOLINT
     }
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -112,6 +112,7 @@ bool SPDLOG_INLINE thread_pool::process_next_msg_()
     }
 
     default: {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         assert(false && "Unexpected async_msg_type");
     }
     }

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -174,7 +174,7 @@
 #endif
 
 #ifndef FMT_ASSERT
-#  define FMT_ASSERT(condition, message) assert((condition) && message)
+#  define FMT_ASSERT(condition, message) assert((condition) && message) // NOLINT
 #endif
 
 // libc++ supports string_view in pre-c++17.

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -244,9 +244,9 @@ SPDLOG_INLINE void logger::err_handler_(const std::string &msg)
         }
         last_report_time = now;
         auto tm_time = details::os::localtime(system_clock::to_time_t(now));
-        char date_buf[64];
-        std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", &tm_time);
-        fprintf(stderr, "[*** LOG ERROR #%04zu ***] [%s] [%s] {%s}\n", err_counter, date_buf, name().c_str(), msg.c_str());
+        std::array<char, 64> date_buf = {};
+        std::strftime(date_buf.data(), sizeof(date_buf), "%Y-%m-%d %H:%M:%S", &tm_time);
+        fprintf(stderr, "[*** LOG ERROR #%04zu ***] [%s] [%s] {%s}\n", err_counter, date_buf.data(), name().c_str(), msg.c_str());
     }
 }
 } // namespace spdlog

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -151,6 +151,7 @@ public:
             return;
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         details::log_msg log_msg(loc, name_, lvl, msg);
         log_it_(log_msg, log_enabled, traceback_enabled);
     }

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -117,7 +117,7 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::print_ccode_(const string_view_
 template<typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::print_range_(const memory_buf_t &formatted, size_t start, size_t end)
 {
-    fwrite(formatted.data() + start, sizeof(char), end - start, target_file_);
+    fwrite(formatted.data() + start, sizeof(char), end - start, target_file_);  // NOLINT
 }
 
 // ansicolor_stdout_sink

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -72,7 +72,7 @@ protected:
         dist_sink<Mutex>::sink_it_(msg);
         last_msg_time_ = msg.time;
         skip_counter_ = 0;
-        last_msg_payload_.assign(msg.payload.data(), msg.payload.data() + msg.payload.size());
+        last_msg_payload_.assign(msg.payload.data(), msg.payload.data() + msg.payload.size());  // NOLINT
     }
 
     // return whether the log msg should be displayed (true) or skipped (false)

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -65,6 +65,7 @@ protected:
             length = static_cast<size_t>(std::numeric_limits<int>::max());
         }
 
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg)
         ::syslog(syslog_prio_from_level(msg), "%.*s", static_cast<int>(length), payload.data());
     }
 

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -119,5 +119,5 @@
 // __PRETTY_FUNCTION__ might be nicer in clang/gcc, and __FUNCTION__ in msvc.
 // Defaults to __FUNCTION__ (should work on all compilers) if not defined.
 //
-// #define SPDLOG_FUNCTION __PRETTY_FUNCTION__
+// #define SPDLOG_FUNCTION static_cast<const char *>(__PRETTY_FUNCTION__) // NOLINT
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
note: each use of assert() produce one!

i.e.:
tests/test_pattern_formatter.cpp:14:95: warning: do not implicitly decay an array into a pointer;
consider using gsl::array_view or an explicit cast instead [cppcoreguidelines-pro-bounds-array-to-pointer-decay]
    oss_logger.set_formatter(std::unique_ptr<spdlog::formatter>(new spdlog::pattern_formatter(args...)));
                                                                                              ^