### PR TITLE
Don't run spdlog-utests and spdlog-utests-ho in parallel

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ function(spdlog_prepare_test test_target spdlog_lib)
 		spdlog_enable_sanitizer(${test_target})
 	endif()
     add_test(NAME ${test_target} COMMAND ${test_target})
+    set_tests_properties(${test_target} PROPERTIES RUN_SERIAL ON)
 endfunction()
 
 # The compiled library tests


### PR DESCRIPTION
Ref #1419 

Change ctest not to execute `spdlog-utests` and `spdlog-utests-ho` in parallel.