### PR TITLE
Fix signed/unsigned mismatch in VS

### DIFF
--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -46,7 +46,7 @@ struct async_factory_impl
         auto tp = registry_inst.get_tp();
         if (tp == nullptr)
         {
-            tp = std::make_shared<details::thread_pool>(details::default_async_q_size, 1);
+            tp = std::make_shared<details::thread_pool>(details::default_async_q_size, 1U);
             registry_inst.set_tp(tp);
         }
 

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -47,7 +47,7 @@ public:
 
 private:
     const int open_tries_ = 5;
-    const int open_interval_ = 10;
+    const unsigned int open_interval_ = 10;
     std::FILE *fd_{nullptr};
     filename_t filename_;
 };

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -366,7 +366,7 @@ SPDLOG_INLINE size_t thread_id() SPDLOG_NOEXCEPT
 
 // This is avoid msvc issue in sleep_for that happens if the clock changes.
 // See https://github.com/gabime/spdlog/issues/609
-SPDLOG_INLINE void sleep_for_millis(int milliseconds) SPDLOG_NOEXCEPT
+SPDLOG_INLINE void sleep_for_millis(unsigned int milliseconds) SPDLOG_NOEXCEPT
 {
 #if defined(_WIN32)
     ::Sleep(milliseconds);

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -74,7 +74,7 @@ SPDLOG_API size_t thread_id() SPDLOG_NOEXCEPT;
 
 // This is avoid msvc issue in sleep_for that happens if the clock changes.
 // See https://github.com/gabime/spdlog/issues/609
-SPDLOG_API void sleep_for_millis(int milliseconds) SPDLOG_NOEXCEPT;
+SPDLOG_API void sleep_for_millis(unsigned int milliseconds) SPDLOG_NOEXCEPT;
 
 SPDLOG_API std::string filename_to_str(const filename_t &filename);
 


### PR DESCRIPTION
When building under VS, I have:

```
[build] [...]\vcpkg\installed\x64-windows\include\spdlog\details\os-inl.h(362,25): warning C4365: 'argument': conversion from 'int' to 'DWORD', signed/unsigned mismatch [[...].vcxproj]
```

This small patch just fix it.

It should be compatible with `std::chrono::milliseconds` where the type of the argument is part of the template;