### PR TITLE
Added additional information for error handler

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -80,7 +80,11 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
         {
             sink->flush();
         }
+#if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
+        SPDLOG_LOGGER_CATCH(wstring_view_t())
+#else
         SPDLOG_LOGGER_CATCH(string_view_t())
+#endif
     }
 }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -80,11 +80,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
         {
             sink->flush();
         }
-#if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
-        SPDLOG_LOGGER_CATCH(wstring_view_t())
-#else
-        SPDLOG_LOGGER_CATCH(string_view_t())
-#endif
+        SPDLOG_LOGGER_CATCH("")
     }
 }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -62,7 +62,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
             {
                 sink->log(msg);
             }
-            SPDLOG_LOGGER_CATCH(msg.payload)
+            SPDLOG_LOGGER_CATCH(msg.source)
         }
     }
 
@@ -80,7 +80,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH("")
+        SPDLOG_LOGGER_CATCH(source_loc())
     }
 }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -80,7 +80,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH("")
+        SPDLOG_LOGGER_CATCH(string_view_t())
     }
 }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -62,7 +62,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
             {
                 sink->log(msg);
             }
-            SPDLOG_LOGGER_CATCH()
+            SPDLOG_LOGGER_CATCH(msg.payload)
         }
     }
 
@@ -80,7 +80,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH()
+        SPDLOG_LOGGER_CATCH("")
     }
 }
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -203,11 +203,7 @@ SPDLOG_INLINE void logger::flush_()
         {
             sink->flush();
         }
-#if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
-        SPDLOG_LOGGER_CATCH(wstring_view_t())
-#else
-        SPDLOG_LOGGER_CATCH(string_view_t())
-#endif
+        SPDLOG_LOGGER_CATCH("")
     }
 }
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -203,7 +203,7 @@ SPDLOG_INLINE void logger::flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH("")
+        SPDLOG_LOGGER_CATCH(string_view_t())
     }
 }
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -185,7 +185,7 @@ SPDLOG_INLINE void logger::sink_it_(const details::log_msg &msg)
             {
                 sink->log(msg);
             }
-            SPDLOG_LOGGER_CATCH()
+            SPDLOG_LOGGER_CATCH(msg.payload)
         }
     }
 
@@ -203,7 +203,7 @@ SPDLOG_INLINE void logger::flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH()
+        SPDLOG_LOGGER_CATCH("")
     }
 }
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -185,7 +185,7 @@ SPDLOG_INLINE void logger::sink_it_(const details::log_msg &msg)
             {
                 sink->log(msg);
             }
-            SPDLOG_LOGGER_CATCH(msg.payload)
+            SPDLOG_LOGGER_CATCH(msg.source)
         }
     }
 
@@ -203,7 +203,7 @@ SPDLOG_INLINE void logger::flush_()
         {
             sink->flush();
         }
-        SPDLOG_LOGGER_CATCH("")
+        SPDLOG_LOGGER_CATCH(source_loc())
     }
 }
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -203,7 +203,11 @@ SPDLOG_INLINE void logger::flush_()
         {
             sink->flush();
         }
+#if (defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT) || defined(SPDLOG_WCHAR_FILENAMES)) && defined(_WIN32)
+        SPDLOG_LOGGER_CATCH(wstring_view_t())
+#else
         SPDLOG_LOGGER_CATCH(string_view_t())
+#endif
     }
 }
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -28,10 +28,24 @@
 #include <vector>
 
 #ifndef SPDLOG_NO_EXCEPTIONS
