### PR TITLE
fix include file twice in the same file

### DIFF
--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -27,7 +27,6 @@ enum class async_msg_type
     terminate
 };
 
-#include <spdlog/details/log_msg_buffer.h>
 // Async msg to move to/from the queue
 // Movable only. should never be copied
 struct async_msg : log_msg_buffer


### PR DESCRIPTION
there is one head file be included twice in the thread_pool.h, I just delete duplicate one.