### PR TITLE
Fix runtime when build with -fsanitize=cfi

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -22,13 +22,17 @@
 
 #ifdef SPDLOG_COMPILED_LIB
 #    undef SPDLOG_HEADER_ONLY
-#    if defined(_WIN32) && defined(SPDLOG_SHARED_LIB)
-#        ifdef spdlog_EXPORTS
-#            define SPDLOG_API __declspec(dllexport)
-#        else
-#            define SPDLOG_API __declspec(dllimport)
+#    if defined(SPDLOG_SHARED_LIB)
+#        if defined(_WIN32)
+#            ifdef spdlog_EXPORTS
+#                define SPDLOG_API __declspec(dllexport)
+#            else // !spdlog_EXPORTS
+#                define SPDLOG_API __declspec(dllimport)
+#            endif
+#        else // !defined(_WIN32)
+#            define SPDLOG_API __attribute__((visibility ("default")))
 #        endif
-#    else // !defined(_WIN32) || !defined(SPDLOG_SHARED_LIB)
+#    else // !defined(SPDLOG_SHARED_LIB)
 #        define SPDLOG_API
 #    endif
 #    define SPDLOG_INLINE

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -16,7 +16,7 @@
 namespace spdlog {
 namespace sinks {
 template<typename Mutex>
-class base_sink : public sink
+class SPDLOG_API base_sink : public sink
 {
 public:
     base_sink();


### PR DESCRIPTION
-flto=thin -fvisibility=hidden -fno-sanitize-trap=cfi

See https://gcc.gnu.org/wiki/Visibility