### PR TITLE
remove std::distance usage

### DIFF
--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -34,7 +34,7 @@ SPDLOG_INLINE spdlog::level::level_enum from_str(const std::string &name) SPDLOG
 {
     auto it = std::find(std::begin(level_string_views), std::end(level_string_views), name);
     if (it != std::end(level_string_views))
-        return static_cast<level::level_enum>(std::distance(std::begin(level_string_views), it));
+        return static_cast<level::level_enum>(it - std::begin(level_string_views));
 
     // check also for "warn" and "err" before giving up..
     if (name == "warn")


### PR DESCRIPTION
std::distance internally runs a loop, which may or may not be optimized
away. Just use simple arithmetic.

Signed-off-by: Rosen Penev <rosenp@gmail.com>