### PR TITLE
Delete old files on init

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -98,10 +98,13 @@ using win32_find_data = WIN32_FIND_DATAW;
 #define SPDLOG_FILENAME_T(s) L##s
 #else
 using filename_t = std::string;
+#define SPDLOG_FILENAME_T(s) s
+#endif
+
+#if defined(_WIN32) && !defined(SPDLOG_WCHAR_FILENAMES)
 using win32_find_data = WIN32_FIND_DATAA;
 #define find_first_file  FindFirstFileA
 #define find_next_file  FindNextFileA
-#define SPDLOG_FILENAME_T(s) s
 #endif
 
 using log_clock = std::chrono::system_clock;

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -6,6 +6,10 @@
 #include <spdlog/tweakme.h>
 #include <spdlog/details/null_mutex.h>
 
+#ifdef _WIN32
+#include <spdlog/details/windows_include.h>
+#endif
+
 #include <atomic>
 #include <chrono>
 #include <initializer_list>
@@ -88,9 +92,15 @@ class sink;
 
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 using filename_t = std::wstring;
+using win32_find_data = WIN32_FIND_DATAW;
+#define find_first_file  FindFirstFileW
+#define find_next_file  FindNextFileW
 #define SPDLOG_FILENAME_T(s) L##s
 #else
 using filename_t = std::string;
