### PR TITLE
[feature] Support dynamic tag setting in android.

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -261,8 +261,8 @@ void syslog_example()
 void android_example()
 {
     std::string tag = "spdlog-android";
-    auto android_logger = spdlog::android_logger_mt("android", tag);
-    android_logger->critical("Use \"adb shell logcat\" to view this message.");
+    auto android_logger = spdlog::android_logger_mt("android");
+    android_logger->critical("cus_critical_tag", "Use \"adb shell logcat\" to view this message.");
 }
 #endif
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -24,7 +24,7 @@ SPDLOG_INLINE spdlog::async_logger::async_logger(
 {}
 
 // send the log message to the thread pool
-SPDLOG_INLINE void spdlog::async_logger::sink_it_(const details::log_msg &msg)
+SPDLOG_INLINE void spdlog::async_logger::sink_it_(const char*tag, const details::log_msg &msg)
 {
     if (auto pool_ptr = thread_pool_.lock())
     {
@@ -52,7 +52,7 @@ SPDLOG_INLINE void spdlog::async_logger::flush_()
 //
 // backend functions - called from the thread pool to do the actual job
 //
-SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg &msg)
+SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const char*tag, const details::log_msg &msg)
 {
     for (auto &sink : sinks_)
     {
@@ -60,7 +60,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
         {
             SPDLOG_TRY
             {
-                sink->log(msg);
+                sink->log(tag, msg);
             }
             SPDLOG_LOGGER_CATCH()
         }

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -52,9 +52,9 @@ public:
     std::shared_ptr<logger> clone(std::string new_name) override;
 
 protected:
-    void sink_it_(const details::log_msg &msg) override;
+    void sink_it_(const char*tag, const details::log_msg &msg) override;
     void flush_() override;
-    void backend_sink_it_(const details::log_msg &incoming_log_msg);
+    void backend_sink_it_(const char*tag, const details::log_msg &incoming_log_msg);
     void backend_flush_();
 
 private:

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -96,7 +96,7 @@ class formatter;
 namespace sinks {
 class sink;
 }
-
+static const char* spdlog_default_tag = "SPD_Log_TAG";
 #if defined(_WIN32) && defined(SPDLOG_WCHAR_FILENAMES)
 using filename_t = std::wstring;
 // allow macro expansion to occur in SPDLOG_FILENAME_T

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -105,7 +105,7 @@ bool SPDLOG_INLINE thread_pool::process_next_msg_()
     switch (incoming_async_msg.msg_type)
     {
     case async_msg_type::log: {
-        incoming_async_msg.worker_ptr->backend_sink_it_(incoming_async_msg);
+        incoming_async_msg.worker_ptr->backend_sink_it_("", incoming_async_msg);
         return true;
     }
     case async_msg_type::flush: {

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -163,11 +163,11 @@ SPDLOG_INLINE std::shared_ptr<logger> logger::clone(std::string logger_name)
 }
 
 // protected methods
-SPDLOG_INLINE void logger::log_it_(const spdlog::details::log_msg &log_msg, bool log_enabled, bool traceback_enabled)
+SPDLOG_INLINE void logger::log_it_(const char*tag, const spdlog::details::log_msg &log_msg, bool log_enabled, bool traceback_enabled)
 {
     if (log_enabled)
     {
-        sink_it_(log_msg);
+        sink_it_(tag, log_msg);
     }
     if (traceback_enabled)
     {
@@ -175,7 +175,7 @@ SPDLOG_INLINE void logger::log_it_(const spdlog::details::log_msg &log_msg, bool
     }
 }
 
-SPDLOG_INLINE void logger::sink_it_(const details::log_msg &msg)
+SPDLOG_INLINE void logger::sink_it_(const char*tag, const details::log_msg &msg)
 {
     for (auto &sink : sinks_)
     {
@@ -183,7 +183,7 @@ SPDLOG_INLINE void logger::sink_it_(const details::log_msg &msg)
         {
             SPDLOG_TRY
             {
-                sink->log(msg);
+                sink->log(tag, msg);
             }
             SPDLOG_LOGGER_CATCH()
         }
@@ -212,9 +212,9 @@ SPDLOG_INLINE void logger::dump_backtrace_()
     using details::log_msg;
     if (tracer_.enabled())
     {
-        sink_it_(log_msg{name(), level::info, "****************** Backtrace Start ******************"});
-        tracer_.foreach_pop([this](const log_msg &msg) { this->sink_it_(msg); });
-        sink_it_(log_msg{name(), level::info, "****************** Backtrace End ********************"});
+        sink_it_("", log_msg{name(), level::info, "****************** Backtrace Start ******************"});
+        tracer_.foreach_pop([this](const log_msg &msg) { this->sink_it_("", msg); });
+        sink_it_("", log_msg{name(), level::info, "****************** Backtrace End ********************"});
     }
 }
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -132,7 +132,7 @@ public:
     }
 
     template<typename T>
-    void log(const char*tag, level::level_enum lvl, const T &msg)
+    void log(const char* tag, level::level_enum lvl, const T &msg)
     {
         log(tag, source_loc{}, lvl, msg);
     }
@@ -145,7 +145,7 @@ public:
         log(tag, loc, lvl, string_view_t{msg});
     }
 
-    void log(log_clock::time_point log_time, source_loc loc, level::level_enum lvl, string_view_t msg)
+    void log(log_clock::time_point log_time, const char* tag, source_loc loc, level::level_enum lvl, string_view_t msg)
     {
         bool log_enabled = should_log(lvl);
         bool traceback_enabled = tracer_.enabled();
@@ -155,7 +155,7 @@ public:
         }
 
         details::log_msg log_msg(log_time, loc, name_, lvl, msg);
-        log_it_("", log_msg, log_enabled, traceback_enabled);
+        log_it_(tag, log_msg, log_enabled, traceback_enabled);
     }
 
     void log(const char* tag, source_loc loc, level::level_enum lvl, string_view_t msg)
@@ -180,9 +180,9 @@ public:
     template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value &&
                                                   !is_convertible_to_wstring_view<const T &>::value,
                           int>::type = 0>
-    void log(source_loc loc, level::level_enum lvl, const T &msg)
+    void log(const char* tag, source_loc loc, level::level_enum lvl, const T &msg)
     {
-        log(loc, lvl, "{}", msg);
+        log(tag, loc, lvl, "{}", msg);
     }
 
     template<typename T>
@@ -394,7 +394,6 @@ protected:
     // handle errors during logging.
     // default handler prints the error to stderr at max rate of 1 message/sec.
     void err_handler_(const std::string &msg);
-    const char* default_tag() { return spdlog_default_tag; }
 };
 
 void swap(logger &a, logger &b);

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -38,7 +38,7 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color(level::level_enum col
 }
 
 template<typename ConsoleMutex>
-SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg)
+SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const char* tag,  const details::log_msg &msg)
 {
     // Wrap the originally formatted message in color codes.
     // If color is not supported in the terminal, log as is instead.

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -39,7 +39,7 @@ public:
     void set_color_mode(color_mode mode);
     bool should_color();
 
-    void log(const details::log_msg &msg) override;
+    void log(const char* tag, const details::log_msg &msg) override;
     void flush() override;
     void set_pattern(const std::string &pattern) final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;

--- a/include/spdlog/sinks/base_sink-inl.h
+++ b/include/spdlog/sinks/base_sink-inl.h
@@ -23,10 +23,10 @@ SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::base_sink(std::unique_ptr<spdlog:
 {}
 
 template<typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::log(const details::log_msg &msg)
+void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::log(const char* tag, const details::log_msg &msg)
 {
     std::lock_guard<Mutex> lock(mutex_);
-    sink_it_(msg);
+    sink_it_(tag, msg);
 }
 
 template<typename Mutex>

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -29,7 +29,7 @@ public:
     base_sink &operator=(const base_sink &) = delete;
     base_sink &operator=(base_sink &&) = delete;
 
-    void log(const details::log_msg &msg) final;
+    void log(const char* tag, const details::log_msg &msg) final;
     void flush() final;
     void set_pattern(const std::string &pattern) final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final;
@@ -39,7 +39,7 @@ protected:
     std::unique_ptr<spdlog::formatter> formatter_;
     mutable Mutex mutex_;
 
-    virtual void sink_it_(const details::log_msg &msg) = 0;
+    virtual void sink_it_(const char* tag, const details::log_msg &msg) = 0;
     virtual void flush_() = 0;
     virtual void set_pattern_(const std::string &pattern);
     virtual void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter);

--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -26,7 +26,7 @@ SPDLOG_INLINE const filename_t &basic_file_sink<Mutex>::filename() const
 }
 
 template<typename Mutex>
