### PR TITLE
Fix typo in comment

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -111,7 +111,7 @@ SPDLOG_API void set_automatic_registration(bool automatic_registration);
 //
 // The default logger object can be accessed using the spdlog::default_logger():
 // For example, to add another sink to it:
-// spdlog::default_logger()->sinks()->push_back(some_sink);
+// spdlog::default_logger()->sinks().push_back(some_sink);
 //
 // The default logger can replaced using spdlog::set_default_logger(new_logger).
 // For example, to replace it with a file logger.


### PR DESCRIPTION
Replacing a wrong `->` by `.` in a code comment. In the wiki the [same example](https://github.com/gabime/spdlog/wiki/1.1.-Thread-Safety#non-thread-safe-functions) is correct.