### PR TITLE
Ensure exported package is relocatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,7 +307,8 @@ if(SPDLOG_INSTALL)
     install(EXPORT spdlog DESTINATION ${export_dest_dir} NAMESPACE spdlog:: FILE ${config_targets_file})
 
     include(CMakePackageConfigHelpers)
-    configure_file("${project_config_in}" "${project_config_out}" @ONLY)
+    configure_package_config_file("${project_config_in}" "${project_config_out}"
+        INSTALL_DESTINATION ${export_dest_dir})
 
     write_basic_package_version_file("${version_config_file}" COMPATIBILITY SameMajorVersion)
     install(FILES "${project_config_out}" "${version_config_file}" DESTINATION "${export_dest_dir}")

--- a/cmake/spdlogConfig.cmake.in
+++ b/cmake/spdlogConfig.cmake.in
@@ -1,6 +1,8 @@
 # Copyright(c) 2019 spdlog authors
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
+@PACKAGE_INIT@
+
 find_package(Threads REQUIRED)
 
 set(SPDLOG_FMT_EXTERNAL @SPDLOG_FMT_EXTERNAL@)
@@ -13,3 +15,5 @@ endif()
 
 
 include("${CMAKE_CURRENT_LIST_DIR}/${config_targets_file}")
+
+check_required_components(spdlog)


### PR DESCRIPTION
As per CMake's Importing and Exporting Guide[1],
configure_package_config_file() should be used for configuring the
package configuration file, not the regular configure_file() function.

This ensures that a spdlog package built on one system (with a given
directory tree) can be imported from a different system -
e.g. creating a pre-compiled spdlog package for use on different
systems.

[1]: https://cmake.org/cmake/help/git-stage/guide/importing-exporting/index.html#id8