### PR TITLE
Removal of C++14-specific std::make_unique from mongo_sink.h

### DIFF
--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -33,7 +33,7 @@ public:
     {
         try
         {
-            client_ = std::make_unique<mongocxx::client>(mongocxx::uri{uri});
+            client_ = spdlog::details::make_unique<mongocxx::client>(mongocxx::uri{uri});
             db_name_ = db_name;
             coll_name_ = collection_name;
         }


### PR DESCRIPTION
mongo_sink.h used `std::make_unique` instead of `spdlog::details::make_unique`, thus making it impossible to compile a project under C++11 which spdlog itself targets. While mongocxx requires use of polyfills to work under C++11, it should not be a case with a spdlog project that just links with it