### PR TITLE
Fix usage of ranges and to_hex in the same compile unit

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -14,6 +14,7 @@ void rotating_example();
 void daily_example();
 void async_example();
 void binary_example();
+void vector_example();
 void stopwatch_example();
 void trace_example();
 void multi_sink_example();
@@ -73,6 +74,7 @@ int main(int, char *[])
         daily_example();
         async_example();
         binary_example();
+        vector_example();
         multi_sink_example();
         user_defined_example();
         err_handler_example();
@@ -186,6 +188,15 @@ void binary_example()
     // logger->info("uppercase, no delimiters, no position info: {:Xsp}", spdlog::to_hex(buf));
     // logger->info("hexdump style: {:a}", spdlog::to_hex(buf));
     // logger->info("hexdump style, 20 chars per line {:a}", spdlog::to_hex(buf, 20));
+}
+
+// Log a vector of numbers
+
+#include "spdlog/fmt/bundled/ranges.h"
+void vector_example()
+{
+    std::vector<int> vec = {1, 2, 3};
+    spdlog::info("Vector example: {}", vec);
 }
 
 // Compile time log levels.

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -40,11 +40,11 @@ public:
     {}
 
     // do not use begin() and end() to avoid collision with fmt/ranges
-    It getBegin() const
+    It get_begin() const
     {
         return begin_;
     }
-    It getEnd() const
+    It get_end() const
     {
         return end_;
     }
@@ -145,14 +145,14 @@ struct formatter<spdlog::details::dump_info<T>, char>
 #endif
 
         int size_per_line = static_cast<int>(the_range.size_per_line());
-        auto start_of_line = the_range.getBegin();
-        for (auto i = the_range.getBegin(); i != the_range.getEnd(); i++)
+        auto start_of_line = the_range.get_begin();
+        for (auto i = the_range.get_begin(); i != the_range.get_end(); i++)
         {
             auto ch = static_cast<unsigned char>(*i);
 
-            if (put_newlines && (i == the_range.getBegin() || i - start_of_line >= size_per_line))
+            if (put_newlines && (i == the_range.get_begin() || i - start_of_line >= size_per_line))
             {
-                if (show_ascii && i != the_range.getBegin())
+                if (show_ascii && i != the_range.get_begin())
                 {
                     *inserter++ = delimiter;
                     *inserter++ = delimiter;
@@ -163,7 +163,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
                     }
                 }
 
-                put_newline(inserter, static_cast<size_t>(i - the_range.getBegin()));
+                put_newline(inserter, static_cast<size_t>(i - the_range.get_begin()));
 
                 // put first byte without delimiter in front of it
                 *inserter++ = hex_chars[(ch >> 4) & 0x0f];
@@ -182,9 +182,9 @@ struct formatter<spdlog::details::dump_info<T>, char>
         }
         if (show_ascii) // add ascii to last line
         {
-            if (the_range.getEnd() - the_range.getBegin() > size_per_line)
+            if (the_range.get_end() - the_range.get_begin() > size_per_line)
             {
-                auto blank_num = size_per_line - (the_range.getEnd() - start_of_line);
+                auto blank_num = size_per_line - (the_range.get_end() - start_of_line);
                 while (blank_num-- > 0)
                 {
                     *inserter++ = delimiter;
@@ -197,7 +197,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
             }
             *inserter++ = delimiter;
             *inserter++ = delimiter;
-            for (auto j = start_of_line; j != the_range.getEnd(); j++)
+            for (auto j = start_of_line; j != the_range.get_end(); j++)
             {
                 auto pc = static_cast<unsigned char>(*j);
                 *inserter++ = std::isprint(pc) ? static_cast<char>(*j) : '.';

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -39,11 +39,12 @@ public:
         , size_per_line_(size_per_line)
     {}
 
-    It begin() const
+    // do not use begin() and end() to avoid collision with fmt/ranges
+    It getBegin() const
     {
         return begin_;
     }
-    It end() const
+    It getEnd() const
     {
         return end_;
     }
@@ -144,14 +145,14 @@ struct formatter<spdlog::details::dump_info<T>, char>
 #endif
 
         int size_per_line = static_cast<int>(the_range.size_per_line());
-        auto start_of_line = the_range.begin();
-        for (auto i = the_range.begin(); i != the_range.end(); i++)
+        auto start_of_line = the_range.getBegin();
+        for (auto i = the_range.getBegin(); i != the_range.getEnd(); i++)
         {
             auto ch = static_cast<unsigned char>(*i);
 
-            if (put_newlines && (i == the_range.begin() || i - start_of_line >= size_per_line))
+            if (put_newlines && (i == the_range.getBegin() || i - start_of_line >= size_per_line))
             {
-                if (show_ascii && i != the_range.begin())
+                if (show_ascii && i != the_range.getBegin())
                 {
                     *inserter++ = delimiter;
                     *inserter++ = delimiter;
@@ -162,7 +163,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
                     }
                 }
 
-                put_newline(inserter, static_cast<size_t>(i - the_range.begin()));
+                put_newline(inserter, static_cast<size_t>(i - the_range.getBegin()));
 
                 // put first byte without delimiter in front of it
                 *inserter++ = hex_chars[(ch >> 4) & 0x0f];
@@ -181,9 +182,9 @@ struct formatter<spdlog::details::dump_info<T>, char>
         }
         if (show_ascii) // add ascii to last line
         {
-            if (the_range.end() - the_range.begin() > size_per_line)
+            if (the_range.getEnd() - the_range.getBegin() > size_per_line)
             {
-                auto blank_num = size_per_line - (the_range.end() - start_of_line);
+                auto blank_num = size_per_line - (the_range.getEnd() - start_of_line);
                 while (blank_num-- > 0)
                 {
                     *inserter++ = delimiter;
@@ -196,7 +197,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
             }
             *inserter++ = delimiter;
             *inserter++ = delimiter;
-            for (auto j = start_of_line; j != the_range.end(); j++)
+            for (auto j = start_of_line; j != the_range.getEnd(); j++)
             {
                 auto pc = static_cast<unsigned char>(*j);
                 *inserter++ = std::isprint(pc) ? static_cast<char>(*j) : '.';


### PR DESCRIPTION
Hello!

First of all, thanks a lot for this great package!

I encountered a compile problem when using ranges and bin_to_hex in the same compile unit. After doing some research I came to the conclusion that probably the only way so solve this is to hide the iterators used in bin_to_hex from the formatter in ranges. 

My change in detail:

When trying to use spdlog/fmt/bin_to_hex.h in the same compile unit as spdlog/fmt/bundled/ranges.h you got a compile error because there was a multiple definitions for iterable classes. This fix renames the begin() and end() getters in dump_info into getBegin()/getEnd() in order to avoid this collision.

Added an example of ranges in example.cpp to show that it actually works (a to_hex example was already there)


What do you think?

All the best
Patrick