### PR TITLE
latest spdlog now available on MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ cmake .. && make -j
 
 ## Package managers:
 * Homebrew: `brew install spdlog`
+* MacPorts: `sudo port install spdlog`
 * FreeBSD:  `cd /usr/ports/devel/spdlog/ && make install clean`
 * Fedora: `yum install spdlog`
 * Gentoo: `emerge dev-libs/spdlog`


### PR DESCRIPTION
I am the maintainer of spdlog on MacPorts, now the latest version(1.4.2) of spdlog is available on MacPorts.