### PR TITLE
Add build2 package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ cmake .. && make -j
 * vcpkg: `vcpkg install spdlog`
 * conan: `spdlog/[>=1.4.1]`
 * conda: `conda install -c conda-forge spdlog`
+* build2: [package `spdlog`](https://cppget.org/spdlog), target `spdlog%lib{spdlog}`
 
 
 ## Features


### PR DESCRIPTION
WARNING: Please do not merge yet! See below.

We are currently in the process of packaging `spdlog` for `build2`, we have it working (even on unsupported Windows, see for example: https://ci.stage.build2.org/@a993b64e-8ba2-422e-97d7-250cdb5828e0?builds=&pv=&tc=*&cf=&mn=&tg=&rs=*)

This change simply adds the necessary information to use this package when using `build2`. Some notes:
 - not sure how to give the info succintly because `build2` allows packages to come from different sources, including the git repository of the package - in doubt I just linked to the future community repository address providing all the info, but the other package manager didn't do it like that so not sure if it's ok for you?; 
 - `build2` distinguish the package (`depends: spdlog <some-version-scheme>`, added in the `manifest` file of a `build2` project) and the target (`spdlog%lib{spdlog}` imported in a `buildfile`) because packages can contain several targets. I was not sure how to formulate that here, so feel free to tell me if I should just provide the name of the package and not more info?

The package isn't available yet so this have to be merged only once it is made available (probably in a few days).