### PR TITLE
Add critical section to filename function of  each file sink

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -70,8 +70,9 @@ public:
         }
     }
 
-    const filename_t &filename() const
+    const filename_t &filename()
     {
+        std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
         return file_helper_.filename();
     }
 

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -54,8 +54,9 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename
 }
 
 template<typename Mutex>
-SPDLOG_INLINE const filename_t &rotating_file_sink<Mutex>::filename() const
+SPDLOG_INLINE const filename_t &rotating_file_sink<Mutex>::filename()
 {
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
     return file_helper_.filename();
 }
 

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -24,7 +24,7 @@ class rotating_file_sink final : public base_sink<Mutex>
 public:
     rotating_file_sink(filename_t base_filename, std::size_t max_size, std::size_t max_files, bool rotate_on_open = false);
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
-    const filename_t &filename() const;
+    const filename_t &filename();
 
 protected:
     void sink_it_(const details::log_msg &msg) override;


### PR DESCRIPTION
`filename()` member function of file sink has no critical section but `spdlog::details::file_helper::filename_` member variable may be changed by calling `sink_it_()`.

This causes a multi-threaded data race.
Added a critical section to avoid data race.

No critical section has been added to  `spdlog::sinks::basic_file_sink::filename()` because `spdlog::sinks::basic_file_sink` doesn't  rotate, the file name doesn't change.