### PR TITLE
WIP: replace SPDLOG_* macros with constexpr funcs + source_location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif ()
 # Compiler config
 # ---------------------------------------------------------------------------------------
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -26,6 +26,18 @@ void custom_flags_example();
 
 int main(int, char *[])
 {
+    spdlog::set_level(spdlog::level::debug);
+
+    spdlog_trace(">>>TRACE");
+    spdlog_logger_trace(spdlog::default_logger_raw(), ">>>TRACE");
+
+    spdlog_debug(">>>DEBUG");
+    spdlog_logger_debug(spdlog::default_logger_raw(), ">>>DEBUG");
+
+    spdlog_critical(">>>CRITICAL");
+    spdlog_logger_critical(spdlog::default_logger_raw(), ">>>CRITICAL");
+
+
     // Log levels can be loaded from argv/env using "SPDLOG_LEVEL"
     load_levels_example();
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <initializer_list>
 #include <exception>
+#include <experimental/source_location>
 #include <string>
 #include <type_traits>
 #include <functional>
@@ -183,8 +184,15 @@ SPDLOG_API void throw_spdlog_ex(std::string msg);
 
 struct source_loc
 {
+    using srcloc = std::experimental::fundamentals_v2::source_location;
+
     constexpr source_loc() = default;
-    constexpr source_loc(const char *filename_in, int line_in, const char *funcname_in)
+    constexpr source_loc(const srcloc& srcloc)
+        : filename{srcloc.file_name()}
+        , line{srcloc.line()}
+        , funcname{srcloc.function_name()}
+    {}
+    constexpr source_loc(const char *filename_in, unsigned line_in, const char *funcname_in)
         : filename{filename_in}
         , line{line_in}
         , funcname{funcname_in}
@@ -195,7 +203,7 @@ struct source_loc
         return line == 0;
     }
     const char *filename{nullptr};
-    int line{0};
+    unsigned line{0};
     const char *funcname{nullptr};
 };
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <experimental/source_location>
 #include <string>
 
 namespace spdlog {
@@ -272,5 +273,174 @@ inline void critical(const T &msg)
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0
 #endif
+
+#ifdef SPDLOG_HEADER_ONLY
+#include "spdlog-inl.h"
+#endif
+
+using srcloc = std::experimental::fundamentals_v2::source_location;
+
+template <typename... Args>
+constexpr void spdlog_logger_call(const srcloc& loc, spdlog::logger* logger, spdlog::level::level_enum level, Args... args)
+{
+    logger->log(spdlog::source_loc{loc}, level, args...);
+}
+
+template <typename... Args>
+struct spdlog_trace
+{
+    constexpr spdlog_trace(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::trace, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_trace
+{
+    constexpr spdlog_logger_trace(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE)
+            spdlog_logger_call(loc, logger, spdlog::level::trace, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_debug
+{
+    constexpr spdlog_debug(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::debug, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_debug
+{
+    constexpr spdlog_logger_debug(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG)
+            spdlog_logger_call(loc, logger, spdlog::level::debug, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_info
+{
+    constexpr spdlog_info(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::info, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_info
+{
+    constexpr spdlog_logger_info(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO)
+            spdlog_logger_call(loc, logger, spdlog::level::info, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_warn
+{
+    constexpr spdlog_warn(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::warn, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_warn
+{
+    constexpr spdlog_logger_warn(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN)
+            spdlog_logger_call(loc, logger, spdlog::level::warn, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_error
+{
+    constexpr spdlog_error(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::err, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_error
+{
+    constexpr spdlog_logger_error(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR)
+            spdlog_logger_call(loc, logger, spdlog::level::err, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_critical
+{
+    constexpr spdlog_critical(Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL)
+            spdlog_logger_call(loc, spdlog::default_logger_raw(), spdlog::level::critical, args...);
+    }
+};
+
+template <typename... Args>
+struct spdlog_logger_critical
+{
+    constexpr spdlog_logger_critical(spdlog::logger* logger, Args&&... args, const srcloc& loc = srcloc::current())
+    {
+        if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL)
+            spdlog_logger_call(loc, logger, spdlog::level::critical, args...);
+    }
+};
+
+template <typename... Args>
+spdlog_trace(Args&&...) -> spdlog_trace<Args...>;
+
+template <typename... Args>
+spdlog_debug(Args&&...) -> spdlog_debug<Args...>;
+
+template <typename... Args>
+spdlog_info(Args&&...) -> spdlog_info<Args...>;
+
+template <typename... Args>
+spdlog_warn(Args&&...) -> spdlog_warn<Args...>;
+
+template <typename... Args>
+spdlog_error(Args&&...) -> spdlog_error<Args...>;
+
+template <typename... Args>
+spdlog_critical(Args&&...) -> spdlog_critical<Args...>;
+
+template <typename... Args>
+spdlog_logger_trace(spdlog::logger*, Args&&...) -> spdlog_logger_trace<Args...>;
+
+template <typename... Args>
+spdlog_logger_debug(spdlog::logger*, Args&&...) -> spdlog_logger_debug<Args...>;
+
+template <typename... Args>
+spdlog_logger_info(spdlog::logger*, Args&&...) -> spdlog_logger_info<Args...>;
+
+template <typename... Args>
+spdlog_logger_warn(spdlog::logger*, Args&&...) -> spdlog_logger_warn<Args...>;
+
+template <typename... Args>
+spdlog_logger_error(spdlog::logger*, Args&&...) -> spdlog_logger_error<Args...>;
+
+template <typename... Args>
+spdlog_logger_critical(spdlog::logger*, Args&&...) -> spdlog_logger_critical<Args...>;
+
 
 #endif // SPDLOG_H


### PR DESCRIPTION
I wanted to investigate what it would take to replace the existing log macros (eg. SPDLOG_TRACE) with constexpr functions that make use of the new `std::source_location` [1] that will be available in GCC11 [2], as originally discussed here:
https://github.com/gabime/spdlog/issues/1823

The idea of `std::source_location` is that you can provide it as a default-value parameter for your log function and it will still log all the info from the call-site.
However, combining default-value params with variadic template functions is almost impossible or at least quite involved. I opted for using `user-defined deduction guides` [3] as advocated on SO [4].

This is more an experiment but please let me know what you think :)
Would this be a direction worth pursuing?


________________________________________________
[1] https://en.cppreference.com/w/cpp/utility/source_location
[2] https://en.cppreference.com/w/cpp/compiler_support
[3] https://en.cppreference.com/w/cpp/language/class_template_argument_deduction#User-defined_deduction_guides
[4] https://stackoverflow.com/questions/57547273/how-to-use-source-location-in-a-variadic-template-function