### PR TITLE
let R header defines switch to REprintf over fprintf(stdderr)

### DIFF
--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -247,7 +247,11 @@ SPDLOG_INLINE void logger::err_handler_(const std::string &msg)
         auto tm_time = details::os::localtime(system_clock::to_time_t(now));
         char date_buf[64];
         std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d %H:%M:%S", &tm_time);
-        fprintf(stderr, "[*** LOG ERROR #%04zu ***] [%s] [%s] {%s}\n", err_counter, date_buf, name().c_str(), msg.c_str());
+        #if !defined(R_R_H) || !defined(USING_R)
+        std::fprintf(stderr, "[*** LOG ERROR #%04zu ***] [%s] [%s] {%s}\n", err_counter, date_buf, name().c_str(), msg.c_str());
+        #else
+        REprintf("[*** LOG ERROR #%04zu ***] [%s] [%s] {%s}\n", err_counter, date_buf, name().c_str(), msg.c_str());
+        #endif
     }
 }
 } // namespace spdlog


### PR DESCRIPTION
As previously discusses, R much prefers to use its own (buffered) standard output and error output and flags it when compiled extensions use the library ones.  

This short PR switches the last remaining `fprintf()` out for R's own `REprintf()` (which is identical, apart from not needing the implicit `stderr`, and printing to R).  

We rely on two defines set in the top-level header file `R.h` which users (such as [RcppSpdlog](https://github.com/eddelbuettel/rcppspdlog)) should include _before_ including `spdlog/spdlog.h`.