### PR TITLE
Avoid harmless warning about unreachable statement in MSVS build

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -246,7 +246,11 @@ SPDLOG_INLINE size_t filesize(FILE *f)
 #endif
 #endif
     throw_spdlog_ex("Failed getting file size from fd", errno);
+
+    // avoid C4702 warning about unreachable statement.
+#ifndef _MSC_VER
     return 0; // will not be reached.
+#endif
 }
 
 // Return utc offset in minutes or throw spdlog_ex on failure


### PR DESCRIPTION
Don't compile "return 0" after throw_spdlog_ex() when using MSVS as this
compiler (at least its 2019 edition) is smart enough to warn about this
statement being unreachable after throw inside this inline function.