### PR TITLE
Bump CMake requirement to 3.10, don't enable C language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.2)
-
-if(${CMAKE_VERSION} VERSION_LESS 3.11)
-    cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-    cmake_policy(VERSION 3.11)
-endif()
-
+cmake_minimum_required(VERSION 3.13)
 enable_language(C)
 
 # ---------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.13)
-enable_language(C)
+cmake_minimum_required(VERSION 3.10)
 
 # ---------------------------------------------------------------------------------------
 # Start spdlog project

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(spdlog_bench CXX)
 
 if(NOT TARGET spdlog)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.13)
 project(spdlog_bench CXX)
 
 if(NOT TARGET spdlog)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(spdlog_examples CXX)
 
 if(NOT TARGET spdlog)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.13)
 project(spdlog_examples CXX)
 
 if(NOT TARGET spdlog)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
-
+cmake_minimum_required(VERSION 3.13)
 project(spdlog_utests CXX)
 
 if (NOT TARGET spdlog)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.10)
 project(spdlog_utests CXX)
 
 if (NOT TARGET spdlog)


### PR DESCRIPTION
Using a version range enables the policies up to the current version.
This fixes warnings due to deprecated policies in newer versions. Testing shows there to be no policy changes that are problematic.

A fallback is retained for versions <3.11 to emulate the version range behaviour.