### PR TITLE
Resolve erroneous clang-tidy warning about using a moved from pointer

### DIFF
--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -89,6 +89,8 @@ SPDLOG_INLINE void logger::set_formatter(std::unique_ptr<formatter> f)
         {
             // last element - we can be move it.
             (*it)->set_formatter(std::move(f));
+            
+            break;
         }
         else
         {


### PR DESCRIPTION
This isn't a fix for anything it's just a patch for an incorrectly flagged clang-tidy warning.

Description
------------

The latest version of clang-tidy contains the check `clang-analyzer-cplusplus.Move` which warns when a moved from object is deferenced.

The check incorrectly identifies a use after move within the spdlog function `logger::set_formatter` because it fails to detect that moving the pointer only occurs on the last iteration of the loop, assuming that it may call `clone()` on it later.

Details of the warning:

```
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:96:34: warning: Moved-from object 'f' is moved [clang-analyzer-cplusplus.Move]
            (*it)->set_formatter(std::move(f));

/3rdParty/spdlog-1.4.2/include/spdlog/sinks/stdout_color_sinks-inl.h:18:12: note: Calling 'synchronous_factory::create'
    return Factory::template create<sinks::stdout_color_sink_mt>(logger_name, mode);
           ^
/3rdParty/spdlog-1.4.2/include/spdlog/details/synchronous_factory.h:20:9: note: Calling 'registry::initialize_logger'
        details::registry::instance().initialize_logger(new_logger);
        ^
/3rdParty/spdlog-1.4.2/include/spdlog/details/registry-inl.h:60:5: note: Calling 'logger::set_formatter'
    new_logger->set_formatter(formatter_->clone());
    ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:91:5: note: Loop condition is true.  Entering loop body
    for (auto it = sinks_.begin(); it != sinks_.end(); ++it)
    ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:93:9: note: Taking true branch
        if (std::next(it) == sinks_.end())
        ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:96:34: note: Object 'f' is moved
            (*it)->set_formatter(std::move(f));
                                 ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:91:5: note: Loop condition is true.  Entering loop body
    for (auto it = sinks_.begin(); it != sinks_.end(); ++it)
    ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:93:9: note: Taking true branch
        if (std::next(it) == sinks_.end())
        ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:96:34: note: Moved-from object 'f' is moved
            (*it)->set_formatter(std::move(f));
                                 ^
/3rdParty/spdlog-1.4.2/include/spdlog/logger-inl.h:100:34: warning: Dereference of null smart pointer 'f' of type 'std::unique_ptr' [clang-analyzer-cplusplus.Move]
            (*it)->set_formatter(f->clone());

```

Fix Summary
--------
To stop clang-tidy showing the warning, explicitly break out of the loop (on the last iteration) after the pointer is moved.
