### PR TITLE
Make spdlog_ex::spdlog_ex work with fmt 8.0.0

### DIFF
--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -56,7 +56,7 @@ SPDLOG_INLINE spdlog_ex::spdlog_ex(std::string msg)
 SPDLOG_INLINE spdlog_ex::spdlog_ex(const std::string &msg, int last_errno)
 {
     memory_buf_t outbuf;
-    fmt::format_system_error(outbuf, last_errno, msg);
+    fmt::format_system_error(outbuf, last_errno, msg.c_str());
     msg_ = fmt::to_string(outbuf);
 }
 


### PR DESCRIPTION
[Fmt 8.0.0](https://github.com/fmtlib/fmt/releases/tag/8.0.0) was released two days ago (2021-06-21) and this change is required to use spdlog with the new release. This change is backwards compatible to older versions of fmt. I think the bundled version of fmt should probably be updated too, but I'm not sure the recommended way to do that.