### PR TITLE
Fix #2034

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -116,6 +116,17 @@ using wstring_view_t = fmt::basic_string_view<wchar_t>;
 using memory_buf_t = fmt::basic_memory_buffer<char, 250>;
 using wmemory_buf_t = fmt::basic_memory_buffer<wchar_t, 250>;
 
+template<class T>
+using remove_cvref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+// clang doesn't like SFINAE disabled constructor in std::is_convertible<> so have to repeat the condition from basic_format_string here,
+// in addition, fmt::basic_runtime<Char> is only convertible to basic_format_string<Char> but not basic_string_view<Char>
+template<class T, class Char = char>
+struct is_convertible_to_basic_format_string
+    : std::integral_constant<bool,
+          std::is_convertible<T, fmt::basic_string_view<Char>>::value || std::is_same<remove_cvref_t<T>, fmt::basic_runtime<Char>>::value>
+{};
+
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
 #    ifndef _WIN32
 #        error SPDLOG_WCHAR_TO_UTF8_SUPPORT only supported on windows
@@ -123,9 +134,9 @@ using wmemory_buf_t = fmt::basic_memory_buffer<wchar_t, 250>;
 template<typename T>
 struct is_convertible_to_wstring_view : std::is_convertible<T, wstring_view_t>
 {};
+
 template<class T>
-struct is_convertible_to_wformat_string : std::is_convertible<T, fmt::wformat_string<>>
-{};
+using is_convertible_to_wformat_string = is_convertible_to_basic_format_string<T, wchar_t>;
 #    endif // _WIN32
 #else
 template<typename>
@@ -137,8 +148,12 @@ struct is_convertible_to_wformat_string : std::false_type
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
 template<class T>
-struct is_convertible_to_basic_format_string
-    : std::integral_constant<bool, std::is_convertible<const T &, fmt::format_string<>>::value || is_convertible_to_wformat_string<T>::value>
+struct is_convertible_to_any_string_view
+    : std::integral_constant<bool, std::is_convertible<T, string_view_t>::value || is_convertible_to_wstring_view<T>::value>
+{};
+template<class T>
+struct is_convertible_to_any_format_string
+    : std::integral_constant<bool, is_convertible_to_basic_format_string<T, char>::value || is_convertible_to_wformat_string<T>::value>
 {};
 
 #if defined(SPDLOG_NO_ATOMIC_LEVELS)

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -130,30 +130,12 @@ struct is_convertible_to_basic_format_string
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
 #    ifndef _WIN32
 #        error SPDLOG_WCHAR_TO_UTF8_SUPPORT only supported on windows
-#    else
-template<typename T>
-struct is_convertible_to_wstring_view : std::is_convertible<T, wstring_view_t>
-{};
-
-template<class T>
-using is_convertible_to_wformat_string = is_convertible_to_basic_format_string<T, wchar_t>;
 #    endif // _WIN32
-#else
-template<typename>
-struct is_convertible_to_wstring_view : std::false_type
-{};
-template<class>
-struct is_convertible_to_wformat_string : std::false_type
-{};
-#endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT
+#endif     // SPDLOG_WCHAR_TO_UTF8_SUPPORT
 
 template<class T>
-struct is_convertible_to_any_string_view
-    : std::integral_constant<bool, std::is_convertible<T, string_view_t>::value || is_convertible_to_wstring_view<T>::value>
-{};
-template<class T>
-struct is_convertible_to_any_format_string
-    : std::integral_constant<bool, is_convertible_to_basic_format_string<T, char>::value || is_convertible_to_wformat_string<T>::value>
+struct is_convertible_to_any_format_string : std::integral_constant<bool, is_convertible_to_basic_format_string<T, char>::value ||
+                                                                              is_convertible_to_basic_format_string<T, wchar_t>::value>
 {};
 
 #if defined(SPDLOG_NO_ATOMIC_LEVELS)

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -103,9 +103,9 @@ public:
     }
 
     // T cannot be statically converted to neither string_view, nor wstring_view and nor format string
-    template<class T, typename std::enable_if<!std::is_convertible<const T &, spdlog::string_view_t>::value &&
-                                                  !is_convertible_to_basic_format_string<const T &>::value,
-                          int>::type = 0>
+    template<class T,
+        typename std::enable_if<
+            !is_convertible_to_any_string_view<const T &>::value && !is_convertible_to_any_format_string<const T &>::value, int>::type = 0>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         log(loc, lvl, "{}", msg);

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -102,10 +102,8 @@ public:
         log(loc, lvl, string_view_t{msg});
     }
 
-    // T cannot be statically converted to neither string_view, nor wstring_view and nor format string
-    template<class T,
-        typename std::enable_if<
-            !is_convertible_to_any_string_view<const T &>::value && !is_convertible_to_any_format_string<const T &>::value, int>::type = 0>
+    // T cannot be statically converted to format string (including string_view)
+    template<class T, typename std::enable_if<!is_convertible_to_any_format_string<const T &>::value, int>::type = 0>
     void log(source_loc loc, level::level_enum lvl, const T &msg)
     {
         log(loc, lvl, "{}", msg);


### PR DESCRIPTION
For some reason clang doesn't like a disabled constructor in `std::is_convertible` so conversion to format strings has to be replaced by conversion to equivalent string views as in `fmt`.

This time also tested with Clang 12.0.1 C++20. Might be a good idea to add C++20 to CI.

Fixes #2034