### PR TITLE
example.cpp failes to build on FreeBSD

### DIFF
--- a/include/spdlog/details/udp_client.h
+++ b/include/spdlog/details/udp_client.h
@@ -14,6 +14,7 @@
 #include <spdlog/details/os.h>
 
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <netdb.h>


### PR DESCRIPTION
We seem to be missing include file netinet/in.h in udp_client.h.

I've tested on Linux and FreeBSD, but don't have access to other platforms.