### PR TITLE
Fix a small problem in the basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ int main()
     
     // Compile time log levels
     // define SPDLOG_ACTIVE_LEVEL to desired level
-    SPDLOG_TRACE("Some trace message with param {}", {});
+    SPDLOG_TRACE("Some trace message with param {}", 42);
     SPDLOG_DEBUG("Some debug message");
     
     // Set the default logger to file logger


### PR DESCRIPTION
The line
```
SPDLOG_TRACE("Some trace message with param {}", {});
```
which normally is discarded at the compile time since by deafult
`SPDLOG_ACTIVE_LEVEL` is at `SPDLOG_LEVEL_INFO`. If however, one goes
to `tweak.me` and sets
```
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
```
suddenly the basic example does not compile any more.
This commit fixes the potential problem.