### PR TITLE
fix bug #1790

### DIFF
--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -15,7 +15,11 @@
 // under windows using fwrite to non-binary stream results in \r\r\n (see issue #1675)
 // so instead we use ::FileWrite
 #include <spdlog/details/windows_include.h>
+
+#ifndef _USING_V110_SDK71_
 #include <fileapi.h> // WriteFile (..)
+#endif
+
 #include <io.h>      // _get_osfhandle(..)
 #include <stdio.h>   // _fileno(..)
 #endif               // WIN32


### PR DESCRIPTION
I'm also stuck at the problem described in issue #1790.
So the PR fix the problem as is in the issue, it just works.

By the way, fully remove **#include <fileapi.h>** is also ok, but as for the code consistency, I think keeping it is a better way.