### PR TITLE
No need to define the Mutex mutex_ as mutable there is no const method.

### DIFF
--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -37,7 +37,7 @@ public:
 protected:
     // sink formatter
     std::unique_ptr<spdlog::formatter> formatter_;
-    mutable Mutex mutex_;
+    Mutex mutex_;
 
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;


### PR DESCRIPTION
There's no need to define the Mutex mutex_ as mutable since class base_sink has no const method. Related issue is seen at https://github.com/gabime/spdlog/issues/2139