### PR TITLE
Added an option to disable compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ option(SPDLOG_BUILD_BENCH "Build benchmarks (Requires https://github.com/google/
 # sanitizer options
 option(SPDLOG_SANITIZE_ADDRESS "Enable address sanitizer in tests" OFF)
 
+# warning options
+option(SPDLOG_ENABLE_WARNINGS "Enable compiler warnings" ON)
+
 # install options
 option(SPDLOG_INSTALL "Generate the install target" ${SPDLOG_MASTER_PROJECT})
 option(SPDLOG_FMT_EXTERNAL "Use external fmt library instead of bundled" OFF)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -28,17 +28,19 @@ endfunction()
 
 # Turn on warnings on the given target
 function(spdlog_enable_warnings target_name)
-	if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-		list(APPEND MSVC_OPTIONS "/W3")
-		if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
-			list(APPEND MSVC_OPTIONS "/WX")
-		endif()
-	endif()
+    if(SPDLOG_ENABLE_WARNINGS)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            list(APPEND MSVC_OPTIONS "/W3")
+            if(MSVC_VERSION GREATER  1900)  #Allow non fatal security wanrnings for msvc 2015
+                list(APPEND MSVC_OPTIONS "/WX")
+            endif()
+        endif()
 
-    target_compile_options(${target_name} PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-            -Wall -Wextra -Wconversion -pedantic -Wfatal-errors>
-        $<$<CXX_COMPILER_ID:MSVC>:${MSVC_OPTIONS}>)
+        target_compile_options(${target_name} PRIVATE
+            $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+                -Wall -Wextra -Wconversion -pedantic -Wfatal-errors>
+            $<$<CXX_COMPILER_ID:MSVC>:${MSVC_OPTIONS}>)
+    endif()
 
 endfunction()
 


### PR DESCRIPTION
I recently started using spdlog in my personal project. I went with submodule + building with project approach. The problem I encountered is that there is no way to disable warnings that I get from spdlog files. So I added a cmake option to disable them for cases such as mine.