### PR TITLE
fmt 7.0.0 renamed the internal namespace to detail.

### DIFF
--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -34,7 +34,15 @@ template<typename T>
 inline unsigned int count_digits(T n)
 {
     using count_type = typename std::conditional<(sizeof(T) > sizeof(uint32_t)), uint64_t, uint32_t>::type;
-    return static_cast<unsigned int>(fmt::internal::count_digits(static_cast<count_type>(n)));
+    return static_cast<unsigned int>(fmt::
+// fmt 7.0.0 renamed the internal namespace to detail.
+// See: https://github.com/fmtlib/fmt/issues/1538
+#if FMT_VERSION < 70000
+internal
+#else
+detail
+#endif
+::count_digits(static_cast<count_type>(n)));
 }
 
 inline void pad2(int n, memory_buf_t &dest)


### PR DESCRIPTION
See: https://github.com/fmtlib/fmt/issues/1538

Fixes: https://github.com/gabime/spdlog/issues/1604