### PR TITLE
Update to include funcname

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -978,6 +978,8 @@ public:
             fmt_helper::append_string_view(filename, dest);
             dest.push_back(':');
             fmt_helper::append_int(msg.source.line, dest);
+            dest.push_back(':');
+            fmt_helper::append_string_view(msg.source.funcname, dest);
             dest.push_back(']');
             dest.push_back(' ');
         }


### PR DESCRIPTION
When logging with ```SPDLOG_LOGGER_DEBUG``` macro the ```funcname``` is missing. 

- Updated ```full_formatter``` to include the ```funcname``` if source location is present.