### PR TITLE
Set minimum version of fmt to 5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 #---------------------------------------------------------------------------------------
 if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
     if (NOT TARGET fmt::fmt)
-        find_package(fmt REQUIRED)
+        find_package(fmt 5.3.0 REQUIRED)
     endif ()
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)


### PR DESCRIPTION
The used `fmt::fmt` target has been introduced with `fmt 5.0.0`.

Without this `spdlog` also picks up older versions of `fmt` like `4.0.0` on Ubuntu 18.04 through `libfmt-dev` or even older versions on Ubuntu 16.04 through `libfmt3-dev`. Compilation fails but the error message is not straight forward at all.

I'm not sure if the version should be higher depending on what features of `fmt` are used within `spdlog`.