### PR TITLE
Preliminary attempt at right_clip alignment

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -36,8 +36,9 @@ int main(int, char *[])
     spdlog::debug("This message should be displayed..");
 
     // Customize msg format for all loggers
-    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [thread %t] %v");
-    spdlog::info("This an info message with custom format");
+    spdlog::set_pattern("[%H:%M:%S %z] %>4B [%^%>3l%$] [thread %t] %>30v");
+    spdlog::debug("This an info message with custom format");
+    spdlog::info("Nicely aligned with the previous message");
     spdlog::set_pattern("%+"); // back to default format
     spdlog::set_level(spdlog::level::info);
 

--- a/include/spdlog/details/pattern_formatter-inl.h
+++ b/include/spdlog/details/pattern_formatter-inl.h
@@ -42,7 +42,14 @@ public:
 
         if (padinfo_.width_ <= wrapped_size)
         {
-            total_pad_ = 0;
+            if (padinfo_.side_ == padding_info::clip_right)
+            {
+                total_pad_ = (long)padinfo_.width_ - (long)wrapped_size;
+            }
+            else
+            {
+                total_pad_ = 0;
+            }
             return;
         }
 
@@ -70,16 +77,23 @@ public:
     }
 
 private:
-    void pad_it(size_t count)
+    void pad_it(long count)
     {
         // count = std::min(count, spaces_.size());
         assert(count <= spaces_.size());
-        fmt_helper::append_string_view(string_view_t(spaces_.data(), count), dest_);
+        if ( count >= 0 )
+        {
+            fmt_helper::append_string_view(string_view_t(spaces_.data(), count), dest_);
+        }
+        else
+        {
+            dest_.resize(dest_.size()+count);
+        }
     }
 
     const padding_info &padinfo_;
     memory_buf_t &dest_;
-    size_t total_pad_;
+    long total_pad_;
     string_view_t spaces_{"                                                                ", 64};
 };
 
@@ -1231,6 +1245,10 @@ SPDLOG_INLINE details::padding_info pattern_formatter::handle_padspec_(std::stri
         break;
     case '=':
         side = padding_info::center;
+        ++it;
+        break;
+    case '>':
+        side = padding_info::clip_right;
         ++it;
         break;
     default:

--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -25,7 +25,8 @@ struct padding_info
     {
         left,
         right,
-        center
+        center,
+        clip_right,
     };
 
     padding_info() = default;


### PR DESCRIPTION
This is a lame attempt at #1297, doing right-clip only. It does not fit the current architecture very well, and left-clipping would be impossible. It also relies on conservative resizing of `memory_buf_t` (as there is no other way to remove chars from the end of the buffer).

Perhaps a better approach would be to derive from (or extend) `aggregate_formatter` which would take the entire user-string and decide what to do: insert padding left/right, clip left/right, or clip left/middle/right with ellipsis marker.

This is from the example:
![image](https://user-images.githubusercontent.com/1029876/68647495-4c91c200-051e-11ea-84fc-e324eb72118f.png)
