### PR TITLE
Removed forward declarations

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -78,14 +78,6 @@
 #define SPDLOG_CATCH_ALL() catch (...)
 #endif
 
-namespace spdlog {
-
-class formatter;
-
-namespace sinks {
-class sink;
-}
-
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 using filename_t = std::wstring;
 // allow macro expansion to occur in SPDLOG_FILENAME_T


### PR DESCRIPTION
Since forward declarations are present in the fwd.h header, having them here is redundant