### PR TITLE
Add a color-terminal type

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -415,8 +415,8 @@ SPDLOG_INLINE bool is_color_terminal() SPDLOG_NOEXCEPT
             return true;
         }
 
-        static constexpr std::array<const char *, 15> terms = {{"ansi", "color", "console", "cygwin", "gnome", "konsole", "kterm", "linux",
-            "msys", "putty", "rxvt", "screen", "vt100", "xterm", "alacritty"}};
+        static constexpr std::array<const char *, 16> terms = {{"ansi", "color", "console", "cygwin", "gnome", "konsole", "kterm", "linux",
+            "msys", "putty", "rxvt", "screen", "vt100", "xterm", "alacritty", "vt102"}};
 
         const char *env_term_p = std::getenv("TERM");
         if (env_term_p == nullptr)


### PR DESCRIPTION
I am using spdlog in RISC-V64 machine,
and the COLORTERM in this machine is "vt102",
so open a pr