### PR TITLE
Fix C++20 build resulting in deprecated implicit copy assignment operator warning

### DIFF
--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -15,6 +15,7 @@ struct SPDLOG_API log_msg
     log_msg(source_loc loc, string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(string_view_t logger_name, level::level_enum lvl, string_view_t msg);
     log_msg(const log_msg &other) = default;
+    log_msg &operator=(const log_msg &other) = default;
 
     string_view_t logger_name;
     level::level_enum level{level::off};


### PR DESCRIPTION
Standard has deprecated implicit copy assignment operator creation - just need to specify the default explicitly. Otherwise results in this error in Clang head:

```
../ExternalLibs/spdlog/include/spdlog/details/log_msg.h:17:5: error: definition of implicit copy assignment operator for 'log_msg' is deprecated because it has a user-declared copy constructor [-Werror,-Wdeprecated-copy]
    log_msg(const log_msg &other) = default;
    ^
../ExternalLibs/spdlog/include/spdlog/details/log_msg_buffer-inl.h:38:14: note: in implicit copy assignment operator for 'spdlog::details::log_msg' first required here
    log_msg::operator=(other);
             ^
1 error generated.
```