### PR TITLE
Fix warning about testing _WIN64 which might be undefined

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -214,7 +214,7 @@ SPDLOG_INLINE size_t filesize(FILE *f)
     }
 #if defined(_WIN32) && !defined(__CYGWIN__)
     int fd = ::_fileno(f);
-#if _WIN64 // 64 bits
+#if defined(_WIN64) // 64 bits
     __int64 ret = ::_filelengthi64(fd);
     if (ret >= 0)
     {


### PR DESCRIPTION
This warning is disabled by default, but is pretty useful and worth
enabling for MSVC, just as -Wundef for gcc, so fix it in Win32 build.

---

Sorry for another trivial PR, but while testing #1930 I've also stumbled on this one in Win32 build.