### PR TITLE
Allow compilation with nvc++ (and possibly PGI)

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -275,3 +275,4 @@ std::unique_ptr<T> make_unique(Args &&...args)
 #ifdef SPDLOG_HEADER_ONLY
 #include "common-inl.h"
 #endif
+

--- a/include/spdlog/sinks/stdout_color_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_color_sinks-inl.h
@@ -36,3 +36,4 @@ SPDLOG_INLINE std::shared_ptr<logger> stderr_color_st(const std::string &logger_
     return Factory::template create<sinks::stderr_color_sink_st>(logger_name, mode);
 }
 } // namespace spdlog
+

--- a/src/async.cpp
+++ b/src/async.cpp
@@ -11,3 +11,4 @@
 #include <spdlog/details/thread_pool-inl.h>
 
 template class SPDLOG_API spdlog::details::mpmc_blocking_queue<spdlog::details::async_msg>;
+

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -6,3 +6,4 @@
 #endif
 
 #include <spdlog/cfg/helpers-inl.h>
+

--- a/src/color_sinks.cpp
+++ b/src/color_sinks.cpp
@@ -49,3 +49,4 @@ template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_color_mt<spdl
     const std::string &logger_name, color_mode mode);
 template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_color_st<spdlog::async_factory>(
     const std::string &logger_name, color_mode mode);
+

--- a/src/file_sinks.cpp
+++ b/src/file_sinks.cpp
@@ -18,3 +18,4 @@ template class SPDLOG_API spdlog::sinks::basic_file_sink<spdlog::details::null_m
 #include <spdlog/sinks/rotating_file_sink-inl.h>
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<std::mutex>;
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;
+

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -24,3 +24,4 @@
 template SPDLOG_API spdlog::logger::logger(std::string name, sinks_init_list::iterator begin, sinks_init_list::iterator end);
 template class SPDLOG_API spdlog::sinks::base_sink<std::mutex>;
 template class SPDLOG_API spdlog::sinks::base_sink<spdlog::details::null_mutex>;
+

--- a/src/stdout_sinks.cpp
+++ b/src/stdout_sinks.cpp
@@ -27,3 +27,4 @@ template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt<spd
 template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_logger_st<spdlog::async_factory>(const std::string &logger_name);
 template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt<spdlog::async_factory>(const std::string &logger_name);
 template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st<spdlog::async_factory>(const std::string &logger_name);
+


### PR DESCRIPTION
Using CMake, Nvidia's `nvc++` adds the `-A` compiler flag ("strict"), causing compilation error if newlines are missing from the end of source files. `nvc++` (not to be confused with `nvcc`) is detected as the PGI C++ compiler and this patch may therefore also apply to that. Proposed changes involve newlines, only.