### PR TITLE
tcp_client.h bugfix for macOS and add tcp example

### DIFF
--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -75,7 +75,11 @@ public:
         int last_errno = 0;
         for (auto *rp = addrinfo_result; rp != nullptr; rp = rp->ai_next)
         {
-            int const flags = SOCK_CLOEXEC;
+#if defined(SOCK_CLOEXEC)
+            const int flags = SOCK_CLOEXEC;
+#else
+            const int flags = 0;
+#endif
             socket_ = ::socket(rp->ai_family, rp->ai_socktype | flags, rp->ai_protocol);
             if (socket_ == -1)
             {
@@ -87,12 +91,9 @@ public:
             {
                 break;
             }
-            else
-            {
-                last_errno = errno;
-                ::close(socket_);
-                socket_ = -1;
-            }
+            last_errno = errno;
+            ::close(socket_);
+            socket_ = -1;
         }
         ::freeaddrinfo(addrinfo_result);
         if (socket_ == -1)


### PR DESCRIPTION
-> fix the issue that the head is not compilable bc. of missing declaration
-> optimize if/else block in connection function. Else not needed bc. of break in if