### PR TITLE
fix shadow warning

### DIFF
--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -1621,8 +1621,8 @@ OutputIt write_nonfinite(OutputIt out, bool isinf,
   constexpr size_t str_size = 3;
   auto sign = fspecs.sign;
   auto size = str_size + (sign ? 1 : 0);
-  using iterator = remove_reference_t<decltype(reserve(out, 0))>;
-  return write_padded(out, specs, size, [=](iterator it) {
+  using pad_iterator = remove_reference_t<decltype(reserve(out, 0))>;
+  return write_padded(out, specs, size, [=](pad_iterator it) {
     if (sign) *it++ = static_cast<Char>(data::signs[sign]);
     return copy_str<Char>(str, str + str_size, it);
   });


### PR DESCRIPTION
When compiling using "-Wshadow", it shows
```
spdlog/fmt/bundled/format.h:1601:11: error: declaration shadows a type alias in 'int_writer<OutputIt, Char, UInt>' [-Werror,-Wshadow]
    using iterator = remove_reference_t<decltype(reserve(out, 0))>;
          ^
spdlog/fmt/bundled/format.h:1490:9: note: previous declaration is here
  using iterator =
        ^
```