### PR TITLE
Update pattern_formatter-inl.h full_formatter comment to describe the default logging pattern expression accurately

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -925,7 +925,7 @@ private:
 };
 
 // Full info formatter
-// pattern: [%Y-%m-%d %H:%M:%S.%e] [%n] [%l] %v
+// pattern: [%Y-%m-%d %H:%M:%S.%e] [%n] [%l] [%s:%#] %v
 class full_formatter final : public flag_formatter
 {
 public:


### PR DESCRIPTION
Comment describing the default logging pattern is missing [%s:%#], which is the abbreviated source file + the line number.

I tried to customize our own logger by copy pasting this info, and then I noticed we had lost that information.