### PR TITLE
CMake: Add SPDLOG_STATIC_VCRT to choose static MSVC runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+cmake_policy(SET CMP0091 NEW)
+
 # ---------------------------------------------------------------------------------------
 # Start spdlog project
 # ---------------------------------------------------------------------------------------
@@ -87,6 +89,7 @@ endif()
 if(WIN32)
     option(SPDLOG_WCHAR_SUPPORT "Support wchar api" OFF)
     option(SPDLOG_WCHAR_FILENAMES "Support wchar filenames" OFF)
+    option(SPDLOG_STATIC_VCRT "Force /MT for static VC runtimes" OFF)
 endif()
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     option(SPDLOG_CLOCK_COARSE
@@ -122,6 +125,10 @@ set(SPDLOG_SRCS src/spdlog.cpp src/stdout_sinks.cpp src/color_sinks.cpp src/file
 
 if(NOT SPDLOG_FMT_EXTERNAL AND NOT SPDLOG_FMT_EXTERNAL_HO)
     list(APPEND SPDLOG_SRCS src/fmt.cpp)
+endif()
+
+if(MSVC AND SPDLOG_STATIC_VCRT)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 if(SPDLOG_BUILD_SHARED OR BUILD_SHARED_LIBS)


### PR DESCRIPTION
This PR simply adds a flag for Windows build to change the target runtime (`/MT`/`/MD`).

The naming comes from SDL2's cmake: https://github.com/libsdl-org/SDL/blob/main/CMakeLists.txt#L226.

I based my tests with this doc: https://stackoverflow.com/a/19487637.