### PR TITLE
delete useless mutable keyword

### DIFF
--- a/include/spdlog/details/backtracer.h
+++ b/include/spdlog/details/backtracer.h
@@ -17,7 +17,7 @@ namespace spdlog {
 namespace details {
 class SPDLOG_API backtracer
 {
-    mutable std::mutex mutex_;
+    std::mutex mutex_;
     std::atomic<bool> enabled_{false};
     circular_q<log_msg_buffer> messages_;
 


### PR DESCRIPTION
as far as i known, mutable keyword is used in some class with const member function. backtracer seems not meet this rule