### PR TITLE
added spdlog::level::set_string_view to enable alternate log level na…

### DIFF
--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -22,6 +22,11 @@ SPDLOG_INLINE const string_view_t &to_string_view(spdlog::level::level_enum l) S
     return level_string_views[l];
 }
 
+SPDLOG_INLINE void set_string_view(spdlog::level::level_enum l, const string_view_t &s) SPDLOG_NOEXCEPT
+{
+    level_string_views[l] = s;
+}
+
 SPDLOG_INLINE const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT
 {
     return short_level_names[l];

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -167,6 +167,7 @@ enum level_enum
 #endif
 
 SPDLOG_API const string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
+SPDLOG_API void set_string_view(spdlog::level::level_enum l, const string_view_t &s) SPDLOG_NOEXCEPT;
 SPDLOG_API const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
 SPDLOG_API spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
 

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -55,6 +55,14 @@ TEST_CASE("level_to_string_view", "[convert_to_string_view")
     REQUIRE(spdlog::level::to_string_view(spdlog::level::off) == "off");
 }
 
+TEST_CASE("set_level_to_string_view", "[set_string_view")
+{
+    spdlog::level::set_string_view(spdlog::level::info, "INF");
+    REQUIRE(spdlog::level::to_string_view(spdlog::level::info) == "INF");
+    spdlog::level::set_string_view(spdlog::level::info, "info"); // set it back
+    REQUIRE(spdlog::level::to_string_view(spdlog::level::info) == "info");
+}
+
 TEST_CASE("to_short_c_str", "[convert_to_short_c_str]")
 {
     REQUIRE(std::string(spdlog::level::to_short_c_str(spdlog::level::trace)) == "T");


### PR DESCRIPTION
…mes without changing the build via SPDLOG_LEVEL_NAMES.  presently we need to clone the repo and create a custom conan package for spdlog just to control the log level strings that appear in the log