### PR TITLE
Properly handling SPDLOG_PREVENT_CHILD_FD

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -38,10 +38,6 @@ static const char folder_sep = '\\';
 SPDLOG_CONSTEXPR static const char folder_sep = '/';
 #endif
 
-#ifdef SPDLOG_PREVENT_CHILD_FD
-void prevent_child_fd(FILE *f);
-#endif
-
 // fopen_s on non windows for writing
 bool fopen_s(FILE **fp, const filename_t &filename, const filename_t &mode);
 


### PR DESCRIPTION
Using the SPDLOG_PREVENT_CHILD_FD option there where still a race when
a other thread was using fork and exec in between the call to fopen and fcntl.

Using open and O_CLOEXEC when possible prevents this race.

I have no idea if this problem  exists on Windows.