### PR TITLE
Bugfix/shadow warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,10 @@ endif()
 add_library(spdlog::spdlog ALIAS spdlog)
 
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
-target_include_directories(spdlog PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-                                         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(spdlog PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+                                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(spdlog SYSTEM INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(spdlog PUBLIC Threads::Threads)
 spdlog_enable_warnings(spdlog)
 
@@ -162,8 +164,8 @@ endif()
 add_library(spdlog_header_only INTERFACE)
 add_library(spdlog::spdlog_header_only ALIAS spdlog_header_only)
 
-target_include_directories(spdlog_header_only INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-                                                        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+target_include_directories(spdlog_header_only SYSTEM INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+                                                               "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 
 # ---------------------------------------------------------------------------------------

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -29,21 +29,27 @@ endfunction()
 function(spdlog_enable_warnings target_name)
     if(SPDLOG_BUILD_WARNINGS)
         if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-            list(APPEND MSVC_OPTIONS "/W3")
+            list(APPEND WARNING_OPTIONS "/W3")
             if(MSVC_VERSION GREATER 1900) # Allow non fatal security warnings for msvc 2015
-                list(APPEND MSVC_OPTIONS "/WX")
+                list(APPEND WARNING_OPTIONS "/WX")
             endif()
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL ".*Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            list(APPEND WARNING_OPTIONS
+                -Wall
+                -Wconversion
+                -Werror
+                -Wextra
+                -Wfatal-errors
+                -Wpedantic
+                -Wshadow
+            )
         endif()
 
         target_compile_options(
             ${target_name}
-            PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-                    -Wall
-                    -Wextra
-                    -Wconversion
-                    -pedantic
-                    -Wfatal-errors>
-                    $<$<CXX_COMPILER_ID:MSVC>:${MSVC_OPTIONS}>)
+            PRIVATE
+                ${WARNING_OPTIONS}
+        )
     endif()
 endfunction()
 

--- a/include/spdlog/fmt/bundled/core.h
+++ b/include/spdlog/fmt/bundled/core.h
@@ -1252,10 +1252,10 @@ class dynamic_arg_list {
 
  public:
   template <typename T, typename Arg> const T& push(const Arg& arg) {
-    auto node = std::unique_ptr<typed_node<T>>(new typed_node<T>(arg));
-    auto& value = node->value;
-    node->next = std::move(head_);
-    head_ = std::move(node);
+    auto node_ptr = std::unique_ptr<typed_node<T>>(new typed_node<T>(arg));
+    auto& value = node_ptr->value;
+    node_ptr->next = std::move(head_);
+    head_ = std::move(node_ptr);
     return value;
   }
 };

--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -3244,9 +3244,9 @@ template <> struct formatter<bytes> {
         specs_.precision, specs_.precision_ref, ctx);
     using range_type =
         internal::output_range<typename FormatContext::iterator, char>;
-    internal::basic_writer<range_type> writer(range_type(ctx.out()));
-    writer.write_bytes(b.data_, specs_);
-    return writer.out();
+    internal::basic_writer<range_type> format_writer(range_type(ctx.out()));
+    format_writer.write_bytes(b.data_, specs_);
+    return format_writer.out();
   }
 
  private:


### PR DESCRIPTION
We are trying to include your project in a project of our company (Eaton) but we are using a longer list of warnings in our source files, when we are trying to include your headers, we only have a warning that raise about some variables shadowing some type. This PR add the warning in the spdlog project, fix it and change a little the CMakeLists so when project try to import spdlog, these projects compiler and linter will not consider to raise warning on spdlog headers, considered as system headers.