### PR TITLE
CMake: Support <PackageName>_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,6 @@ message(STATUS "Build spdlog: ${SPDLOG_VERSION}")
 include(GNUInstallDirs)
 
 # ---------------------------------------------------------------------------------------
-# Set CMake policies to support later version behaviour
-# ---------------------------------------------------------------------------------------
-if(POLICY CMP0077)
-    cmake_policy(SET CMP0077 NEW) # option() honors variables already set
-endif()
-
-# ---------------------------------------------------------------------------------------
 # Set default build to release
 # ---------------------------------------------------------------------------------------
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.21)
 
 # ---------------------------------------------------------------------------------------
 # Start spdlog project


### PR DESCRIPTION
I am no expert in all the policies, but I have seen no issues when using it with cmake 3.21.2.
My main user-case is getting `fmt_ROOT` to work (CMP0074).