### PR TITLE
ensure stdout color sinks do not leak windows headers with SPDLOG_COMPILED_LIB

### DIFF
--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -7,22 +7,30 @@
 #include <spdlog/sinks/wincolor_sink.h>
 #endif
 
+#include <spdlog/details/windows_include.h>
+#include <wincon.h>
+
 #include <spdlog/common.h>
 #include <spdlog/pattern_formatter.h>
 
 namespace spdlog {
 namespace sinks {
-
 template<typename ConsoleMutex>
-SPDLOG_INLINE wincolor_sink<ConsoleMutex>::wincolor_sink(HANDLE out_handle, color_mode mode)
-    : out_handle_(out_handle)
+SPDLOG_INLINE wincolor_sink<ConsoleMutex>::wincolor_sink(void *out_handle, color_mode mode)
+    : BOLD(FOREGROUND_INTENSITY)
+    , RED(FOREGROUND_RED)
+    , GREEN(FOREGROUND_GREEN)
+    , CYAN(FOREGROUND_GREEN | FOREGROUND_BLUE)
+    , WHITE(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE)
+    , YELLOW(FOREGROUND_RED | FOREGROUND_GREEN)
+    , out_handle_(out_handle)
     , mutex_(ConsoleMutex::mutex())
     , formatter_(details::make_unique<spdlog::pattern_formatter>())
 {
     // check if out_handle is points to the actual console.
     // ::GetConsoleMode() should return 0 if it is redirected or not valid console handle.
     DWORD console_mode;
-    in_console_ = ::GetConsoleMode(out_handle, &console_mode) != 0;
+    in_console_ = ::GetConsoleMode(static_cast<HANDLE>(out_handle_), &console_mode) != 0;
 
     set_color_mode(mode);
     colors_[level::trace] = WHITE;
@@ -42,7 +50,7 @@ SPDLOG_INLINE wincolor_sink<ConsoleMutex>::~wincolor_sink()
 
 // change the color for the given level
 template<typename ConsoleMutex>
-void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color(level::level_enum level, WORD color)
+void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color(level::level_enum level, std::uint16_t color)
 {
     std::lock_guard<mutex_t> lock(mutex_);
     colors_[level] = color;
@@ -67,10 +75,10 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::log(const details::log_msg &msg)
         print_range_(formatted, 0, msg.color_range_start);
 
         // in color range
-        auto orig_attribs = set_foreground_color_(colors_[msg.level]);
+        auto orig_attribs = static_cast<WORD>(set_foreground_color_(colors_[msg.level]));
         print_range_(formatted, msg.color_range_start, msg.color_range_end);
         // reset to orig colors
-        ::SetConsoleTextAttribute(out_handle_, orig_attribs);
+        ::SetConsoleTextAttribute(static_cast<HANDLE>(out_handle_), orig_attribs);
         print_range_(formatted, msg.color_range_end, formatted.size());
     }
     else // print without colors if color range is invalid (or color is disabled)
@@ -118,16 +126,16 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color_mode(color_mode mode)
 
 // set foreground color and return the orig console attributes (for resetting later)
 template<typename ConsoleMutex>
-WORD SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_foreground_color_(WORD attribs)
+std::uint16_t SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_foreground_color_(std::uint16_t attribs)
 {
     CONSOLE_SCREEN_BUFFER_INFO orig_buffer_info;
-    ::GetConsoleScreenBufferInfo(out_handle_, &orig_buffer_info);
+    ::GetConsoleScreenBufferInfo(static_cast<HANDLE>(out_handle_), &orig_buffer_info);
     WORD back_color = orig_buffer_info.wAttributes;
     // retrieve the current background color
     back_color &= static_cast<WORD>(~(FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY));
     // keep the background color unchanged
-    ::SetConsoleTextAttribute(out_handle_, attribs | back_color);
-    return orig_buffer_info.wAttributes; // return orig attribs
+    ::SetConsoleTextAttribute(static_cast<HANDLE>(out_handle_), static_cast<WORD>(attribs) | back_color);
+    return static_cast<std::uint16_t>(orig_buffer_info.wAttributes); // return orig attribs
 }
 
 // print a range of formatted message to console
@@ -135,7 +143,7 @@ template<typename ConsoleMutex>
 void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::print_range_(const memory_buf_t &formatted, size_t start, size_t end)
 {
     auto size = static_cast<DWORD>(end - start);
-    ::WriteConsoleA(out_handle_, formatted.data() + start, size, nullptr, nullptr);
+    ::WriteConsoleA(static_cast<HANDLE>(out_handle_), formatted.data() + start, size, nullptr, nullptr);
 }
 
 template<typename ConsoleMutex>
@@ -147,7 +155,7 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::write_to_file_(const memory_buf_
     }
     auto size = static_cast<DWORD>(formatted.size());
     DWORD bytes_written = 0;
-    bool ok = ::WriteFile(out_handle_, formatted.data(), size, &bytes_written, nullptr) != 0;
+    bool ok = ::WriteFile(static_cast<HANDLE>(out_handle_), formatted.data(), size, &bytes_written, nullptr) != 0;
     if (!ok)
     {
         throw_spdlog_ex("wincolor_sink: ::WriteFile() failed. GetLastError(): " + std::to_string(::GetLastError()));
@@ -165,6 +173,5 @@ template<typename ConsoleMutex>
 SPDLOG_INLINE wincolor_stderr_sink<ConsoleMutex>::wincolor_stderr_sink(color_mode mode)
     : wincolor_sink<ConsoleMutex>(::GetStdHandle(STD_ERROR_HANDLE), mode)
 {}
-
 } // namespace sinks
 } // namespace spdlog

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -12,9 +12,7 @@
 #include <mutex>
 #include <string>
 #include <array>
-
-#include <spdlog/details/windows_include.h>
-#include <wincon.h>
+#include <cstdint>
 
 namespace spdlog {
 namespace sinks {
@@ -26,21 +24,21 @@ template<typename ConsoleMutex>
 class wincolor_sink : public sink
 {
 public:
-    const WORD BOLD = FOREGROUND_INTENSITY;
-    const WORD RED = FOREGROUND_RED;
-    const WORD GREEN = FOREGROUND_GREEN;
-    const WORD CYAN = FOREGROUND_GREEN | FOREGROUND_BLUE;
-    const WORD WHITE = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;
-    const WORD YELLOW = FOREGROUND_RED | FOREGROUND_GREEN;
+    const std::uint16_t BOLD;
+    const std::uint16_t RED;
+    const std::uint16_t GREEN;
+    const std::uint16_t CYAN;
+    const std::uint16_t WHITE;
+    const std::uint16_t YELLOW;
 
-    wincolor_sink(HANDLE out_handle, color_mode mode);
+    wincolor_sink(void *out_handle, color_mode mode);
     ~wincolor_sink() override;
 
     wincolor_sink(const wincolor_sink &other) = delete;
     wincolor_sink &operator=(const wincolor_sink &other) = delete;
 
     // change the color for the given level
-    void set_color(level::level_enum level, WORD color);
+    void set_color(level::level_enum level, std::uint16_t color);
     void log(const details::log_msg &msg) final override;
     void flush() final override;
     void set_pattern(const std::string &pattern) override final;
@@ -49,15 +47,15 @@ public:
 
 protected:
     using mutex_t = typename ConsoleMutex::mutex_t;
-    HANDLE out_handle_;
+    void *out_handle_;
     mutex_t &mutex_;
     bool in_console_;
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;
-    std::array<WORD, level::n_levels> colors_;
+    std::array<std::uint16_t, level::n_levels> colors_;
 
     // set foreground color and return the orig console attributes (for resetting later)
-    WORD set_foreground_color_(WORD attribs);
+    std::uint16_t set_foreground_color_(std::uint16_t attribs);
 
     // print a range of formatted message to console
     void print_range_(const memory_buf_t &formatted, size_t start, size_t end);
@@ -85,7 +83,6 @@ using wincolor_stdout_sink_st = wincolor_stdout_sink<details::console_nullmutex>
 
 using wincolor_stderr_sink_mt = wincolor_stderr_sink<details::console_mutex>;
 using wincolor_stderr_sink_st = wincolor_stderr_sink<details::console_nullmutex>;
-
 } // namespace sinks
 } // namespace spdlog
 

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,6 +1,8 @@
 #include "includes.h"
 
-#ifndef _WIN32
+#ifdef _WIN32
+#include <Windows.h>
+#else
 #include <sys/types.h>
 #include <dirent.h>
 #endif


### PR DESCRIPTION
fixes #1770 