### PR TITLE
Change c-style casts to reinterpret casts in tcp_client

### DIFF
--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -144,7 +144,7 @@ public:
 
         // set TCP_NODELAY
         int enable_flag = 1;
-        ::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char *)&enable_flag, sizeof(enable_flag));
+        ::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&enable_flag), sizeof(enable_flag));
     }
 
     // Send exactly n_bytes of the given data.

--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -103,11 +103,11 @@ public:
 
         // set TCP_NODELAY
         int enable_flag = 1;
-        ::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, (char *)&enable_flag, sizeof(enable_flag));
+        ::setsockopt(socket_, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&enable_flag), sizeof(enable_flag));
 
         // prevent sigpipe on systems where MSG_NOSIGNAL is not available
 #if defined(SO_NOSIGPIPE) && !defined(MSG_NOSIGNAL)
-        ::setsockopt(socket_, SOL_SOCKET, SO_NOSIGPIPE, (char *)&enable_flag, sizeof(enable_flag));
+        ::setsockopt(socket_, SOL_SOCKET, SO_NOSIGPIPE, reinterpret_cast<char *>(&enable_flag), sizeof(enable_flag));
 #endif
 
 #if !defined(SO_NOSIGPIPE) && !defined(MSG_NOSIGNAL)


### PR DESCRIPTION
Changed some c-style casts to use reinterpret casts in tcp_client.h and tcp_client-windows.h. Similar to #1164.

Thanks.