### PR TITLE
The install instructions for "header only" refers to the wrong folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Very fast, header-only/compiled, C++ logging library. [![Build Status](https://t
 
 ## Install 
 #### Header only version
-Copy the source [folder](https://github.com/gabime/spdlog/tree/v1.x/include/spdlog) to your build tree and use a C++11 compiler.
+Copy the include [folder](https://github.com/gabime/spdlog/tree/v1.x/include/spdlog) to your build tree and use a C++11 compiler.
 
 #### Static lib version (recommended - much faster compile times)
 ```console


### PR DESCRIPTION
Source makes me think the instruction is to copy `src`, not `include`. Changed the text accordingly.