### PR TITLE
📝 README example: Add {:a} format flag to bin_to_hex example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ void stopwatch_example()
 // {:s} - don't separate each byte with space.
 // {:p} - don't print the position on each line start.
 // {:n} - don't split the output to lines.
+// {:a} - show ASCII if :n is not set.
 
 #include "spdlog/fmt/bin_to_hex.h"
 


### PR DESCRIPTION
Add {:a} format flag to bin_to_hex example