### PR TITLE
Support for precompiled headers with SPDLOG_ENABLE_PCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ endif ()
 # build shared option
 option(SPDLOG_BUILD_SHARED "Build shared library" OFF)
 
+# precompiled headers option
+option(SPDLOG_ENABLE_PCH "Build static or shared library using precompiled header to speed up compilation time" OFF)
+
 # example options
 option(SPDLOG_BUILD_EXAMPLE "Build example" ${SPDLOG_MASTER_PROJECT})
 option(SPDLOG_BUILD_EXAMPLE_HO "Build header only example" OFF)
@@ -157,6 +160,11 @@ spdlog_enable_warnings(spdlog)
 
 set_target_properties(spdlog PROPERTIES VERSION ${SPDLOG_VERSION} SOVERSION ${SPDLOG_VERSION_MAJOR})
 set_target_properties(spdlog PROPERTIES DEBUG_POSTFIX d)
+
+if(COMMAND target_precompile_headers AND SPDLOG_ENABLE_PCH)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/pch.h.in ${PROJECT_BINARY_DIR}/spdlog_pch.h @ONLY)
+    target_precompile_headers(spdlog PRIVATE ${PROJECT_BINARY_DIR}/spdlog_pch.h)
+endif()
 
 #---------------------------------------------------------------------------------------
 # Header only version

