### PR TITLE
yaourt is outdated and insecure, use yay in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ cmake .. && make -j
 * FreeBSD:  `cd /usr/ports/devel/spdlog/ && make install clean`
 * Fedora: `yum install spdlog`
 * Gentoo: `emerge dev-libs/spdlog`
-* Arch Linux: `yay -S spdlog-git`
+* Arch Linux: `pacman -S spdlog`
 * vcpkg: `vcpkg install spdlog`
 * conan: `spdlog/[>=1.4.1]`
 * conda: `conda install -c conda-forge spdlog`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ cmake .. && make -j
 * FreeBSD:  `cd /usr/ports/devel/spdlog/ && make install clean`
 * Fedora: `yum install spdlog`
 * Gentoo: `emerge dev-libs/spdlog`
-* Arch Linux: `yaourt -S spdlog-git`
+* Arch Linux: `yay -S spdlog-git`
 * vcpkg: `vcpkg install spdlog`
 * conan: `spdlog/[>=1.4.1]`
 * conda: `conda install -c conda-forge spdlog`


### PR DESCRIPTION
Not maintained anymore: https://archlinux.fr/yaourt-en
Alternatively: spdlog is now apart of the community repo (https://www.archlinux.org/packages/community/x86_64/spdlog/)