### PR TITLE
the abstract interfaces should be private other than protected

### DIFF
--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -38,7 +38,8 @@ protected:
     // sink formatter
     std::unique_ptr<spdlog::formatter> formatter_;
     Mutex mutex_;
-
+    
+private:
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;
     virtual void set_pattern_(const std::string &pattern);


### PR DESCRIPTION
The abstract interfaces of `class base_sink` should be private other than protected. These methods won't be invoked by any derived class.