### PR TITLE
Fix(tweakme): SPDLOG_FUNCTION

### DIFF
--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -127,5 +127,9 @@
 // __PRETTY_FUNCTION__ might be nicer in clang/gcc, and __FUNCTION__ in msvc.
 // Defaults to __FUNCTION__ (should work on all compilers) if not defined.
 //
-// #define SPDLOG_FUNCTION __PRETTY_FUNCTION__
+// #ifdef __PRETTY_FUNCTION__
+// # define SPDLOG_FUNCTION __PRETTY_FUN  CTION__
+// #else
+// # define SPDLOG_FUNCTION __FUNCTION__
+// #endif
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -128,7 +128,7 @@
 // Defaults to __FUNCTION__ (should work on all compilers) if not defined.
 //
 // #ifdef __PRETTY_FUNCTION__
-// # define SPDLOG_FUNCTION __PRETTY_FUN  CTION__
+// # define SPDLOG_FUNCTION __PRETTY_FUNCTION__
 // #else
 // # define SPDLOG_FUNCTION __FUNCTION__
 // #endif


### PR DESCRIPTION
Uncommenting `SPDLOG_FUNCTION` will make MSVC fail to compile,

Fixed it by adding an `#ifdef` around `__PRETTY_FUNCTION__`