### PR TITLE
Use std::function for the global error handler

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -195,14 +195,14 @@ SPDLOG_INLINE void registry::flush_every(std::chrono::seconds interval)
     periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
 }
 
-SPDLOG_INLINE void registry::set_error_handler(void (*handler)(const std::string &msg))
+SPDLOG_INLINE void registry::set_error_handler(err_handler handler)
 {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);
     for (auto &l : loggers_)
     {
         l.second->set_error_handler(handler);
     }
-    err_handler_ = handler;
+    err_handler_ = std::move(handler);
 }
 
 SPDLOG_INLINE void registry::apply_all(const std::function<void(const std::shared_ptr<logger>)> &fun)

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -63,7 +63,7 @@ public:
 
     void flush_every(std::chrono::seconds interval);
 
-    void set_error_handler(void (*handler)(const std::string &msg));
+    void set_error_handler(err_handler handler);
 
     void apply_all(const std::function<void(const std::shared_ptr<logger>)> &fun);
 
@@ -99,7 +99,7 @@ private:
     std::unique_ptr<formatter> formatter_;
     spdlog::level::level_enum global_log_level_ = level::info;
     level::level_enum flush_level_ = level::off;
-    void (*err_handler_)(const std::string &msg) = nullptr;
+    err_handler err_handler_;
     std::shared_ptr<thread_pool> tp_;
     std::unique_ptr<periodic_worker> periodic_flusher_;
     std::shared_ptr<logger> default_logger_;


### PR DESCRIPTION
```cpp
// error C2664: 'void spdlog::set_error_handler(void (__cdecl *)(const std::string &))': cannot convert argument 1 from '<lambda_1>' to 'void (__cdecl *)(const std::string &)'
//
spdlog::set_error_handler([&](const std::string &message) { /* ... */ });
spdlog::set_error_handler([=](const std::string &message) { /* ... */ });
```

The pure pointer function type error handler cannot store `lambda with capture` or `std::bind`.

I think this might be a mistake? Because the error handler in `spdlog::logger` is using `err_handler` (`std::function`).

This PR changes the global error handler type from a pure pointer function (`void (*)(const std::string &msg)`) to `err_handler` (`std::function<void(const std::string &err_msg)>`) to fix that problem.