-SPDLOG_INLINE void basic_file_sink<Mutex>::sink_it_(const details::log_msg &msg)
+SPDLOG_INLINE void basic_file_sink<Mutex>::sink_it_(const char*tag, const details::log_msg &msg)
 {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -24,7 +24,7 @@ public:
     const filename_t &filename() const;
 
 protected:
-    void sink_it_(const details::log_msg &msg) override;
+    void sink_it_(const char*tag, const details::log_msg &msg) override;
     void flush_() override;
 
 private:

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -99,7 +99,7 @@ public:
     }
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char*tag, const details::log_msg &msg) override
     {
         auto time = msg.time;
         bool should_rotate = time >= rotation_tp_;

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -61,7 +61,7 @@ protected:
         {
             if (sink->should_log(msg.level))
             {
-                sink->log(msg);
+                sink->log(tag, msg);
             }
         }
     }

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -55,7 +55,7 @@ public:
     }
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char*tag, const details::log_msg &msg) override
     {
         for (auto &sink : sinks_)
         {

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -51,7 +51,7 @@ protected:
     std::string last_msg_payload_;
     size_t skip_counter_ = 0;
 
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char*tag, const details::log_msg &msg) override
     {
         bool filtered = filter_(msg);
         if (!filtered)

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "dist_sink.h"
+#include <spdlog/common.h>
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/log_msg.h>
 
@@ -68,12 +69,12 @@ protected:
             if (msg_size > 0 && static_cast<size_t>(msg_size) < sizeof(buf))
             {
                 details::log_msg skipped_msg{msg.logger_name, level::info, string_view_t{buf, static_cast<size_t>(msg_size)}};
-                dist_sink<Mutex>::sink_it_(skipped_msg);
+                dist_sink<Mutex>::sink_it_(tag, skipped_msg);
             }
         }
 
         // log current message
-        dist_sink<Mutex>::sink_it_(msg);
+        dist_sink<Mutex>::sink_it_(spdlog_default_tag, msg);
         last_msg_time_ = msg.time;
         skip_counter_ = 0;
         last_msg_payload_.assign(msg.payload.data(), msg.payload.data() + msg.payload.size());

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -16,7 +16,7 @@ template<typename Mutex>
 class null_sink : public base_sink<Mutex>
 {
 protected:
-    void sink_it_(const details::log_msg &) override {}
+    void sink_it_(const char* tag, const details::log_msg &) override {}
     void flush_() override {}
 };
 

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -23,7 +23,7 @@ public:
     ostream_sink &operator=(const ostream_sink &) = delete;
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char* tag, const details::log_msg &msg) override
     {
         memory_buf_t formatted;
         base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -56,7 +56,7 @@ public:
     }
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char*tag, const details::log_msg &msg) override
     {
         q_.push_back(details::log_msg_buffer{msg});
     }

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -61,7 +61,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename()
 }
 
 template<typename Mutex>
-SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg)
+SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const char*tag, const details::log_msg &msg)
 {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -27,7 +27,7 @@ public:
     filename_t filename();
 
 protected:
-    void sink_it_(const details::log_msg &msg) override;
+    void sink_it_(const char*tag, const details::log_msg &msg) override;
     void flush_() override;
 
 private:

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -13,7 +13,7 @@ class SPDLOG_API sink
 {
 public:
     virtual ~sink() = default;
-    virtual void log(const details::log_msg &msg) = 0;
+    virtual void log(const char* tag, const details::log_msg &msg) = 0;
     virtual void flush() = 0;
     virtual void set_pattern(const std::string &pattern) = 0;
     virtual void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) = 0;

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -50,7 +50,7 @@ SPDLOG_INLINE stdout_sink_base<ConsoleMutex>::stdout_sink_base(FILE *file)
 }
 
 template<typename ConsoleMutex>
-SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const details::log_msg &msg)
+SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const char* tag, const details::log_msg &msg)
 {
 #ifdef _WIN32
     if (handle_ == INVALID_HANDLE_VALUE)

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -30,7 +30,7 @@ public:
     stdout_sink_base &operator=(const stdout_sink_base &other) = delete;
     stdout_sink_base &operator=(stdout_sink_base &&other) = delete;
 
-    void log(const details::log_msg &msg) override;
+    void log(const char* tag, const details::log_msg &msg) override;
     void flush() override;
     void set_pattern(const std::string &pattern) override;
 

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -45,7 +45,7 @@ public:
     syslog_sink &operator=(const syslog_sink &) = delete;
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char* tag, const details::log_msg &msg) override
     {
         string_view_t payload;
         memory_buf_t formatted;

--- a/include/spdlog/sinks/win_eventlog_sink.h
+++ b/include/spdlog/sinks/win_eventlog_sink.h
@@ -214,7 +214,7 @@ private:
     }
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char* tag, const details::log_msg &msg) override
     {
         using namespace internal;
 

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -49,7 +49,7 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color(level::level_enum leve
 }
 
 template<typename ConsoleMutex>
-void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::log(const details::log_msg &msg)
+void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::log(const char* tag, const details::log_msg &msg)
 {
     if (out_handle_ == nullptr || out_handle_ == INVALID_HANDLE_VALUE)
     {

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -32,7 +32,7 @@ public:
 
     // change the color for the given level
     void set_color(level::level_enum level, std::uint16_t color);
-    void log(const details::log_msg &msg) final override;
+    void log(const char* tag, const details::log_msg &msg) final override;
     void flush() final override;
     void set_pattern(const std::string &pattern) override final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override final;

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -16,7 +16,9 @@ SPDLOG_INLINE void initialize_logger(std::shared_ptr<logger> logger)
 {
     details::registry::instance().initialize_logger(std::move(logger));
 }
-
+SPDLOG_API const char* default_tag() {
+    return spdlog_default_tag;
+}
 SPDLOG_INLINE std::shared_ptr<logger> get(const std::string &name)
 {
     return details::registry::instance().get(name);

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -16,7 +16,8 @@ SPDLOG_INLINE void initialize_logger(std::shared_ptr<logger> logger)
 {
     details::registry::instance().initialize_logger(std::move(logger));
 }
-SPDLOG_API const char* default_tag() {
+SPDLOG_INLINE const char *default_tag()
+{
     return spdlog_default_tag;
 }
 SPDLOG_INLINE std::shared_ptr<logger> get(const std::string &name)

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -46,6 +46,8 @@ inline std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs 
 //   spdlog::initialize_logger(mylogger);
 SPDLOG_API void initialize_logger(std::shared_ptr<logger> logger);
 
+SPDLOG_API const char* default_tag();
+
 // Return an existing logger or nullptr if a logger with such name doesn't
 // exist.
 // example: spdlog::get("my_logger")->info("hello {}", "world");
@@ -237,52 +239,57 @@ inline void critical(const T &msg)
 // SPDLOG_LEVEL_CRITICAL,
 // SPDLOG_LEVEL_OFF
 //
-
-#define SPDLOG_LOGGER_CALL(logger, level, ...) (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+#define SPDLOG_LOGGER_CALL(logger, tag, level, ...) (logger)->log(tag, spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-#define SPDLOG_LOGGER_TRACE(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__)
-#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_TRACE(logger, tag ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::trace, __VA_ARGS__)
+#define SPDLOG_TAG_TRACE(tag, ...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), tag, __VA_ARGS__)
+#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
 #define SPDLOG_TRACE(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
-#define SPDLOG_LOGGER_DEBUG(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::debug, __VA_ARGS__)
-#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_DEBUG(logger, tag, ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::debug, __VA_ARGS__)
+#define SPDLOG_TAG_DEBUG(tag, ...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), tag, __VA_ARGS__)
+#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
 #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::info, __VA_ARGS__)
-#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_INFO(logger, tag, ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::info, __VA_ARGS__)
+#define SPDLOG_TAG_INFO(tag, ...) SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), tag, __VA_ARGS__)
+#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
 #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::warn, __VA_ARGS__)
-#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_WARN(logger, tag, ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::warn, __VA_ARGS__)
+#define SPDLOG_TAG_WARN(tag, ...) SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(),tag,  __VA_ARGS__)
+#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
 #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::err, __VA_ARGS__)
-#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_ERROR(logger, tag, ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::err, __VA_ARGS__)
+#define SPDLOG_TAG_ERROR(tag, ...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), tag, __VA_ARGS__)
+#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
 #define SPDLOG_ERROR(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
-#define SPDLOG_LOGGER_CRITICAL(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::critical, __VA_ARGS__)
-#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_CRITICAL(logger, tag, ...) SPDLOG_LOGGER_CALL(logger, tag, spdlog::level::critical, __VA_ARGS__)
+#define SPDLOG_TAG_CRITICAL(tag, ...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), tag, __VA_ARGS__)
+#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), spdlog::default_tag(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0

--- a/tests/test_daily_logger.cpp
+++ b/tests/test_daily_logger.cpp
@@ -139,7 +139,7 @@ static void test_rotate(int days_to_run, uint16_t max_days, uint16_t expected_n_
     for (int i = 0; i < days_to_run; i++)
     {
         auto offset = std::chrono::seconds{24 * 3600 * i};
-        sink.log(create_msg(offset));
+        sink.log(spdlog::default_tag(), create_msg(offset));
     }
 
     REQUIRE(count_files("test_logs") == static_cast<size_t>(expected_n_files));

--- a/tests/test_dup_filter.cpp
+++ b/tests/test_dup_filter.cpp
@@ -13,7 +13,7 @@ TEST_CASE("dup_filter_test1", "[dup_filter_sink]")
 
     for (int i = 0; i < 10; i++)
     {
-        dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+        dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
     }
 
     REQUIRE(test_sink->msg_counter() == 1);
@@ -30,7 +30,7 @@ TEST_CASE("dup_filter_test2", "[dup_filter_sink]")
 
     for (int i = 0; i < 10; i++)
     {
-        dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+        dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
 
@@ -48,8 +48,8 @@ TEST_CASE("dup_filter_test3", "[dup_filter_sink]")
 
     for (int i = 0; i < 10; i++)
     {
-        dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
-        dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message2"});
+        dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+        dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message2"});
     }
 
     REQUIRE(test_sink->msg_counter() == 20);
@@ -64,9 +64,9 @@ TEST_CASE("dup_filter_test4", "[dup_filter_sink]")
     auto test_sink = std::make_shared<test_sink_mt>();
     dup_sink.add_sink(test_sink);
 
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message"});
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message"});
     REQUIRE(test_sink->msg_counter() == 2);
 }
 
@@ -80,10 +80,10 @@ TEST_CASE("dup_filter_test5", "[dup_filter_sink]")
     test_sink->set_pattern("%v");
     dup_sink.add_sink(test_sink);
 
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
-    dup_sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "message2"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message1"});
+    dup_sink.log(spdlog::default_tag(), spdlog::details::log_msg{"test", spdlog::level::info, "message2"});
 
     REQUIRE(test_sink->msg_counter() == 3); // skip 2 messages but log the "skipped.." message before message2
     REQUIRE(test_sink->lines()[1] == "Skipped 2 duplicate messages..");

--- a/tests/test_errors.cpp
+++ b/tests/test_errors.cpp
@@ -11,7 +11,7 @@
 class failing_sink : public spdlog::sinks::base_sink<std::mutex>
 {
 protected:
-    void sink_it_(const spdlog::details::log_msg &) final
+    void sink_it_(const char* tag, const spdlog::details::log_msg &) final
     {
         throw std::runtime_error("some error happened during log");
     }

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -20,8 +20,8 @@ TEST_CASE("debug and trace w/o format string", "[macros]]")
     logger->set_pattern("%v");
     logger->set_level(spdlog::level::trace);
 
-    SPDLOG_LOGGER_TRACE(logger, "Test message 1");
-    SPDLOG_LOGGER_DEBUG(logger, "Test message 2");
+    SPDLOG_LOGGER_TRACE(logger, spdlog::default_tag(), "Test message 1");
+    SPDLOG_LOGGER_DEBUG(logger, spdlog::default_tag(), "Test message 2");
     logger->flush();
 
     using spdlog::details::os::default_eol;
@@ -47,8 +47,8 @@ TEST_CASE("pass logger pointer", "[macros]")
 {
     auto logger = spdlog::create<spdlog::sinks::null_sink_mt>("refmacro");
     auto &ref = *logger;
-    SPDLOG_LOGGER_TRACE(&ref, "Test message 1");
-    SPDLOG_LOGGER_DEBUG(&ref, "Test message 2");
+    SPDLOG_LOGGER_TRACE(&ref, spdlog::default_tag(), "Test message 1");
+    SPDLOG_LOGGER_DEBUG(&ref, spdlog::default_tag(), "Test message 2");
 }
 
 // ensure that even if right macro level is on- don't evaluate if the logger's level is not high enough

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -236,11 +236,11 @@ TEST_CASE("padding_truncate_funcname", "[pattern_formatter]")
     test_sink.set_formatter(std::move(formatter));
 
     spdlog::details::log_msg msg1{spdlog::source_loc{"ignored", 1, "func"}, "test_logger", spdlog::level::info, "message"};
-    test_sink.log(msg1);
+    test_sink.log(spdlog::default_tag(), msg1);
     REQUIRE(test_sink.lines()[0] == "message [ func]");
 
     spdlog::details::log_msg msg2{spdlog::source_loc{"ignored", 1, "function"}, "test_logger", spdlog::level::info, "message"};
-    test_sink.log(msg2);
+    test_sink.log(spdlog::default_tag(), msg2);
     REQUIRE(test_sink.lines()[1] == "message [funct]");
 }
 
@@ -253,11 +253,11 @@ TEST_CASE("padding_funcname", "[pattern_formatter]")
     test_sink.set_formatter(std::move(formatter));
 
     spdlog::details::log_msg msg1{spdlog::source_loc{"ignored", 1, "func"}, "test_logger", spdlog::level::info, "message"};
-    test_sink.log(msg1);
+    test_sink.log(spdlog::default_tag(), msg1);
     REQUIRE(test_sink.lines()[0] == "message [      func]");
 
     spdlog::details::log_msg msg2{spdlog::source_loc{"ignored", 1, "func567890123"}, "test_logger", spdlog::level::info, "message"};
-    test_sink.log(msg2);
+    test_sink.log(spdlog::default_tag(), msg2);
     REQUIRE(test_sink.lines()[1] == "message [func567890123]");
 }
 

--- a/tests/test_sink.h
+++ b/tests/test_sink.h
@@ -47,7 +47,7 @@ public:
     }
 
 protected:
-    void sink_it_(const details::log_msg &msg) override
+    void sink_it_(const char* tag, const details::log_msg &msg) override
     {
         memory_buf_t formatted;
         base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/tests/test_time_point.cpp
+++ b/tests/test_time_point.cpp
@@ -19,10 +19,10 @@ TEST_CASE("time_point1", "[time_point log_msg]")
         test_sink->log(spdlog::default_tag(), msg);
     }
 
-    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
-    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
-    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
-    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
+    logger.log(spdlog::default_tag(), tp, source, spdlog::level::info, "formatted message");
+    logger.log(spdlog::default_tag(), tp, source, spdlog::level::info, "formatted message");
+    logger.log(spdlog::default_tag(), tp, source, spdlog::level::info, "formatted message");
+    logger.log(spdlog::default_tag(), tp, source, spdlog::level::info, "formatted message");
     logger.log(spdlog::default_tag(), source, spdlog::level::info, "formatted message"); // last line has different time_point
 
     // now the real test... that the times are the same.

--- a/tests/test_time_point.cpp
+++ b/tests/test_time_point.cpp
@@ -16,14 +16,14 @@ TEST_CASE("time_point1", "[time_point log_msg]")
     for (int i = 0; i < 5; i++)
     {
         spdlog::details::log_msg msg{tp, source, "test_logger", spdlog::level::info, "message"};
-        test_sink->log(msg);
+        test_sink->log(spdlog::default_tag(), msg);
     }
 
-    logger.log(tp, source, spdlog::level::info, "formatted message");
-    logger.log(tp, source, spdlog::level::info, "formatted message");
-    logger.log(tp, source, spdlog::level::info, "formatted message");
-    logger.log(tp, source, spdlog::level::info, "formatted message");
-    logger.log(source, spdlog::level::info, "formatted message"); // last line has different time_point
+    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
+    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
+    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
+    logger.log(tp, spdlog::default_tag(), source, spdlog::level::info, "formatted message");
+    logger.log(spdlog::default_tag(), source, spdlog::level::info, "formatted message"); // last line has different time_point
 
     // now the real test... that the times are the same.
     std::vector<std::string> lines = test_sink->lines();


### PR DESCRIPTION
[feature] Support dynamic tag setting in android.
[change] Modify the Android example, and other examples fail to run error.

Support for dynamically modifying the TAG value in Android is achieved by adding a tag parameter to sink_it_ in base_sink. 