--- a/cmake/pch.h.in
+++ b/cmake/pch.h.in
@@ -1,0 +1,258 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+// details/pattern_formatter-inl.h
+// fmt/bin_to_hex.h
+// fmt/bundled/format-inl.h
+#include <cctype>
+
+// details/file_helper-inl.h
+// details/os-inl.h
+// fmt/bundled/core.h
+// fmt/bundled/posix.h
+// logger-inl.h
+// sinks/daily_file_sink.h
+// sinks/stdout_sinks.h
+#include <cstdio>
+
+// details/os-inl.h
+// fmt/bundled/posix.h
+#include <cstdlib>
+
+// details/os-inl.h
+// details/pattern_formatter-inl.h
+// fmt/bundled/core.h
+// fmt/bundled/format-inl.h
+#include <cstring>
+
+// details/os-inl.h
+// details/os.h
+// details/pattern_formatter-inl.h
+// details/pattern_formatter.h
+// fmt/bundled/chrono.h
+// sinks/daily_file_sink.h
+// sinks/rotating_file_sink-inl.h
+#include <ctime>
+
+// fmt/bundled/format-inl.h
+#include <climits>
+
+// fmt/bundled/format-inl.h
+#include <cwchar>
+
+// fmt/bundled/format-inl.h
+// fmt/bundled/format.h
+#include <cmath>
+
+// fmt/bundled/format-inl.h
+#include <cstdarg>
+
+// details/file_helper-inl.h
+// fmt/bundled/format.h
+// fmt/bundled/posix.h
+// sinks/rotating_file_sink-inl.h
+#include <cerrno>
+
+// details/circular_q.h
+// details/thread_pool-inl.h
+// fmt/bundled/format-inl.h
+#include <cassert>
+
+// async_logger-inl.h
+// cfg/helpers-inl.h
+// log_levels.h
+// common.h
+// details/file_helper-inl.h
+// details/log_msg.h
+// details/os-inl.h
+// details/pattern_formatter-inl.h
+// details/pattern_formatter.h
+// details/registry-inl.h
+// details/registry.h
+// details/tcp_client-windows.h
+// details/tcp_client.h
+// fmt/bundled/core.h
+// sinks/android_sink.h
+// sinks/ansicolor_sink.h
+// sinks/basic_file_sink.h
+// sinks/daily_file_sink.h
+// sinks/dup_filter_sink.h
+// sinks/msvc_sink.h
+// sinks/ringbuffer_sink.h
+// sinks/rotating_file_sink-inl.h
+// sinks/rotating_file_sink.h
+// sinks/syslog_sink.h
+// sinks/tcp_sink.h
+// sinks/win_eventlog_sink.h
+// sinks/wincolor_sink.h
+// spdlog.h:
+#include <string>
+
+// cfg/helpers-inl.h
+// fmt/bundled/chrono.h
+#include <sstream>
+
+// fmt/bundled/ostream.h
+// sinks/ostream_sink.h
+#include <ostream>
+
+// cfg/log_levels.h
+// details/registry-inl.h
+// details/registry.h
+#include <unordered_map>
+
+// details/circular_q.h
+// details/pattern_formatter-inl.h
+// details/pattern_formatter.h
+// details/thread_pool.h
+// fmt/bundled/compile.h
+// logger.h
+// sinks/dist_sink.h
+// sinks/ringbuffer_sink.h
+// sinks/win_eventlog_sink.h
+#include <vector>
+
+// details/os-inl.h
+// details/pattern_formatter-inl.h
+// sinks/ansicolor_sink.h
+// sinks/syslog_sink.h
+// sinks/systemd_sink.h
+// sinks/wincolor_sink.h
+#include <array>
+
+// details/file_helper-inl.h
+// details/file_helper.h
+// sinks/rotating_file_sink-inl.h
+#include <tuple>
+
+// details/os-inl.h
+// fmt/bundled/format.h
+// fmt/bundled/printf.h
+#include <limits>
+
+// common.h
+// details/backtracer.h
+// details/null_mutex.h
+#include <atomic>
+
+// common.h
+// details/backtracer.h
+// details/null_mutex.h
+#include <locale>
+
+// common.h
+#include <initializer_list>
+
+// common.h
+#include <exception>
+
+// common.h
+// details/fmt_helper.h
+// fmt/bundled/core.h
+// fmt/bundled/ranges.h
+#include <type_traits>
+
+// cfg/helpers-inl.h
+// details/null_mutex.h
+// details/pattern_formatter-inl.h
+#include <utility>
+
+// async.h
+// async_logger-inl.h
+// common.h
+// details/pattern_formatter-inl.h
+// details/pattern_formatter.h
+// details/registry-inl.h
+// details/registry.h
+// details/thread_pool.h
+// fmt/bundled/format.h
+// sinks/ansicolor_sink.h
+// sinks/base_sink-inl.h
+// sinks/dist_sink.h
+// sinks/stdout_sinks-inl.h
+// sinks/wincolor_sink.h
+// spdlog.h
+#include <memory>
+
+// async.h
+// common.h
+// details/backtracer.h
+// details/periodic_worker.h
+// details/registry-inl.h
+// details/registry.h
+// details/thread_pool.h
+// sinks/tcp_sink.h
+// spdlog.h
+#include <functional>
+
+// details/mpmc_blocking_q.h
+// details/periodic_worker.h
+#include <condition_variable>
+
+// details/os-inl.h
+// fmt/bundled/format.h
+// fmt/bundled/printf.h
+// sinks/dist_sink.h
+#include <algorithm>
+
+// common.h
+// details/file_helper-inl.h
+// details/fmt_helper.h
+// details/os-inl.h
+// details/pattern_formatter-inl.h
+// details/pattern_formatter.h
+// details/periodic_worker.h
+// details/registry-inl.h
+// details/registry.h
+// details/thread_pool.h
+// fmt/bundled/chrono.h
+// sinks/android_sink.h
+// sinks/daily_file_sink.h
+// sinks/dup_filter_sink.h
+// sinks/rotating_file_sink-inl.h
+// sinks/rotating_file_sink.h
+// sinks/tcp_sink.h
+// spdlog.h
+#include <chrono>
+
+// details/file_helper-inl.h
+// details/os-inl.h
+// details/pattern_formatter-inl.h
+// details/periodic_worker.h
+// details/thread_pool.h
+// sinks/android_sink.h
+#include <thread>
+
+// async.h
+// details/backtracer.h
+// details/console_globals.h
+// details/mpmc_blocking_q.h
+// details/pattern_formatter-inl.h
+// details/periodic_worker.h
+// details/registry.h
+// sinks/android_sink.h
+// sinks/ansicolor_sink.h
+// sinks/basic_file_sink.h
+// sinks/daily_file_sink.h
+// sinks/dist_sink.h
+// sinks/dup_filter_sink.h
+// sinks/msvc_sink.h
+// sinks/null_sink.h
+// sinks/ostream_sink.h
+// sinks/ringbuffer_sink.h
+// sinks/rotating_file_sink-inl.h
+// sinks/rotating_file_sink.h
+// sinks/tcp_sink.h
+// sinks/win_eventlog_sink.h
+// sinks/wincolor_sink.h
+//
+// color_sinks.cpp
+// file_sinks.cpp
+// spdlog.cpp
+// stdout_sinks.cpp
+#include <mutex>
+
+// spdlog
+#include <spdlog/common.h>


