### PR TITLE
Add missing include

### DIFF
--- a/include/spdlog/cfg/helpers-inl.h
+++ b/include/spdlog/cfg/helpers-inl.h
@@ -11,6 +11,7 @@
 #include <spdlog/details/os.h>
 #include <spdlog/details/registry.h>
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <sstream>


### PR DESCRIPTION
Hi,

I noticed a missing `<algorithm>` include in `helpers-inl.h`.  It uses std::transform in l. 26 which I assume it previously (for me) got through some chain of other includes. However this breaks for me using external fmt and gcc-10. Anyway, the include should clearly be there, so I added it.

Cheers,
Jonas