### PR TITLE
Centralize and make accessible default log level (to level::info)

### DIFF
--- a/include/spdlog/cfg/helpers-inl.h
+++ b/include/spdlog/cfg/helpers-inl.h
@@ -88,7 +88,7 @@ SPDLOG_INLINE void load_levels(const std::string &input)
 
     auto key_vals = extract_key_vals_(input);
     std::unordered_map<std::string, level::level_enum> levels;
-    level::level_enum global_level = level::info;
+    level::level_enum global_level = level::kDefault;
     bool global_level_found = false;
 
     for (auto &name_level : key_vals)

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -152,10 +152,6 @@ using level_t = std::atomic<int>;
 #define SPDLOG_LEVEL_CRITICAL 5
 #define SPDLOG_LEVEL_OFF 6
 
-#if !defined(SPDLOG_ACTIVE_LEVEL)
-#    define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO
-#endif
-
 // Log level enum
 namespace level {
 enum level_enum
@@ -177,6 +173,12 @@ enum level_enum
 #define SPDLOG_LEVEL_NAME_ERROR spdlog::string_view_t("error", 5)
 #define SPDLOG_LEVEL_NAME_CRITICAL spdlog::string_view_t("critical", 8)
 #define SPDLOG_LEVEL_NAME_OFF spdlog::string_view_t("off", 3)
+
+static constexpr level_enum kDefault = info;
+
+#if !defined(SPDLOG_ACTIVE_LEVEL)
+#    define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_INFO
+#endif
 
 #if !defined(SPDLOG_LEVEL_NAMES)
 #    define SPDLOG_LEVEL_NAMES                                                                                                             \

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -97,7 +97,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<logger>> loggers_;
     log_levels log_levels_;
     std::unique_ptr<formatter> formatter_;
-    spdlog::level::level_enum global_log_level_ = level::info;
+    spdlog::level::level_enum global_log_level_ = level::kDefault;
     level::level_enum flush_level_ = level::off;
     err_handler err_handler_;
     std::shared_ptr<thread_pool> tp_;

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -318,7 +318,7 @@ public:
 protected:
     std::string name_;
     std::vector<sink_ptr> sinks_;
-    spdlog::level_t level_{level::info};
+    spdlog::level_t level_{level::kDefault};
     spdlog::level_t flush_level_{level::off};
     err_handler custom_err_handler_{nullptr};
     details::backtracer tracer_;


### PR DESCRIPTION
Hello,

I would like to access to the default level for a `logger` (currently hardcoded to `level::info` in `logger.h`):

```
protected:
    std::string name_;
    std::vector<sink_ptr> sinks_;
    spdlog::level_t level_{level::info};
    spdlog::level_t flush_level_{level::off};
    err_handler custom_err_handler_{nullptr};
    details::backtracer tracer_;
```

This PR defines a `constexpr` variable `kDefault` (name could be discussed, `default` is a keyword in C++ so not possible) such that client code can retrieve it. I took the opportunity to replace the `level::info` used here and there with this constant value.

WDYT?

Thanks in advance