### PR TITLE
tests/utils.h: removed duplicate entry for count_lines()

### DIFF
--- a/tests/utils.h
+++ b/tests/utils.h
@@ -3,8 +3,6 @@
 #include <cstddef>
 #include <string>
 
-std::size_t count_lines(const std::string &filename);
-
 std::size_t count_files(const std::string &folder);
 
 void prepare_logdir();


### PR DESCRIPTION
This PR removes a duplicate line in `tests/utils.h`.