### PR TITLE
Remove version requirement from fmt find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 # ---------------------------------------------------------------------------------------
 if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
     if(NOT TARGET fmt::fmt)
-        find_package(fmt 5.3.0 CONFIG REQUIRED)
+        find_package(fmt CONFIG REQUIRED)
     endif()
     target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL)
     target_compile_definitions(spdlog_header_only INTERFACE SPDLOG_FMT_EXTERNAL)


### PR DESCRIPTION
By introducing 'no module' support https://github.com/gabime/spdlog/commit/3d8f71c4d23fd2df08e4f6284155958b0df47b33 this inadvertently triggered the find_package to use the "full version" version selection.

From https://cmake.org/cmake/help/latest/command/find_package.html#version-selection:

> When the [version] argument is given, Config mode will only find a version of the package that claims compatibility with the requested version (see format specification).

FMT does not set this configuration https://github.com/fmtlib/fmt/blob/7.1.3/support/cmake/fmt-config.cmake.in... but regardless it would not be "any compatibility" based on version semantics.

Which causes this error. v1.8.2 builds perfectly fine.

```
CMake Error at CMakeLists.txt:181 (find_package):
  Could not find a configuration file for package "fmt" that is compatible
  with requested version "5.3.0".

  The following configuration files were considered but not accepted:

    /home/proj/build/e98598522b7c484d9220bffc7ec84474515facbc/fmt-config.cmake, version: 7.1.3
```