+using win32_find_data = WIN32_FIND_DATAA;
+#define find_first_file  FindFirstFileA
+#define find_next_file  FindNextFileA
 #define SPDLOG_FILENAME_T(s) s
 #endif
 

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -622,7 +622,7 @@ SPDLOG_INLINE std::vector<std::string> get_directory_files(const std::string &di
         if (is_directory)
             continue;
 
-        files.push_back(full_file_name);
+        files.emplace_back(std::move(full_file_name));
     }
 
     closedir(dir);

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -581,7 +581,7 @@ SPDLOG_INLINE std::vector<filename_t> get_directory_files(const filename_t &dire
 
         const filename_t full_file_name = directory + SPDLOG_FILENAME_T("/") + file_name;
 
-        files.push_back(full_file_name);
+        files.emplace_back(std::move(full_file_name));
     } while (find_next_file(dir, &file_data));
 
     FindClose(dir);

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -566,15 +566,20 @@ SPDLOG_INLINE std::vector<filename_t> get_directory_files(const filename_t &dire
 
     do
     {
-        const filename_t file_name = file_data.cFileName;
-        const filename_t full_file_name = directory + SPDLOG_FILENAME_T("/") + file_name;
+        const filename_t::value_type* file_name = file_data.cFileName;
+        if (file_name[0] == '.')
+        {
+            continue;
+        }
+
         const bool is_directory = (file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 
-        if (file_name[0] == '.')
-            continue;
-
         if (is_directory)
+        {
             continue;
+        }
+
+        const filename_t full_file_name = directory + SPDLOG_FILENAME_T("/") + file_name;
 
         files.push_back(full_file_name);
     } while (find_next_file(dir, &file_data));

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -605,11 +605,14 @@ SPDLOG_INLINE std::vector<std::string> get_directory_files(const std::string &di
 
     while ((ent = readdir(dir)) != nullptr)
     {
-        const std::string file_name = ent->d_name;
-        const std::string full_file_name = directory + "/" + file_name;
+        const std::string file_name::value_type* = ent->d_name;
 
         if (file_name[0] == '.')
+        {
             continue;
+        }
+
+        const std::string full_file_name = directory + "/" + file_name;
 
         if (::stat(full_file_name.c_str(), &st) == -1)
             continue;

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -605,7 +605,7 @@ SPDLOG_INLINE std::vector<std::string> get_directory_files(const std::string &di
 
     while ((ent = readdir(dir)) != nullptr)
     {
-        const std::string file_name::value_type* = ent->d_name;
+        const std::string::value_type* file_name = ent->d_name;
 
         if (file_name[0] == '.')
         {

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -554,21 +554,20 @@ std::string SPDLOG_INLINE getenv(const char *field)
 }
 
 #ifdef _WIN32
-#ifdef SPDLOG_WCHAR_FILENAMES
-SPDLOG_INLINE std::vector<std::wstring> get_directory_files(const std::wstring &directory) SPDLOG_NOEXCEPT
+SPDLOG_INLINE std::vector<filename_t> get_directory_files(const filename_t &directory) SPDLOG_NOEXCEPT
 {
-    std::vector<std::wstring> files;
+    std::vector<filename_t> files;
 
     HANDLE dir;
-    WIN32_FIND_DATAW file_data;
+    win32_find_data file_data;
 
-    if ((dir = FindFirstFileW((directory + L"/*").c_str(), &file_data)) == INVALID_HANDLE_VALUE)
+    if ((dir = find_first_file((directory + SPDLOG_FILENAME_T("/*")).c_str(), &file_data)) == INVALID_HANDLE_VALUE)
         return files;
 
     do
     {
-        const std::wstring file_name = file_data.cFileName;
-        const std::wstring full_file_name = directory + L"/" + file_name;
+        const filename_t file_name = file_data.cFileName;
+        const filename_t full_file_name = directory + SPDLOG_FILENAME_T("/") + file_name;
         const bool is_directory = (file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 
         if (file_name[0] == '.')
@@ -578,43 +577,12 @@ SPDLOG_INLINE std::vector<std::wstring> get_directory_files(const std::wstring &
             continue;
 
         files.push_back(full_file_name);
-    } while (FindNextFileW(dir, &file_data));
+    } while (find_next_file(dir, &file_data));
 
     FindClose(dir);
 
     return files;
 }
-#else
-SPDLOG_INLINE std::vector<std::string> get_directory_files(const std::string &directory) SPDLOG_NOEXCEPT
-{
-    std::vector<std::string> files;
-
-    HANDLE dir;
-    WIN32_FIND_DATAA file_data;
-
-    if ((dir = FindFirstFileA((directory + "/*").c_str(), &file_data)) == INVALID_HANDLE_VALUE)
-        return files;
-
-    do
-    {
-        const std::string file_name = file_data.cFileName;
-        const std::string full_file_name = directory + "/" + file_name;
-        const bool is_directory = (file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
-
-        if (file_name[0] == '.')
-            continue;
-
-        if (is_directory)
-            continue;
-
-        files.push_back(full_file_name);
-    } while (FindNextFileA(dir, &file_data));
-
-    FindClose(dir);
-
-    return files;
-}
-#endif
 #else
 SPDLOG_INLINE std::vector<std::string> get_directory_files(const std::string &directory) SPDLOG_NOEXCEPT
 {

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -102,6 +102,12 @@ SPDLOG_API bool create_dir(filename_t path);
 // return empty string if field not found
 SPDLOG_API std::string getenv(const char *field);
 
+#if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
+SPDLOG_API std::vector<std::wstring> get_directory_files(const std::wstring &directory) SPDLOG_NOEXCEPT;
+#else
+SPDLOG_API std::vector<std::string> get_directory_files(const std::string &directory) SPDLOG_NOEXCEPT;
+#endif
+
 } // namespace os
 } // namespace details
 } // namespace spdlog

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -102,11 +102,7 @@ SPDLOG_API bool create_dir(filename_t path);
 // return empty string if field not found
 SPDLOG_API std::string getenv(const char *field);
 
-#if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
-SPDLOG_API std::vector<std::wstring> get_directory_files(const std::wstring &directory) SPDLOG_NOEXCEPT;
-#else
-SPDLOG_API std::vector<std::string> get_directory_files(const std::string &directory) SPDLOG_NOEXCEPT;
-#endif
+SPDLOG_API std::vector<filename_t> get_directory_files(const filename_t &directory) SPDLOG_NOEXCEPT;
 
 } // namespace os
 } // namespace details

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -161,8 +161,9 @@ private:
 
         filenames_q_ = details::circular_q<filename_t>(static_cast<size_t>(max_files_));
 
-        // Because the map key is the date in yyyy-mm--dd, it is sorted by lexicographical order.
-        const std::map<filename_t, filename_t> dates_to_filenames = daily_filename_calculator::calc_dates_to_filenames(base_filename_);
+        // The returned map from FileNameCalc::calc_dates_to_filenames must be ordered from earliest date to latest. The default implementation uses
+        // YYYY-MM-DD format for the date to allow lexicographical order.
+        const std::map<filename_t, filename_t> dates_to_filenames = FileNameCalc::calc_dates_to_filenames(base_filename_);
 
         const auto first_valid_file_pos = max_files_ > 0 && dates_to_filenames.size() > max_files_ ? dates_to_filenames.size() - max_files_ : 0;
 

--- a/tests/test_daily_logger.cpp
+++ b/tests/test_daily_logger.cpp
@@ -99,6 +99,28 @@ TEST_CASE("daily_file_sink::daily_filename_calculator", "[daily_file_sink]]")
 }
 #endif
 
+TEST_CASE("daily_file_sink::daily_filename_calculator::extract_date_suffix", "[daily_file_sink]]")
+{
+    auto now = spdlog::details::os::localtime();
+
+    auto basename = "daily.txt";
+
+    auto filename = spdlog::sinks::daily_filename_calculator::calc_filename(basename, now);
+
+    auto date_suffix = spdlog::sinks::daily_filename_calculator::extract_date_suffix(basename, filename);
+
+    auto expected_suffix = fmt::format(SPDLOG_FILENAME_T("{:04d}-{:02d}-{:02d}"), now.tm_year + 1900, now.tm_mon + 1, now.tm_mday);
+
+    REQUIRE(date_suffix == expected_suffix);
+}
+
+TEST_CASE("daily_file_sink::daily_filename_calculator::extract_date_suffix2", "[daily_file_sink]]")
+{
+    auto date_suffix = spdlog::sinks::daily_filename_calculator::extract_date_suffix("basename", "filename");
+
+    REQUIRE(date_suffix == "");
+}
+
 /* Test removal of old files */
 static spdlog::details::log_msg create_msg(std::chrono::seconds offset)
 {

--- a/tests/test_daily_logger.cpp
+++ b/tests/test_daily_logger.cpp
@@ -35,6 +35,11 @@ struct custom_daily_file_name_calculator
         fmt::format_to(w, "{}{:04d}{:02d}{:02d}", basename, now_tm.tm_year + 1900, now_tm.tm_mon + 1, now_tm.tm_mday);
         return fmt::to_string(w);
     }
+
+    static std::map<spdlog::filename_t, spdlog::filename_t> calc_dates_to_filenames(const spdlog::filename_t &base_filename)
+    {
+        return {};
+    }
 };
 
 TEST_CASE("daily_logger with custom calculator", "[daily_logger]")


### PR DESCRIPTION
- Current init of file names queue does not cater for case where the logger is initialised several days after the last log (all it does is go back day by day and stop if the file does not exist). Changed this to ensure we cater for all files in the log directory.
- Extract the YYYY-MM-DD component of the file name to allow lexicographical ordering by inserting key/value pair of date to file name in a map.

Solves issue #1566