### PR TITLE
Download googlebenchmark if not found 

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -9,7 +9,24 @@ if(NOT TARGET spdlog)
 endif()
 
 find_package(Threads REQUIRED)
-find_package(benchmark CONFIG REQUIRED)
+find_package(benchmark CONFIG)
+if (NOT benchmark_FOUND)
+    message(STATUS "Using CMake Version ${CMAKE_VERSION}")
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.11.0")
+        # User can fetch googlebenchmark 			
+        message(STATUS "Downloading GoogleBenchmark")
+        include(FetchContent)
+        set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE INTERNAL "")
+        # Do not build and run googlebenchmark tests
+        FetchContent_Declare(googlebenchmark
+            GIT_REPOSITORY https://github.com/google/benchmark.git
+            GIT_TAG v1.5.2)
+
+        FetchContent_MakeAvailable(googlebenchmark)
+    else()
+        message(FATAL_ERROR "GoogleBenchmark is missing. Use CMake >= 3.11 or download it")
+    endif()
+endif()
 
 add_executable(bench bench.cpp)
 spdlog_enable_warnings(bench)


### PR DESCRIPTION
Currently building with `-DSPDLOG_BUILD_ALL=1` fails if googlebench is not installed on the user system (because `bench` depends on googlebench). CMake FetchContent can be used to download and build it (also test it, but I disabled that option) so that the bench build doesn't fail. FetchContent is however only available on CMake 3.11+, hence the hacky version check.

Obviously, the cleaner solution is to bump CMake minimum to 3.11, but I didn't change that because https://github.com/gabime/spdlog/pull/1624

