### PR TITLE
Trim the newline-chars instead of removing of 2 chars

### DIFF
--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -39,7 +39,7 @@ public:
 
     void append(const spdlog::string_view_t &str)
     {
-        emit append_text(QString::fromUtf8(str.data(), static_cast<int>(str.size() - 2)));
+        emit append_text( QString::fromUtf8(str.data(), static_cast<int>(str.size())).trimmed() );
     }
 
 signals:
@@ -69,7 +69,7 @@ public:
 
     void append(const spdlog::string_view_t &str)
     {
-        emit append_text(QString::fromUtf8(str.data(), static_cast<int>(str.size() - 2)));
+        emit append_text( QString::fromUtf8(str.data(), static_cast<int>(str.size())).trimmed() );
     }
 
 signals:


### PR DESCRIPTION
Removing 2 chars (CR/LF) is under Windows okay, but on Linux only one char (LF) has to be deleted. Otherwise a char of the content is removed. So the fix is to use the QString method `trimmed()` to remove the CR/LF or LF chars.