### PR TITLE
add /WX mscv compiler option for only mscv compiler

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,9 +28,9 @@ endfunction()
 
 # Turn on warnings on the given target
 function(spdlog_enable_warnings target_name)
-	set(MSVC_OPTIONS "/W3")
+	list(APPEND MSVC_OPTIONS "/W3")
 	if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
-		set(MSVC_OPTIONS "${MSVC_OPTIONS} /WX")
+		list(APPEND MSVC_OPTIONS "/WX")
 	endif()
     target_compile_options(${target_name} PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,10 +28,13 @@ endfunction()
 
 # Turn on warnings on the given target
 function(spdlog_enable_warnings target_name)
-	list(APPEND MSVC_OPTIONS "/W3")
-	if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
-		list(APPEND MSVC_OPTIONS "/WX")
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+		list(APPEND MSVC_OPTIONS "/W3")
+		if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
+			list(APPEND MSVC_OPTIONS "/WX")
+		endif()
 	endif()
+
     target_compile_options(${target_name} PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
             -Wall -Wextra -Wconversion -pedantic -Wfatal-errors>

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,13 +28,15 @@ endfunction()
 
 # Turn on warnings on the given target
 function(spdlog_enable_warnings target_name)
+	set(MSVC_OPTIONS "/W3")
+	if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
+		set(MSVC_OPTIONS "${MSVC_OPTIONS} /WX")
+	endif()
     target_compile_options(${target_name} PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
             -Wall -Wextra -Wconversion -pedantic -Wfatal-errors>
-        $<$<CXX_COMPILER_ID:MSVC>:/W3>)
-		if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
-			target_compile_options(${target_name} PRIVATE /WX)
-		endif()
+        $<$<CXX_COMPILER_ID:MSVC>:${MSVC_OPTIONS}>)
+
 endfunction()
 
 


### PR DESCRIPTION
clang on windows support both gcc and mscv style options. Clang.exe on windows
defaults to gcc style, which will result in /WX unknown compiler command.
This will set /WX if and only if the compiler is MSVC and greater than version 1900.

Could perhaps be done in a prettier way, but it solves the issue nicely.