### PR TITLE
Add preserve_parent_name in async/logger::clone method

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -84,9 +84,14 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
     }
 }
 
-SPDLOG_INLINE std::shared_ptr<spdlog::logger> spdlog::async_logger::clone(std::string new_name)
+SPDLOG_INLINE std::shared_ptr<spdlog::logger> spdlog::async_logger::clone(std::string new_name, bool preserve_parent_name)
 {
     auto cloned = std::make_shared<spdlog::async_logger>(*this);
-    cloned->name_ = std::move(new_name);
+    if (preserve_parent_name) {
+        cloned->name_ += ".";
+        cloned->name_ += new_name;
+    } else {
+        cloned->name_ = std::move(new_name);
+    }
     return cloned;
 }

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -49,7 +49,7 @@ public:
     async_logger(std::string logger_name, sink_ptr single_sink, std::weak_ptr<details::thread_pool> tp,
         async_overflow_policy overflow_policy = async_overflow_policy::block);
 
-    std::shared_ptr<logger> clone(std::string new_name) override;
+    std::shared_ptr<logger> clone(std::string new_name, bool preserve_parent_name = false) override;
 
 protected:
     void sink_it_(const details::log_msg &msg) override;

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -154,10 +154,14 @@ SPDLOG_INLINE void logger::set_error_handler(err_handler handler)
 }
 
 // create new logger with same sinks and configuration.
-SPDLOG_INLINE std::shared_ptr<logger> logger::clone(std::string logger_name)
-{
+SPDLOG_INLINE std::shared_ptr<logger> logger::clone(std::string logger_name, bool preserve_parent_name) {
     auto cloned = std::make_shared<logger>(*this);
-    cloned->name_ = std::move(logger_name);
+    if (preserve_parent_name) {
+        cloned->name_ += ".";
+        cloned->name_ += logger_name;
+    } else {
+        cloned->name_ = std::move(logger_name);
+    }
     return cloned;
 }
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -347,7 +347,7 @@ public:
     void set_error_handler(err_handler);
 
     // create new logger with same sinks and configuration.
-    virtual std::shared_ptr<logger> clone(std::string logger_name);
+    virtual std::shared_ptr<logger> clone(std::string logger_name, bool preserve_parent_name = false);
 
 protected:
     std::string name_;

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -112,6 +112,10 @@ TEST_CASE("clone-logger", "[clone]")
     REQUIRE(test_sink->lines()[0] == "Some message 1");
     REQUIRE(test_sink->lines()[1] == "Some message 2");
 
+    auto cloned_with_parent_name = cloned->clone("sub_logger", /* preserve_parent_name = */ true);
+
+    REQUIRE(cloned_with_parent_name->name() == "clone.sub_logger");
+
     spdlog::drop_all();
 }
 
@@ -138,6 +142,10 @@ TEST_CASE("clone async", "[clone]")
     REQUIRE(test_sink->lines().size() == 2);
     REQUIRE(test_sink->lines()[0] == "Some message 1");
     REQUIRE(test_sink->lines()[1] == "Some message 2");
+
+    auto cloned_with_parent_name = cloned->clone("sub_logger", /* preserve_parent_name = */ true);
+
+    REQUIRE(cloned_with_parent_name->name() == "clone.sub_logger");
 
     spdlog::drop_all();
 }


### PR DESCRIPTION
In order to support logical hierarchy of loggers.

Imagine you have something like this architecture:
````
Application / Controller / First
                         / Second
````
And you want to have the log messages and understand from witch part it come.
After changes you can do:

```
first_controller_logger = controller_logger.clone("first", true);
```
and you will get in log output something similar to:

```
[2014-10-31 23:46:59.678] [controller.first] [info] Some message
```

What is quite convenient.

Actually now you can do it by wrapping clone method, but with my changes it
won't require any user's code.

Thanks.