### PR TITLE
Fix Windows event log sink

### DIFF
--- a/include/spdlog/sinks/win_eventlog_sink.h
+++ b/include/spdlog/sinks/win_eventlog_sink.h
@@ -219,7 +219,7 @@ protected:
         using namespace internal;
 
         memory_buf_t formatted;
-        formatter_->format(msg, formatted);
+        base_sink<Mutex>::formatter_->format(msg, formatted);
         formatted.push_back('\0');
         LPCSTR lp_str = static_cast<LPCSTR>(formatted.data());
 


### PR DESCRIPTION
Fixes #1432 and building under Windows. The `base_sink` scope is not examined as it is a dependent name, we must explicitly specify the scope.

https://eel.is/c++draft/temp.dep#4