### PR TITLE
Add option for dll-local registry on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ endif ()
 # build shared option
 if(NOT WIN32)
     option(SPDLOG_BUILD_SHARED "Build shared library" OFF)
+    option(SPDLOG_DLL_LOCAL_REGISTRY "If enabled, the logger registry will not be shared between shared objects" OFF)
 endif()
 
 # example options
@@ -120,6 +121,10 @@ if (SPDLOG_BUILD_SHARED)
     add_library(spdlog SHARED ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
 else()
     add_library(spdlog STATIC ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
+endif()
+
+if (SPDLOG_DLL_LOCAL_REGISTRY)
+    target_compile_definitions(spdlog PUBLIC SPDLOG_DLL_LOCAL_REGISTRY)
 endif()
 
 add_library(spdlog::spdlog ALIAS spdlog)

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -54,6 +54,12 @@
 #define SPDLOG_DEPRECATED
 #endif
 
+#if defined(SPDLOG_DLL_LOCAL_REGISTRY) && (defined(__GNUC__) || defined(__clang__))
+#define SPDLOG_REGISTRY_ATTRIBUTES __attribute__((visibility("hidden")))
+#else
+#define SPDLOG_REGISTRY_ATTRIBUTES
+#endif
+
 // disable thread local on msvc 2013
 #ifndef SPDLOG_NO_TLS
 #if (defined(_MSC_VER) && (_MSC_VER < 1900)) || defined(__cplusplus_winrt)

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -24,7 +24,7 @@ namespace details {
 class thread_pool;
 class periodic_worker;
 
-class registry
+class SPDLOG_REGISTRY_ATTRIBUTES registry
 {
 public:
     registry(const registry &) = delete;


### PR DESCRIPTION
Currently, when using spdlog in shared libraries, it behaves quite differently between Windows and Linux. On Linux, the `static registry s_instance` is visible to other shared libraries and therefore shared across them. Hence we have **only one global** default logger. On Windows however, there is a `static registry s_instance`  for each shared object, hence we have **multiple default loggers**, one per shared object.

In our use case, we actually like the Windows-behaviour of having one default logger per shared object. This allows us to print log messages from multiple plug-ins of our application and the log messages will be automatically prepended with the plugin's name.

This PR adds an option to hide the `registry` class from shared objects on Linux and thus making spdlog behave more similar on Linux and Windows.

You can consider this PR as a suggestion - you have a much better understanding of the code - I am sure that this can be implemented much cleaner (are there other statics which behave similar?). And maybe there are some side-effects of this approach I am not aware of.

For us however, this is a very valuable tweak and others may find it useful as well.