### PR TITLE
Fix invalid meson option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,7 @@ endif
 # ---   Conditionally add subdirs   ---
 # -------------------------------------
 
-if get_option('enable_tests') or get_option('enable_tests-ho')
+if get_option('enable_tests') or get_option('enable_tests_ho')
     subdir('tests')
 endif
 


### PR DESCRIPTION
The option is: 'enable_tests_ho' as stated in meson_options.txt