### PR DESCRIPTION

# Use precompiled header to improve compilation time

Precompiled headers can speed up compilation time by a lot.

Since CMake `3.16` there is a new function `target_precompile_headers` that handle precompiled header for every compilers. It's really easy to set up in the project, and doesn't required more step from final user.

## Motivation

I'm building `spdlog` as part of my CMake project, and since there are lots of target in the build, i'm trying to earn so time by using precompiled header for some target that are still not supporting it.

## Benchmark

I did an implementation on my [fork](https://github.com/OlivierLDff/spdlog), branch is `pch-support`. And made some basic benchmark. 

### Windows Msvc

I measured timing with msvc using built in build times measurement. [Example here](https://stackoverflow.com/questions/82128/displaying-build-times-in-visual-studio).

My processor is `i7-9750H @ 2.60 Ghz` with msvc.

|   Cpu    | Without Precompiled Headers | With Precompiled Headers |
| :------: | :-------------------------: | :----------------------: |
| i7-9750H |        5.5-6 seconds        |      3-3.5 seconds       |


As you can see when building compilation time is almost decreased by 2.

### Mojave with CMake 3.14

Command is  `time sh -c 'make clean -j spdlog'`. I'm not using the same computer as the windows one. It's a hackintosh into lenovo t430.

Compiler is AppleClang 10. This CMake version doesn't support precompiled header so nothing happened. Build took 95s.

### Mojave with CMake 3.17

Then i upgraded CMake to 3.17. I was a little bit disapointeed. Build went down from 95s to 90s only. But it still a little improvement.

|   Cpu    | Without Precompiled Headers | With Precompiled Headers |
| :------: | :-------------------------: | :----------------------: |
| i5-3320M |         95 seconds          |        90 seconds        |

### Fedora

Same machine as the hackintosh. Same command. Using gcc 8.

|   Cpu    | Without Precompiled Headers | With Precompiled Headers |
| :------: | :-------------------------: | :----------------------: |
| i5-3320M |         29 seconds          |        26 seconds        |

### Debian (Wsl)

 `time sh -c 'make clean -j spdlog'`. Using gcc 8. Same machine as the msvc benchmark.

|   Cpu    | Without Precompiled Headers | With Precompiled Headers |
| :------: | :-------------------------: | :----------------------: |
| i7-9750H |        17-18 seconds        |      15-16 seconds       |

## Proposed Changed

For the benchmark I just created a new file `pch.h` in `include/spdlog/details`.

I included stl headers that were included around the project and also `common.h` that isn't supposed to changed.

So this is `pch.h`:

```c++
// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
// Distributed under the MIT License (http://opensource.org/licenses/MIT)

#pragma once

// details/pattern_formatter-inl.h
// fmt/bin_to_hex.h
// fmt/bundled/format-inl.h
#include <cctype>

// details/file_helper-inl.h
// details/os-inl.h
// fmt/bundled/core.h
// fmt/bundled/posix.h
// logger-inl.h
// sinks/daily_file_sink.h
// sinks/stdout_sinks.h
#include <cstdio>

// details/os-inl.h
// fmt/bundled/posix.h
#include <cstdlib>

// details/os-inl.h
// details/pattern_formatter-inl.h
// fmt/bundled/core.h
// fmt/bundled/format-inl.h
#include <cstring>

// details/os-inl.h
// details/os.h
// details/pattern_formatter-inl.h
// details/pattern_formatter.h
// fmt/bundled/chrono.h
// sinks/daily_file_sink.h
// sinks/rotating_file_sink-inl.h
#include <ctime>

// fmt/bundled/format-inl.h
#include <climits>

// fmt/bundled/format-inl.h
#include <cwchar>

// fmt/bundled/format-inl.h
// fmt/bundled/format.h
#include <cmath>

// fmt/bundled/format-inl.h
#include <cstdarg>

// details/file_helper-inl.h
// fmt/bundled/format.h
// fmt/bundled/posix.h
// sinks/rotating_file_sink-inl.h
#include <cerrno>

// details/circular_q.h
// details/thread_pool-inl.h
// fmt/bundled/format-inl.h
#include <cassert>

// async_logger-inl.h
// cfg/helpers-inl.h
// log_levels.h
// common.h
// details/file_helper-inl.h
// details/log_msg.h
// details/os-inl.h
// details/pattern_formatter-inl.h
// details/pattern_formatter.h
// details/registry-inl.h
// details/registry.h
// details/tcp_client-windows.h
// details/tcp_client.h
// fmt/bundled/core.h
// sinks/android_sink.h
// sinks/ansicolor_sink.h
// sinks/basic_file_sink.h
// sinks/daily_file_sink.h
// sinks/dup_filter_sink.h
// sinks/msvc_sink.h
// sinks/ringbuffer_sink.h
// sinks/rotating_file_sink-inl.h
// sinks/rotating_file_sink.h
// sinks/syslog_sink.h
// sinks/tcp_sink.h
// sinks/win_eventlog_sink.h
// sinks/wincolor_sink.h
// spdlog.h:
#include <string>

// cfg/helpers-inl.h
// fmt/bundled/chrono.h
#include <sstream>

// fmt/bundled/ostream.h
// sinks/ostream_sink.h
#include <ostream>

// cfg/log_levels.h
// details/registry-inl.h
// details/registry.h
#include <unordered_map>

// details/circular_q.h
// details/pattern_formatter-inl.h
// details/pattern_formatter.h
// details/thread_pool.h
// fmt/bundled/compile.h
// logger.h
// sinks/dist_sink.h
// sinks/ringbuffer_sink.h
// sinks/win_eventlog_sink.h
#include <vector>

// details/os-inl.h
// details/pattern_formatter-inl.h
// sinks/ansicolor_sink.h
// sinks/syslog_sink.h
// sinks/systemd_sink.h
// sinks/wincolor_sink.h
#include <array>

// details/file_helper-inl.h
// details/file_helper.h
// sinks/rotating_file_sink-inl.h
#include <tuple>

// details/os-inl.h
// fmt/bundled/format.h
// fmt/bundled/printf.h
#include <limits>

// common.h
// details/backtracer.h
// details/null_mutex.h
#include <atomic>

// common.h
// details/backtracer.h
// details/null_mutex.h
#include <locale>

// common.h
#include <initializer_list>

// common.h
#include <exception>

// common.h
// details/fmt_helper.h
// fmt/bundled/core.h
// fmt/bundled/ranges.h
#include <type_traits>

// cfg/helpers-inl.h
// details/null_mutex.h
// details/pattern_formatter-inl.h
#include <utility>

// async.h
// async_logger-inl.h
// common.h
// details/pattern_formatter-inl.h
// details/pattern_formatter.h
// details/registry-inl.h
// details/registry.h
// details/thread_pool.h
// fmt/bundled/format.h
// sinks/ansicolor_sink.h
// sinks/base_sink-inl.h
// sinks/dist_sink.h
// sinks/stdout_sinks-inl.h
// sinks/wincolor_sink.h
// spdlog.h
#include <memory>

// async.h
// common.h
// details/backtracer.h
// details/periodic_worker.h
// details/registry-inl.h
// details/registry.h
// details/thread_pool.h
// sinks/tcp_sink.h
// spdlog.h
#include <functional>

// details/mpmc_blocking_q.h
// details/periodic_worker.h
#include <condition_variable>

// details/os-inl.h
// fmt/bundled/format.h
// fmt/bundled/printf.h
// sinks/dist_sink.h
#include <algorithm>

// common.h
// details/file_helper-inl.h
// details/fmt_helper.h
// details/os-inl.h
// details/pattern_formatter-inl.h
// details/pattern_formatter.h
// details/periodic_worker.h
// details/registry-inl.h
// details/registry.h
// details/thread_pool.h
// fmt/bundled/chrono.h
// sinks/android_sink.h
// sinks/daily_file_sink.h
// sinks/dup_filter_sink.h
// sinks/rotating_file_sink-inl.h
// sinks/rotating_file_sink.h
// sinks/tcp_sink.h
// spdlog.h
#include <chrono>

// details/file_helper-inl.h
// details/os-inl.h
// details/pattern_formatter-inl.h
// details/periodic_worker.h
// details/thread_pool.h
// sinks/android_sink.h
#include <thread>

// async.h
// details/backtracer.h
// details/console_globals.h
// details/mpmc_blocking_q.h
// details/pattern_formatter-inl.h
// details/periodic_worker.h
// details/registry.h
// sinks/android_sink.h
// sinks/ansicolor_sink.h
// sinks/basic_file_sink.h
// sinks/daily_file_sink.h
// sinks/dist_sink.h
// sinks/dup_filter_sink.h
// sinks/msvc_sink.h
// sinks/null_sink.h
// sinks/ostream_sink.h
// sinks/ringbuffer_sink.h
// sinks/rotating_file_sink-inl.h
// sinks/rotating_file_sink.h
// sinks/tcp_sink.h
// sinks/win_eventlog_sink.h
// sinks/wincolor_sink.h
//
// color_sinks.cpp
// file_sinks.cpp
// spdlog.cpp
// stdout_sinks.cpp
#include <mutex>

// spdlog
#include <spdlog/common.h>
```

I introduced a new option `SPDLOG_ENABLE_PCH` that is defaulted to `ON`.

Then to use it i modified `CMakelists.txt` to add:

```cmake
# precompiled headers option
option(SPDLOG_ENABLE_PCH "Build static or shared library using precompiled header to speed up compilation time" ON)

## ...

# After creating target spdlog
if(COMMAND target_precompile_headers AND SPDLOG_ENABLE_PCH)
    target_precompile_headers(spdlog PRIVATE include/spdlog/details/pch.h)
endif()
```

As you can see if `target_precompile_headers` doesn't exist (ie CMake version <= 3.16) no compilation time reduction will happen.

* For people using old version of CMake nothing change. 
* For people using new version of CMake they will get better compilation time without touching anything.
* `SPDLOG_ENABLE_PCH` can be set to `OFF` to check that `spdlog` is still compiling with compilers that doesn't support precompiled headers.
* Precompiled headers seems to be the heart of lots of debate on the internet, is it useful or not, etc... From my benchmark worst case is that it changed nothing in compile time, best is a x2 speed up.
* Remember the `pch.h` is only forced included for `.cpp` file in spdlog compilation. If a user want to reuse the same precompiled header file for his project he can do `target_precompile_headers(<target> REUSE_FROM spdlog)`.

## Opinion

What should i improve?

Thanks a lot for reading.

Olivier Le Doeuff.

## Reference

* https://cmake.org/cmake/help/git-stage/command/target_precompile_headers.html