### PR TITLE
Made mutex member variable mutable

### DIFF
--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -37,7 +37,7 @@ public:
 protected:
     // sink formatter
     std::unique_ptr<spdlog::formatter> formatter_;
-    Mutex mutex_;
+    mutable Mutex mutex_;
 
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;


### PR DESCRIPTION
Classes inheriting from `base_sink` can now lock the base mutex inside their `const` member methods (e.g., basic accessors).