-#    define SPDLOG_LOGGER_CATCH(additional_info)                                                                                                          \
+#    define SPDLOG_LOGGER_CATCH(location)                                                                                                  \
         catch (const std::exception &ex)                                                                                                   \
         {                                                                                                                                  \
-            err_handler_(fmt::format("{} ({})", ex.what(), additional_info));                                                                                                       \
+            if(location.filename)                                                                                                          \
+            {                                                                                                                              \
+                try                                                                                                                        \
+                {                                                                                                                          \
+                    err_handler_(fmt::format("{} [{}({})]", ex.what(), location.filename, location.line));                                \
+                }                                                                                                                          \
+                catch (const std::exception &ex)                                                                                           \
+                {                                                                                                                          \
+                    err_handler_(ex.what());                                                                                               \
+                }                                                                                                                          \
+            }                                                                                                                              \
+            else                                                                                                                           \
+            {                                                                                                                              \
+                err_handler_(ex.what());                                                                                                   \
+            }                                                                                                                              \
         }                                                                                                                                  \
         catch (...)                                                                                                                        \
         {                                                                                                                                  \
@@ -333,7 +347,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH(fmt)
+        SPDLOG_LOGGER_CATCH(loc)
     }
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
@@ -356,9 +370,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-		// TODO: This isn't working yet.
-        SPDLOG_LOGGER_CATCH("")
-		//SPDLOG_LOGGER_CATCH(fmt)
+        SPDLOG_LOGGER_CATCH(loc)
     }
 
     // T can be statically converted to wstring_view, and no formatting needed.
@@ -378,9 +390,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-		// TODO: This isn't working yet.
-		SPDLOG_LOGGER_CATCH("")
-        //SPDLOG_LOGGER_CATCH(msg)
+        SPDLOG_LOGGER_CATCH(loc)
     }
 
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -356,7 +356,9 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH(fmt)
+		// TODO: This isn't working yet.
+        SPDLOG_LOGGER_CATCH("")
+		//SPDLOG_LOGGER_CATCH(fmt)
     }
 
     // T can be statically converted to wstring_view, and no formatting needed.
@@ -376,7 +378,9 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH(msg)
+		// TODO: This isn't working yet.
+		SPDLOG_LOGGER_CATCH("")
+        //SPDLOG_LOGGER_CATCH(msg)
     }
 
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -33,14 +33,7 @@
         {                                                                                                                                  \
             if(location.filename)                                                                                                          \
             {                                                                                                                              \
-                try                                                                                                                        \
-                {                                                                                                                          \
-                    err_handler_(fmt::format("{} [{}({})]", ex.what(), location.filename, location.line));                                \
-                }                                                                                                                          \
-                catch (const std::exception &ex)                                                                                           \
-                {                                                                                                                          \
-                    err_handler_(ex.what());                                                                                               \
-                }                                                                                                                          \
+                err_handler_(fmt::format("{} [{}({})]", ex.what(), location.filename, location.line));                                     \
             }                                                                                                                              \
             else                                                                                                                           \
             {                                                                                                                              \

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -28,10 +28,10 @@
 #include <vector>
 
 #ifndef SPDLOG_NO_EXCEPTIONS
-#    define SPDLOG_LOGGER_CATCH()                                                                                                          \
+#    define SPDLOG_LOGGER_CATCH(additional_info)                                                                                                          \
         catch (const std::exception &ex)                                                                                                   \
         {                                                                                                                                  \
-            err_handler_(ex.what());                                                                                                       \
+            err_handler_(fmt::format("{} ({})", ex.what(), additional_info));                                                                                                       \
         }                                                                                                                                  \
         catch (...)                                                                                                                        \
         {                                                                                                                                  \
@@ -39,7 +39,7 @@
             throw;                                                                                                                         \
         }
 #else
-#    define SPDLOG_LOGGER_CATCH()
+#    define SPDLOG_LOGGER_CATCH(additional_info)
 #endif
 
 namespace spdlog {
@@ -333,7 +333,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH()
+        SPDLOG_LOGGER_CATCH(fmt)
     }
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
@@ -356,7 +356,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH()
+        SPDLOG_LOGGER_CATCH(fmt)
     }
 
     // T can be statically converted to wstring_view, and no formatting needed.
@@ -376,7 +376,7 @@ protected:
             details::log_msg log_msg(loc, name_, lvl, string_view_t(buf.data(), buf.size()));
             log_it_(log_msg, log_enabled, traceback_enabled);
         }
-        SPDLOG_LOGGER_CATCH()
+        SPDLOG_LOGGER_CATCH(msg)
     }
 
 #endif // SPDLOG_WCHAR_TO_UTF8_SUPPORT


### PR DESCRIPTION
Useful when formatting log messages fails. Now you can tell which log message caused the problem.