### PR TITLE
Ability to get size of messages queue of async thread pool

### DIFF
--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -110,6 +110,12 @@ public:
         return q_.overrun_counter();
     }
 
+    size_t size()
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        return q_.size();
+    }
+
 private:
     std::mutex queue_mutex_;
     std::condition_variable push_cv_;

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -68,6 +68,11 @@ size_t SPDLOG_INLINE thread_pool::overrun_counter()
     return q_.overrun_counter();
 }
 
+size_t SPDLOG_INLINE thread_pool::queue_size()
+{
+    return q_.size();
+}
+
 void SPDLOG_INLINE thread_pool::post_async_msg_(async_msg &&new_msg, async_overflow_policy overflow_policy)
 {
     if (overflow_policy == async_overflow_policy::block)

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -97,6 +97,7 @@ public:
     void post_log(async_logger_ptr &&worker_ptr, const details::log_msg &msg, async_overflow_policy overflow_policy);
     void post_flush(async_logger_ptr &&worker_ptr, async_overflow_policy overflow_policy);
     size_t overrun_counter();
+    size_t queue_size();
 
 private:
     q_type q_;


### PR DESCRIPTION
I want to monitor messages queue size, so I need such method into thread_pool.