### PR TITLE
tcp_sink implementation for fluentbit

### DIFF
--- a/include/spdlog/tcp_sink.h
+++ b/include/spdlog/tcp_sink.h
@@ -1,0 +1,47 @@
+
+#include <spdlog/spdlog.h>
+#include <spdlog/sinks/base_sink.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+using namespace std;
+template<typename Mutex>
+class tcp_sink : public spdlog::sinks::base_sink <Mutex>
+{
+public:
+    tcp_sink(std::string address,int port)
+    {
+        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+        {
+            printf("\n Socket creation error \n");
+        }
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_port = htons(port);
+        if(inet_pton(AF_INET, address.c_str(), &serv_addr.sin_addr)<=0)
+        {
+            printf("\nInvalid address/ Address not supported \n");
+        }
+        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+        {
+            printf("\nConnection Failed \n");
+        }
+
+    }
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t formatted;
+        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+        std::string message = fmt::to_string(formatted);
+        send(sock , message.c_str() , message.size() , 0 );
+    }
+
+    void flush_() override
+    {
+    }
+private:
+    int sock;
+    struct sockaddr_in serv_addr;
+};
+using tcp_sink_mt = tcp_sink<std::mutex>;
+using tcp_sink_st = tcp_sink<spdlog::details::null_mutex>;

--- a/include/spdlog/tcp_sink.h
+++ b/include/spdlog/tcp_sink.h
@@ -14,17 +14,17 @@ class tcp_sink : public spdlog::sinks::base_sink <Mutex>
 public:
     tcp_sink(std::string address,int port)
     {
-        if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+        if ((sock_ = socket(AF_INET, SOCK_STREAM, 0)) < 0)
         {
             SPDLOG_THROW(spdlog::spdlog_ex("Socket creation error", errno));
         }
-        serv_addr.sin_family = AF_INET;
-        serv_addr.sin_port = htons(port);
-        if(inet_pton(AF_INET, address.c_str(), &serv_addr.sin_addr)<=0)
+        serv_addr_.sin_family = AF_INET;
+        serv_addr_.sin_port = htons(port);
+        if(inet_pton(AF_INET, address.c_str(), &serv_addr_.sin_addr)<=0)
         {
             SPDLOG_THROW(spdlog::spdlog_ex("Invalid address/ Address not supported", errno));
         }
-        if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+        if (connect(sock_, (struct sockaddr *)&serv_addr_, sizeof(serv_addr_)) < 0)
         {
             SPDLOG_THROW(spdlog::spdlog_ex("Connection Failed", errno));
         }
@@ -35,7 +35,7 @@ protected:
     {
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-        int res = send(sock , formatted.data() , formatted.size() , 0 );
+        int res = send(sock_ , formatted.data() , formatted.size() , 0 );
         if(res < 0)
             SPDLOG_THROW(spdlog::spdlog_ex("Message Send Failed", errno));
     }
@@ -44,8 +44,8 @@ protected:
     {
     }
 private:
-    int sock;
-    struct sockaddr_in serv_addr;
+    int sock_;
+    struct sockaddr_in serv_addr_;
 };
 using tcp_sink_mt = tcp_sink<std::mutex>;
 using tcp_sink_st = tcp_sink<spdlog::details::null_mutex>;

--- a/include/spdlog/tcp_sink.h
+++ b/include/spdlog/tcp_sink.h
@@ -1,3 +1,5 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/base_sink.h>
@@ -32,7 +34,9 @@ protected:
     {
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-        send(sock , formatted.data() , formatted.size() , 0 );
+        int res = send(sock , formatted.data() , formatted.size() , 0 );
+        if(res < 0) 
+            SPDLOG_THROW(spdlog_ex("Message Send Failed", errno));
     }
 
     void flush_() override

--- a/include/spdlog/tcp_sink.h
+++ b/include/spdlog/tcp_sink.h
@@ -13,17 +13,17 @@ public:
     {
         if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
         {
-            printf("\n Socket creation error \n");
+            SPDLOG_THROW(spdlog_ex("Socket creation error", errno));
         }
         serv_addr.sin_family = AF_INET;
         serv_addr.sin_port = htons(port);
         if(inet_pton(AF_INET, address.c_str(), &serv_addr.sin_addr)<=0)
         {
-            printf("\nInvalid address/ Address not supported \n");
+            SPDLOG_THROW(spdlog_ex("Invalid address/ Address not supported", errno));
         }
         if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
         {
-            printf("\nConnection Failed \n");
+            SPDLOG_THROW(spdlog_ex("Connection Failed", errno));
         }
 
     }
@@ -32,8 +32,7 @@ protected:
     {
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-        std::string message = fmt::to_string(formatted);
-        send(sock , message.c_str() , message.size() , 0 );
+        send(sock , formatted.data() , formatted.size() , 0 );
     }
 
     void flush_() override

--- a/include/spdlog/tcp_sink.h
+++ b/include/spdlog/tcp_sink.h
@@ -3,10 +3,11 @@
 
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/base_sink.h>
+#include <spdlog/common-inl.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-using namespace std;
+
 template<typename Mutex>
 class tcp_sink : public spdlog::sinks::base_sink <Mutex>
 {
@@ -15,17 +16,17 @@ public:
     {
         if ((sock = socket(AF_INET, SOCK_STREAM, 0)) < 0)
         {
-            SPDLOG_THROW(spdlog_ex("Socket creation error", errno));
+            SPDLOG_THROW(spdlog::spdlog_ex("Socket creation error", errno));
         }
         serv_addr.sin_family = AF_INET;
         serv_addr.sin_port = htons(port);
         if(inet_pton(AF_INET, address.c_str(), &serv_addr.sin_addr)<=0)
         {
-            SPDLOG_THROW(spdlog_ex("Invalid address/ Address not supported", errno));
+            SPDLOG_THROW(spdlog::spdlog_ex("Invalid address/ Address not supported", errno));
         }
         if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
         {
-            SPDLOG_THROW(spdlog_ex("Connection Failed", errno));
+            SPDLOG_THROW(spdlog::spdlog_ex("Connection Failed", errno));
         }
 
     }
@@ -35,8 +36,8 @@ protected:
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
         int res = send(sock , formatted.data() , formatted.size() , 0 );
-        if(res < 0) 
-            SPDLOG_THROW(spdlog_ex("Message Send Failed", errno));
+        if(res < 0)
+            SPDLOG_THROW(spdlog::spdlog_ex("Message Send Failed", errno));
     }
 
     void flush_() override


### PR DESCRIPTION
Implementation of tcp_sink. Can be used for remote log collectors.