### PR TITLE
add a methods which have a time_point argument to the logger API

### DIFF
--- a/include/spdlog/details/log_msg-inl.h
+++ b/include/spdlog/details/log_msg-inl.h
@@ -13,6 +13,18 @@ namespace spdlog {
 namespace details {
 
 SPDLOG_INLINE log_msg::log_msg(
+    spdlog::log_clock::time_point &log_time, spdlog::source_loc loc, string_view_t a_logger_name, spdlog::level::level_enum lvl, spdlog::string_view_t msg)
+    : logger_name(a_logger_name)
+    , level(lvl)
+    , time(log_time)
+#ifndef SPDLOG_NO_THREAD_ID
+    , thread_id(os::thread_id())
+#endif
+    , source(loc)
+    , payload(msg)
+{}
+
+SPDLOG_INLINE log_msg::log_msg(
     spdlog::source_loc loc, string_view_t a_logger_name, spdlog::level::level_enum lvl, spdlog::string_view_t msg)
     : logger_name(a_logger_name)
     , level(lvl)

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -11,6 +11,7 @@ namespace details {
 struct SPDLOG_API log_msg
 {
     log_msg() = default;
+    log_msg(log_clock::time_point &log_time, source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(const log_msg &other) = default;


### PR DESCRIPTION
I've created a branch: log_methods_with_time_point
This is the first time I've created a pull request,  therefore please bear with me if this isn't right.
I hope you accept this addition to the API.
Thanks,
Ron