### PR TITLE
fix compiling errors on AIX

### DIFF
--- a/bench/async_bench.cpp
+++ b/bench/async_bench.cpp
@@ -162,7 +162,7 @@ void thread_fun(std::shared_ptr<spdlog::logger> logger, int howmany)
 void bench_mt(int howmany, std::shared_ptr<spdlog::logger> logger, int thread_count)
 {
     using std::chrono::high_resolution_clock;
-    vector<thread> threads;
+    vector<std::thread> threads;
     auto start = high_resolution_clock::now();
 
     int msgs_per_thread = howmany / thread_count;

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -230,8 +230,8 @@ SPDLOG_INLINE size_t filesize(FILE *f)
 #    endif
 
 #else // unix
-// OpenBSD doesn't compile with :: before the fileno(..)
-#    if defined(__OpenBSD__)
+// OpenBSD and AIX doesn't compile with :: before the fileno(..)
+#    if defined(__OpenBSD__) || defined(_AIX)
     int fd = fileno(f);
 #    else
     int fd = ::fileno(f);
@@ -336,7 +336,9 @@ SPDLOG_INLINE size_t _thread_id() SPDLOG_NOEXCEPT
 #        define SYS_gettid __NR_gettid
 #    endif
     return static_cast<size_t>(::syscall(SYS_gettid));
-#elif defined(_AIX) || defined(__DragonFly__) || defined(__FreeBSD__)
+#elif defined(_AIX)
+    return static_cast<size_t>(::pthread_self());
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
     return static_cast<size_t>(::pthread_getthreadid_np());
 #elif defined(__NetBSD__)
     return static_cast<size_t>(::_lwp_self());

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -46,7 +46,7 @@
 #        include <sys/syscall.h> //Use gettid() syscall under linux to get thread id
 
 #    elif defined(_AIX)
-#        include <pthread.h> // for pthread_getthreadid_np
+#        include <pthread.h> // for pthread_getthrds_np
 
 #    elif defined(__DragonFly__) || defined(__FreeBSD__)
 #        include <pthread_np.h> // for pthread_getthreadid_np
@@ -337,7 +337,12 @@ SPDLOG_INLINE size_t _thread_id() SPDLOG_NOEXCEPT
 #    endif
     return static_cast<size_t>(::syscall(SYS_gettid));
 #elif defined(_AIX)
-    return static_cast<size_t>(::pthread_self());
+    struct __pthrdsinfo buf;
+    int reg_size = 0;
+    pthread_t pt = pthread_self();
+    int retval = pthread_getthrds_np(&pt, PTHRDSINFO_QUERY_TID, &buf, sizeof(buf), NULL, &reg_size);
+    int tid = (!retval) ? buf.__pi_tid : 0;
+    return static_cast<size_t>(tid);
 #elif defined(__DragonFly__) || defined(__FreeBSD__)
     return static_cast<size_t>(::pthread_getthreadid_np());
 #elif defined(__NetBSD__)


### PR DESCRIPTION
## What
spdlog failed to compile on `AIX 7.2`

```
In file included from /~/spdlog/src/spdlog.cpp:12:
/~/spdlog/include/spdlog/details/os-inl.h:237:16: error: expected unqualified-id
    int fd = ::fileno(f);
               ^
/usr/include/stdio.h:515:25: note: expanded from macro 'fileno'
#define fileno(__p)     ((__p)->_file)
                        ^
In file included from /~spdlog/src/spdlog.cpp:12:
/~/spdlog/include/spdlog/details/os-inl.h:340:34: error: no member named 'pthread_getthreadid_np' in the global namespace
    return static_cast<size_t>(::pthread_getthreadid_np());
                               ~~^
1 warning and 2 errors generated.
```

with following configurations

```
export OBJECT_MODE=64
cmake .. -DCMAKE_C_COMPILER=xlclang -DCMAKE_CXX_COMPILER=xlclang++ -DCMAKE_POSITION_INDEPENDENT_CODE=ON
```

## Code Change

- `fileno` is a macro on AIX, so we cannot use `::` scope decorator for this function.
- AIX use `pthread_self + pthread_getthrds_np` instead of `pthread_getthreadid_np` [See AIX Doc](https://www.ibm.com/docs/en/aix/7.2?topic=p-pthread-self-subroutine)


## Environment

```
# xlclang++ --version
IBM XL C/C++ for AIX, V16.1.0  (5725-C72, 5765-J12)
Version: 16.01.0000.0009
```

```
System Model: IBM,9119-MHE
Machine Serial Number: 10D945P
Processor Type: PowerPC_POWER8
Processor Implementation Mode: POWER 8
Processor Version: PV_8_Compat
Number Of Processors: 2
Processor Clock Speed: 4024 MHz
CPU Type: 64-bit
Kernel Type: 64-bit
LPAR Info: 24 paix871
Memory Size: 8192 MB
Good Memory Size: 8192 MB
Platform Firmware level: SC860_226
Firmware Version: IBM,FW860.90 (SC860_226)
Console Login: enable
Auto Restart: true
Full Core: false
NX Crypto Acceleration: Capable and Enabled
In-Core Crypto Acceleration: Capable, but not Enabled
```
