### PR TITLE
bin_to_hex.h: include spdlog.h 

### DIFF
--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <cctype>
-#include <spdlog/spdlog.h>
+#include <spdlog/common.h>
 
 //
 // Support for logging binary data as hex

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <cctype>
+#include <spdlog/spdlog.h>
 
 //
 // Support for logging binary data as hex


### PR DESCRIPTION
The goal is to support inclusion of `bin_to_hex.h` in any order with `spdlog.h`

PROBLEM FIXED (UNWANTED COMPILATION BEHAVIOR):
Some projects require sorting inclusions in alphabetical order. But in case one includes `<spdlog/fmt/bin_to_hex.h>` prior to `<spdlog/spdlog.h>`, multiple compilation errors arise:
* `bin_to_hex.h:35:45: error: ‘size_t’ has not been declared`
* `bin_to_hex.h:59:42: error: ‘begin’ is not a member of ‘std’`
* `bin_to_hex.h:59:65: error: ‘end’ is not a member of ‘std’`
* `bin_to_hex.h:83:5: error: ‘FMT_CONSTEXPR’ does not name a type`
* `bin_to_hex.h:115:9: error: ‘SPDLOG_CONSTEXPR’ was not declared in this scope`
and so on...

(My compiler is GCC 10.3)

This PR adds an include of `spdlog.h` into `bin_to_hex.h`, so they can be included in any order.