### PR TITLE
Add an option that allow user to disable warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,11 @@ target_include_directories(spdlog PUBLIC
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(spdlog PUBLIC Threads::Threads)
-spdlog_enable_warnings(spdlog)
+
+option(SPDLOG_DISABLE_WARNINGS "Skip enabling warnings when building spdlog" off)
+if(NOT SPDLOG_DISABLE_WARNINGS)
+	spdlog_enable_warnings(spdlog)
+endif()
 
 set_target_properties(spdlog PROPERTIES VERSION ${SPDLOG_VERSION} SOVERSION ${SPDLOG_VERSION_MAJOR})
 set_target_properties(spdlog PROPERTIES DEBUG_POSTFIX d)


### PR DESCRIPTION
This option is false by default, thus do not change the current behavior
of the build system.

This is useful when the user vendor spdlog's code into his own
codebase and do not want to have the compiler warn about spdlog's code.

This also is an easy way to prevent CMake to set non-compatible flags on
`clang-cl` (clang for Visual Studio) like `-pedantic`.

In practice, this patch does:

 -add option `SPDLOG_DISABLE_WARNINGS`, `off` state by default
 -add conditional test checking that the option above is `off`.

If the option is manually turned on by the user: behavior is to
skip the call to `spdlog_enable_warnings` on `spdlog` build target.

If the user does nothing, current behavior is unchanged.