### PR TITLE
Fix compilation error in clang 13 in C++20 mode - ambiguous call to log function

### DIFF
--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -102,13 +102,13 @@ public:
         log(loc, lvl, string_view_t{msg});
     }
 
-    // T cannot be statically converted to niether string_view, neither wstring_view and niether to format string
-    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value 
-        && !is_convertible_to_basic_format_string<const T&>::value,
-            int>::type = 0>
+    // T cannot be statically converted to neither string_view, nor wstring_view and nor format string
+    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value &&
+                                                  !is_convertible_to_basic_format_string<const T &>::value,
+                          int>::type = 0>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
-        log(loc, lvl, "{}", msg);        
+        log(loc, lvl, "{}", msg);
     }
 
     void log(log_clock::time_point log_time, source_loc loc, level::level_enum lvl, string_view_t msg)
@@ -141,7 +141,7 @@ public:
     {
         log(source_loc{}, lvl, msg);
     }
-    
+
     template<typename... Args>
     void trace(fmt::format_string<Args...> fmt, Args &&...args)
     {


### PR DESCRIPTION
To reproduce, you will need to install clang 13 development branch:
```
mkdir build
cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=Debug -DSPDLOG_BUILD_TESTS=ON -DCMAKE_CXX_COMPILER=clang++-13 -DSPDLOG_BUILD_EXAMPLE=ON ..
make
...
spdlog/include/spdlog/logger.h:95:9: error: call to member function 'log' is ambiguous
        log(source_loc{}, lvl, msg);
        ^~~
spdlog/include/spdlog/logger.h:238:9: note: in instantiation of function template specialization 'spdlog::logger::log<char [38]>' requested here
        log(level::debug, msg);
        ^
spdlog/include/spdlog/spdlog.h:249:27: note: in instantiation of function template specialization 'spdlog::logger::debug<char [38]>' requested here
    default_logger_raw()->debug(msg);
                          ^
spdlog/example/example.cpp:43:13: note: in instantiation of function template specialization 'spdlog::debug<char [38]>' requested here
    spdlog::debug("This message should not be displayed!");
            ^
spdlog/include/spdlog/logger.h:100:10: note: candidate function [with T = char [38], $1 = 0]
    void log(source_loc loc, level::level_enum lvl, const T &msg)
         ^
spdlog/include/spdlog/logger.h:138:10: note: candidate function [with T = char [38], $1 = 0]
    void log(source_loc loc, level::level_enum lvl, const T &msg)
         ^
```

Not sure if this is an issue coming from clang 13 in C++20 mode - but the 2 enable_if in logger.h are anyway not complement to each other.

Issue appeared recently (in **1.9** version), it is compiling fine with **v1.8.5**


