### PR TITLE
Twice tolerance waiting time with MinGW

### DIFF
--- a/tests/test_mpmc_q.cpp
+++ b/tests/test_mpmc_q.cpp
@@ -10,7 +10,7 @@ static milliseconds millis_from(const test_clock::time_point &tp0)
 TEST_CASE("dequeue-empty-nowait", "[mpmc_blocking_q]")
 {
     size_t q_size = 100;
-    milliseconds tolerance_wait(10);
+    milliseconds tolerance_wait(20);
     spdlog::details::mpmc_blocking_queue<int> q(q_size);
     int popped_item = 0;
 


### PR DESCRIPTION
Increased tolerance waiting time for MinGW in dequeue-empty-nowait test
case, because this test case not passed on slow and powerful computers.