### PR TITLE
Add %N log pattern formatter for logging the thread name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 
 option(SPDLOG_PREVENT_CHILD_FD "Prevent from child processes to inherit log file descriptors" OFF)
 option(SPDLOG_NO_THREAD_ID "prevent spdlog from querying the thread id on each log call if thread id is not needed" OFF)
+option(SPDLOG_NO_PTHREAD_ID "prevent spdlog from querying the pthread id on each log call if pthread id is not needed (required for %N)" ON)
 option(SPDLOG_NO_TLS "prevent spdlog from using thread local storage" OFF)
 option(
     SPDLOG_NO_ATOMIC_LEVELS
@@ -220,6 +221,7 @@ foreach(
     SPDLOG_CLOCK_COARSE
     SPDLOG_PREVENT_CHILD_FD
     SPDLOG_NO_THREAD_ID
+    SPDLOG_NO_PTHREAD_ID
     SPDLOG_NO_TLS
     SPDLOG_NO_ATOMIC_LEVELS
     SPDLOG_DISABLE_DEFAULT_LOGGER)

--- a/include/spdlog/details/log_msg-inl.h
+++ b/include/spdlog/details/log_msg-inl.h
@@ -20,6 +20,9 @@ SPDLOG_INLINE log_msg::log_msg(spdlog::log_clock::time_point log_time, spdlog::s
 #ifndef SPDLOG_NO_THREAD_ID
     , thread_id(os::thread_id())
 #endif
+#ifndef SPDLOG_NO_PTHREAD_ID
+    , pthread_id(pthread_self())
+#endif
     , source(loc)
     , payload(msg)
 {}

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -22,6 +22,10 @@ struct SPDLOG_API log_msg
     log_clock::time_point time;
     size_t thread_id{0};
 
+#ifndef SPDLOG_NO_PTHREAD_ID
+    pthread_t pthread_id{0};
+#endif
+
     // wrapping the formatted text with color (updated by pattern_formatter).
     mutable size_t color_range_start{0};
     mutable size_t color_range_end{0};

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -658,6 +658,29 @@ public:
     }
 };
 
+// Thread name
+template<typename ScopedPadder>
+class N_formatter final : public flag_formatter
+{
+public:
+    explicit N_formatter(padding_info padinfo)
+        : flag_formatter(padinfo)
+    {}
+
+    void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
+    {
+        char threadNameBuffer[16] = { 0 };
+#ifndef SPDLOG_NO_PTHREAD_ID
+        pthread_getname_np(msg.pthread_id, threadNameBuffer, 16);
+#endif
+        threadName_ = threadNameBuffer;
+        ScopedPadder p(threadName_.size(), padinfo_, dest);
+        fmt_helper::append_string_view(threadName_, dest);
+    }
+private:
+    std::string threadName_;
+};
+
 // Current pid
 template<typename ScopedPadder>
 class pid_formatter final : public flag_formatter
@@ -1113,6 +1136,10 @@ SPDLOG_INLINE void pattern_formatter::handle_flag_(char flag, details::padding_i
 
     case ('t'): // thread id
         formatters_.push_back(details::make_unique<details::t_formatter<Padder>>(padding));
+        break;
+
+    case ('N'): // thread name
+        formatters_.push_back(details::make_unique<details::N_formatter<Padder>>(padding));
         break;
 
     case ('v'): // the message text

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -672,6 +672,8 @@ public:
         char threadNameBuffer[16] = { 0 };
 #ifndef SPDLOG_NO_PTHREAD_ID
         pthread_getname_np(msg.pthread_id, threadNameBuffer, 16);
+#else
+        (void)msg;
 #endif
         threadName_ = threadNameBuffer;
         ScopedPadder p(threadName_.size(), padinfo_, dest);

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -59,6 +59,23 @@ TEST_CASE("date MM/DD/YY ", "[pattern_formatter]")
     REQUIRE(log_to_str("Some message", "%D %v", spdlog::pattern_time_type::local, "\n") == oss.str());
 }
 
+
+#ifndef SPDLOG_NO_PTHREAD_ID
+TEST_CASE("thread name formatter", "[pattern_formatter]")
+{
+    char originalName[16] = { 0 };
+    pthread_getname_np(pthread_self(), originalName, 16);
+    std::string expected = "[";
+    expected += originalName;
+    expected += "] Some message\n";
+    REQUIRE(log_to_str("Some message", "[%N] %v", spdlog::pattern_time_type::local, "\n") == expected);
+    pthread_setname_np(pthread_self(), "Testname");
+    REQUIRE(log_to_str("Some message", "[%N] %v", spdlog::pattern_time_type::local, "\n") == "[Testname] Some message\n");
+    pthread_setname_np(pthread_self(), originalName);
+}
+
+#endif
+
 TEST_CASE("color range test1", "[pattern_formatter]")
 {
     auto formatter = std::make_shared<spdlog::pattern_formatter>("%^%v%$", spdlog::pattern_time_type::local, "\n");


### PR DESCRIPTION
First of all, thank you all for this great library, it's really a joy to use and tinker with!

I noticed that while it's possible to log a thread's id, it's not possible to log the name of the thread. Naming threads is very common in large programs with many threads as it makes it easier to know which thread is doing what. This patch adds the %N logger format specifier for logging the thread name.

It isn't possible to get the name of a thread from its thread-id, so the specific pthread_t-id has to be saved in log_msg. As I'm sure this won't work on Windows and will probably hurt performance everywhere where it works, this patch adds a option for enabling or disabling saving of the pthread_t-id. It's disabled by default. Maybe you should get an error if you enable it on Windows, or maybe we should enable it by default on Unix, I don't know, feel free to adjust that.

The new pattern formatter can be used with the %N (thread **N**ame) format specifier. I would have used %T (in parallel to %t), but that is already used for time. If someone thinks another letter would be a better choice, feel free to change it. I picked it just because it was the closest one that was available.

I also added some tests to ensure this works.