### PR TITLE
Add ringbuffer sink

### DIFF
--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -75,7 +75,14 @@ public:
     // Return number of elements actually stored
     size_t size() const
     {
-        return (tail_ - head_) % max_items_;
+        if (tail_ > head_)
+        {
+           return (tail_ - head_) % max_items;
+        }
+        else
+        {
+            return max_items - (head_ - tail_ ) % max_items;
+        }
     }
 
     // Return const reference to item by index.

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -75,7 +75,7 @@ public:
     // Return number of elements actually stored
     size_t size() const
     {
-        if (tail_ > head_)
+        if (tail_ >= head_)
         {
            return tail_ - head_;
         }

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -77,11 +77,11 @@ public:
     {
         if (tail_ > head_)
         {
-           return (tail_ - head_) % max_items_;
+           return tail_ - head_;
         }
         else
         {
-            return max_items_ - (head_ - tail_ ) % max_items_;
+            return max_items_ - (head_ - tail_ );
         }
     }
 

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -77,11 +77,11 @@ public:
     {
         if (tail_ > head_)
         {
-           return (tail_ - head_) % max_items;
+           return (tail_ - head_) % max_items_;
         }
         else
         {
-            return max_items - (head_ - tail_ ) % max_items;
+            return max_items_ - (head_ - tail_ ) % max_items_;
         }
     }
 

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -72,6 +72,20 @@ public:
         return v_[head_];
     }
 
+    // Return number of elements actually stored
+    size_t size() const
+    {
+        return (tail_ - head_) % max_items_;
+    }
+
+    // Return const reference to item by index.
+    // If index is out of range 0…size()-1, the behavior is undefined.
+    const T &at(size_t i) const
+    {
+        assert(i < size());
+        return v_[(head_+ i) % max_items_];
+    }
+
     // Pop item from front.
     // If there are no elements in the container, the behavior is undefined.
     void pop_front()

--- a/include/spdlog/sinks/ringbuffer_sink-inl.h
+++ b/include/spdlog/sinks/ringbuffer_sink-inl.h
@@ -1,0 +1,48 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+#include "spdlog/sinks/ringbuffer_sink.h"
+#endif
+
+#include "spdlog/common.h"
+#include "spdlog/details/os.h"
+
+#include<boost/circular_buffer.hpp>
+
+namespace spdlog {
+namespace sinks {
+
+template<typename Mutex>
+SPDLOG_INLINE ringbuffer_sink<Mutex>::ringbuffer_sink(size_t buf_size)
+{
+    buf.set_capacity(buf_size);
+}
+
+template<typename Mutex>
+SPDLOG_INLINE void ringbuffer_sink<Mutex>::sink_it_(const details::log_msg &msg)
+{
+    memory_buf_t formatted;
+    base_sink<Mutex>::formatter_->format(msg, formatted);
+    buf.push_front(fmt::to_string(formatted));
+}
+
+template<typename Mutex>
+SPDLOG_INLINE std::vector<std::string> ringbuffer_sink<Mutex>::last(size_t lim)
+{
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
+    std::vector<std::string> ret;
+    ret.reserve(lim);
+    size_t num=0;
+    for(const std::string& msg: buf){
+        num++;
+        ret.push_back(msg);
+        if(lim>0 && num==lim) break;
+    }
+    return ret;
+}
+
+} // namespace sinks
+} // namespace spdlog

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -1,0 +1,60 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include "spdlog/details/null_mutex.h"
+#include "spdlog/sinks/base_sink.h"
+#include "spdlog/details/synchronous_factory.h"
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include<boost/circular_buffer.hpp>
+
+namespace spdlog {
+namespace sinks {
+/*
+ * Ring buffer sink
+ */
+template<typename Mutex>
+class ringbuffer_sink final : public base_sink<Mutex>
+{
+public:
+    explicit ringbuffer_sink(size_t buf_size);
+    std::vector<std::string> last(size_t lim=0);
+
+protected:
+    void sink_it_(const details::log_msg &msg) override;
+    void flush_() override {};
+
+private:
+    boost::circular_buffer<std::string> buf;
+};
+
+using ringbuffer_sink_mt = ringbuffer_sink<std::mutex>;
+using ringbuffer_sink_st = ringbuffer_sink<details::null_mutex>;
+
+} // namespace sinks
+
+//
+// factory functions
+//
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> basic_logger_mt(const std::string &logger_name, size_t buf_size)
+{
+    return Factory::template create<sinks::ringbuffer_sink_mt>(logger_name, buf_size);
+}
+
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> basic_logger_st(const std::string &logger_name, size_t buf_size)
+{
+    return Factory::template create<sinks::ringbuffer_sink_st>(logger_name, buf_size);
+}
+
+} // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+#include "ringbuffer_sink-inl.h"
+#endif

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -7,6 +7,7 @@
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/synchronous_factory.h"
 #include "spdlog/details/circular_q.h"
+#include "spdlog/details/log_msg_buffer.h"
 
 #include <mutex>
 #include <string>
@@ -29,7 +30,7 @@ protected:
     void flush_() override {};
 
 private:
-    details::circular_q<std::string> buf;
+    details::circular_q<details::log_msg_buffer> buf_;
 };
 
 using ringbuffer_sink_mt = ringbuffer_sink<std::mutex>;

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -6,12 +6,11 @@
 #include "spdlog/details/null_mutex.h"
 #include "spdlog/sinks/base_sink.h"
 #include "spdlog/details/synchronous_factory.h"
+#include "spdlog/details/circular_q.h"
 
 #include <mutex>
 #include <string>
 #include <vector>
-
-#include<boost/circular_buffer.hpp>
 
 namespace spdlog {
 namespace sinks {
@@ -30,7 +29,7 @@ protected:
     void flush_() override {};
 
 private:
-    boost::circular_buffer<std::string> buf;
+    details::circular_q<std::string> buf;
 };
 
 using ringbuffer_sink_mt = ringbuffer_sink<std::mutex>;


### PR DESCRIPTION
Ringbuffer sink keeps user-given number of most recent log messages in
memory and returns them upon request (using the ringbuffer_sink::last
method). This can be useful for e.g. remote debugging of a running app.