### PR TITLE
Rotating file sink callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ void rotating_example()
 }
 ```
 
+It's possible to use callback for manipulating (compressing, copying somewhere, etc) the newly completed and rotated log file (essentially `rotating.1.txt` in this example). If that callback compresses and appends extension (ex. `.gz`) it has to be mentioned in the parameters, otherwise keep it empty string. The callback can be any functional which accepts `spdlog::filename_t` parameter to manipulate it.
+```c++
+#include "spdlog/sinks/rotating_file_sink.h"
+#include <cstdlib>
+void rotating_example()
+{
+    // Create a file rotating logger with 5mb size max and 3 rotated files
+    auto max_size = 1048576 * 5;
+    auto max_files = 3;
+    auto logger = spdlog::rotating_logger_mt("some_logger_name", "logs/rotating.txt", max_size, max_files, ".gz", [](spdlog::filename_t filename){
+        std::system(std::string("gzip " + filename).c_str());
+    });
+}
+```
+
+
 ---
 #### Daily files
 ```c++

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <mutex>
 #include <string>
+#include <functional>
 
 namespace spdlog {
 namespace sinks {
@@ -23,6 +24,8 @@ class rotating_file_sink final : public base_sink<Mutex>
 {
 public:
     rotating_file_sink(filename_t base_filename, std::size_t max_size, std::size_t max_files, bool rotate_on_open = false);
+    rotating_file_sink(filename_t base_filename, std::size_t max_size, std::size_t max_files,
+        filename_t compress_extension, std::function<void(filename_t)> compress_callback, bool rotate_on_open = false);
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
 
@@ -42,11 +45,19 @@ private:
     // return true on success, false otherwise.
     bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
 
+    // runs given compress_
+    void call_compressor_callback();
+
+    // Common init called from constructor
+    void init();
+
     filename_t base_filename_;
     std::size_t max_size_;
     std::size_t max_files_;
     std::size_t current_size_;
     details::file_helper file_helper_;
+    filename_t compress_extension_;
+    std::function<void(filename_t)> compress_callback_;
 };
 
 using rotating_file_sink_mt = rotating_file_sink<std::mutex>;
@@ -66,10 +77,28 @@ inline std::shared_ptr<logger> rotating_logger_mt(
 }
 
 template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> rotating_logger_mt(
+    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files,
+    const filename_t &compress_extension, std::function<void(filename_t)> compress_callback, bool rotate_on_open = false)
+{
+    return Factory::template create<sinks::rotating_file_sink_mt>(logger_name, filename, max_file_size, max_files,
+        compress_extension, std::move(compress_callback), rotate_on_open);
+}
+
+template<typename Factory = spdlog::synchronous_factory>
 inline std::shared_ptr<logger> rotating_logger_st(
     const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files, bool rotate_on_open = false)
 {
     return Factory::template create<sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files, rotate_on_open);
+}
+
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> rotating_logger_st(
+    const std::string &logger_name, const filename_t &filename, size_t max_file_size, size_t max_files,
+    const filename_t &compress_extension, std::function<void(filename_t)> compress_callback, bool rotate_on_open = false)
+{
+    return Factory::template create<sinks::rotating_file_sink_st>(logger_name, filename, max_file_size, max_files,
+        compress_extension, std::move(compress_callback), rotate_on_open);
 }
 } // namespace spdlog
 

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -107,7 +107,10 @@ TEST_CASE("rotating_file_logger_compress_callback", "[rotating_logger]]")
     std::string compress_ext = ".gz";
 
     auto callback = [=](spdlog::filename_t filename){
-        // Here could be gzip filename which will rename it to filename.gz
+        // Example usage on *nix OS:
+        // std::system(std::string("gzip " + filename).c_str());
+
+        // for testing we use rename(), simulating gzipping
         rename(filename.c_str(), std::string(filename + compress_ext).c_str());
     };
 


### PR DESCRIPTION
### Added callback to rotating_file_sink

It's possible to use callback for manipulating (compressing, copying somewhere, etc) the newly completed and rotated log file (essentially rotating.1.txt in this example). If that callback compresses and appends extension (ex. .gz) it has to be mentioned in the parameters, otherwise keep it empty string. The callback can be any functional which accepts spdlog::filename_t parameter to manipulate it.

