### PR TITLE
Make tests support empty SPDLOG_EOL

### DIFF
--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -169,9 +169,10 @@ TEST_CASE("to_file", "[async]")
         }
     }
 
-    REQUIRE(count_lines(filename) == messages);
+    require_message_count(filename, messages);
     auto contents = file_contents(filename);
-    REQUIRE(ends_with(contents, std::string("Hello message #1023\n")));
+    using spdlog::details::os::default_eol;
+    REQUIRE(ends_with(contents, fmt::format("Hello message #1023{}", default_eol)));
 }
 
 TEST_CASE("to_file multi-workers", "[async]")
@@ -191,5 +192,5 @@ TEST_CASE("to_file multi-workers", "[async]")
         }
     }
 
-    REQUIRE(count_lines(filename) == messages);
+    require_message_count(filename, messages);
 }

--- a/tests/test_daily_logger.cpp
+++ b/tests/test_daily_logger.cpp
@@ -24,7 +24,7 @@ TEST_CASE("daily_logger with dateonly calculator", "[daily_logger]")
     logger->flush();
 
     auto filename = fmt::to_string(w);
-    REQUIRE(count_lines(filename) == 10);
+    require_message_count(filename, 10);
 }
 
 struct custom_daily_file_name_calculator
@@ -55,12 +55,10 @@ TEST_CASE("daily_logger with custom calculator", "[daily_logger]")
         logger->info("Test message {}", i);
     }
 
-    logger->
-
-        flush();
+    logger->flush();
 
     auto filename = fmt::to_string(w);
-    REQUIRE(count_lines(filename) == 10);
+    require_message_count(filename, 10);
 }
 
 /*

--- a/tests/test_errors.cpp
+++ b/tests/test_errors.cpp
@@ -34,7 +34,8 @@ TEST_CASE("default_error_handler", "[errors]]")
     logger->info("Test message {}", 2);
     logger->flush();
 
-    REQUIRE(file_contents(filename) == std::string("Test message 2\n"));
+    using spdlog::details::os::default_eol;
+    REQUIRE(file_contents(filename) == fmt::format("Test message 2{}", default_eol));
     REQUIRE(count_lines(filename) == 1);
 }
 
@@ -51,7 +52,7 @@ TEST_CASE("custom_error_handler", "[errors]]")
 
     REQUIRE_THROWS_AS(logger->info("Bad format msg {} {}", "xxx"), custom_ex);
     logger->info("Good message #2");
-    REQUIRE(count_lines(filename) == 2);
+    require_message_count(filename, 2);
 }
 
 TEST_CASE("default_error_handler2", "[errors]]")
@@ -93,7 +94,7 @@ TEST_CASE("async_error_handler", "[errors]]")
         spdlog::drop("logger"); // force logger to drain the queue and shutdown
     }
     spdlog::init_thread_pool(128, 1);
-    REQUIRE(count_lines(filename) == 2);
+    require_message_count(filename, 2);
     REQUIRE(file_contents("test_logs/custom_err.txt") == err_msg);
 }
 

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -15,8 +15,10 @@ TEST_CASE("simple_file_logger", "[simple_logger]]")
     logger->info("Test message {}", 2);
 
     logger->flush();
-    REQUIRE(file_contents(filename) == std::string("Test message 1\nTest message 2\n"));
-    REQUIRE(count_lines(filename) == 2);
+    require_message_count(filename, 2);
+    using spdlog::details::os::default_eol;
+    REQUIRE(file_contents(filename) == fmt::format("Test message 1{}Test message 2{}",
+        default_eol, default_eol));
 }
 
 TEST_CASE("flush_on", "[flush_on]]")
@@ -34,8 +36,10 @@ TEST_CASE("flush_on", "[flush_on]]")
     logger->info("Test message {}", 1);
     logger->info("Test message {}", 2);
 
-    REQUIRE(file_contents(filename) == std::string("Should not be flushed\nTest message 1\nTest message 2\n"));
-    REQUIRE(count_lines(filename) == 3);
+    require_message_count(filename, 3);
+    using spdlog::details::os::default_eol;
+    REQUIRE(file_contents(filename) == fmt::format("Should not be flushed{}Test message 1{}Test message 2{}",
+        default_eol, default_eol, default_eol));
 }
 
 TEST_CASE("rotating_file_logger1", "[rotating_logger]]")
@@ -52,7 +56,7 @@ TEST_CASE("rotating_file_logger1", "[rotating_logger]]")
 
     logger->flush();
     auto filename = basename;
-    REQUIRE(count_lines(filename) == 10);
+    require_message_count(filename, 10);
 }
 
 TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
@@ -81,7 +85,8 @@ TEST_CASE("rotating_file_logger2", "[rotating_logger]]")
 
     logger->flush();
     auto filename = basename;
-    REQUIRE(count_lines(filename) == 10);
+    require_message_count(filename, 10);
+
     for (int i = 0; i < 1000; i++)
     {
 

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -22,7 +22,8 @@ TEST_CASE("debug and trace w/o format string", "[macros]]")
     SPDLOG_LOGGER_DEBUG(logger, "Test message 2");
     logger->flush();
 
-    REQUIRE(ends_with(file_contents(filename), "Test message 2\n"));
+    using spdlog::details::os::default_eol;
+    REQUIRE(ends_with(file_contents(filename), fmt::format("Test message 2{}", default_eol)));
     REQUIRE(count_lines(filename) == 1);
 
     spdlog::set_default_logger(logger);
@@ -31,8 +32,8 @@ TEST_CASE("debug and trace w/o format string", "[macros]]")
     SPDLOG_DEBUG("Test message {}", 4);
     logger->flush();
 
-    REQUIRE(ends_with(file_contents(filename), "Test message 4\n"));
-    REQUIRE(count_lines(filename) == 2);
+    require_message_count(filename, 2);
+    REQUIRE(ends_with(file_contents(filename), fmt::format("Test message 4{}", default_eol)));
 }
 
 TEST_CASE("disable param evaluation", "[macros]")

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -21,7 +21,7 @@ void prepare_logdir()
 
 std::string file_contents(const std::string &filename)
 {
-    std::ifstream ifs(filename);
+    std::ifstream ifs(filename, std::ios_base::binary);
     if (!ifs)
     {
         throw std::runtime_error("Failed open file ");

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -44,6 +44,15 @@ std::size_t count_lines(const std::string &filename)
     return counter;
 }
 
+void require_message_count(const std::string &filename, const std::size_t messages)
+{
+    if (strlen(spdlog::details::os::default_eol) == 0) {
+        REQUIRE(count_lines(filename) == 1);
+    } else {
+        REQUIRE(count_lines(filename) == messages);
+    }
+}
+
 std::size_t get_filesize(const std::string &filename)
 {
     std::ifstream ifs(filename, std::ifstream::ate | std::ifstream::binary);

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -13,6 +13,8 @@ std::string file_contents(const std::string &filename);
 
 std::size_t count_lines(const std::string &filename);
 
+void require_message_count(const std::string &filename, const std::size_t messages);
+
 std::size_t get_filesize(const std::string &filename);
 
 bool ends_with(std::string const &value, std::string const &ending);


### PR DESCRIPTION
This PR is currently a demo only. It is created against tag v1.5.0. It should show-case how one could add support for empty `SPDLOG_EOL` in the tests. This seems a "relatively" common request amongst users so it may be nice if the tests can support it.

Closes #1413 .