### PR TITLE
README: add conda as a supported package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ cmake .. && make -j
 * Arch Linux: `yaourt -S spdlog-git`
 * vcpkg: `vcpkg install spdlog`
 * conan: `spdlog/[>=1.4.1]`
+* conda: `conda install -c conda-forge spdlog`
 
 
 ## Features


### PR DESCRIPTION
spdlog is available on conda-forge for a long time.
https://anaconda.org/conda-forge/spdlog