### PR TITLE
skip module mode when finding fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 # ---------------------------------------------------------------------------------------
 if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
     if(NOT TARGET fmt::fmt)
-        find_package(fmt 5.3.0 REQUIRED)
+        find_package(fmt 5.3.0 CONFIG REQUIRED)
     endif()
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)


### PR DESCRIPTION
`fmt` provides a config file, so there's no need to waste time trying module mode. Also, it would appear the `CONFIG` option was previously passed, [until being removed in what appears to be an accident?](https://github.com/gabime/spdlog/commit/6fe899af104930c381b8bb0498e93b7a09418241#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL71) In any case, there's no explanation for it, so I assume it will be fine to add it back.