### PR TITLE
Fix for issue #1627: Global get_level() and should_log()

### DIFF
--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -47,6 +47,16 @@ SPDLOG_INLINE void dump_backtrace()
     default_logger_raw()->dump_backtrace();
 }
 
+SPDLOG_API level::level_enum get_level()
+{
+    return default_logger_raw()->level();
+}
+
+SPDLOG_INLINE bool should_log(level::level_enum log_level)
+{
+    return default_logger_raw()->should_log(log_level);
+}
+
 SPDLOG_INLINE void set_level(level::level_enum log_level)
 {
     details::registry::instance().set_level(log_level);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -67,8 +67,14 @@ SPDLOG_API void disable_backtrace();
 // call dump backtrace on default logger
 SPDLOG_API void dump_backtrace();
 
+// Get global logging level
+SPDLOG_API level::level_enum get_level();
+
 // Set global logging level
 SPDLOG_API void set_level(level::level_enum log_level);
+
+// Determine whether the default logger should log messages with a certain level
+SPDLOG_API bool should_log(level::level_enum lvl);
 
 // Set global flush level
 SPDLOG_API void flush_on(level::level_enum log_level);


### PR DESCRIPTION
* Added: `spdlog::get_level()` API function - like `logger::level()`, except for the name change
* Added: `spdlog::should_log()` API function - like `logger: should_log()`
* Added some code to the example program to use the two new API functions.