### PR TITLE
Add custom on_stop callback to thread-pool, executed by each thread before joining them.

### DIFF
--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -73,16 +73,20 @@ inline std::shared_ptr<spdlog::logger> create_async_nb(std::string logger_name, 
 }
 
 // set global thread pool.
-inline void init_thread_pool(size_t q_size, size_t thread_count, std::function<void()> on_thread_start)
+inline void init_thread_pool(size_t q_size, size_t thread_count, std::function<void()> on_thread_start, std::function<void()> on_thread_stop)
 {
-    auto tp = std::make_shared<details::thread_pool>(q_size, thread_count, on_thread_start);
+    auto tp = std::make_shared<details::thread_pool>(q_size, thread_count, on_thread_start, on_thread_stop);
     details::registry::instance().set_tp(std::move(tp));
 }
 
-// set global thread pool.
+inline void init_thread_pool(size_t q_size, size_t thread_count, std::function<void()> on_thread_start)
+{
+    init_thread_pool(q_size, thread_count, on_thread_start, [] {});
+}
+
 inline void init_thread_pool(size_t q_size, size_t thread_count)
 {
-    init_thread_pool(q_size, thread_count, [] {});
+    init_thread_pool(q_size, thread_count, [] {}, [] {});
 }
 
 // get the global thread pool.

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -13,7 +13,7 @@
 namespace spdlog {
 namespace details {
 
-SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items, size_t threads_n, std::function<void()> on_thread_start)
+SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items, size_t threads_n, std::function<void()> on_thread_start, std::function<void()> on_thread_stop)
     : q_(q_max_items)
 {
     if (threads_n == 0 || threads_n > 1000)
@@ -23,15 +23,20 @@ SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items, size_t threads_n, std
     }
     for (size_t i = 0; i < threads_n; i++)
     {
-        threads_.emplace_back([this, on_thread_start] {
+        threads_.emplace_back([this, on_thread_start, on_thread_stop] {
             on_thread_start();
             this->thread_pool::worker_loop_();
+            on_thread_stop();
         });
     }
 }
 
+SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items, size_t threads_n, std::function<void()> on_thread_start)
+    : thread_pool(q_max_items, threads_n, on_thread_start, [] {})
+{}
+
 SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items, size_t threads_n)
-    : thread_pool(q_max_items, threads_n, [] {})
+    : thread_pool(q_max_items, threads_n, [] {}, [] {})
 {}
 
 // message all threads to terminate gracefully join them

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -84,6 +84,7 @@ public:
     using item_type = async_msg;
     using q_type = details::mpmc_blocking_queue<item_type>;
 
+    thread_pool(size_t q_max_items, size_t threads_n, std::function<void()> on_thread_start, std::function<void()> on_thread_stop);
     thread_pool(size_t q_max_items, size_t threads_n, std::function<void()> on_thread_start);
     thread_pool(size_t q_max_items, size_t threads_n);
 


### PR DESCRIPTION
Hello Gabi,

A while ago, you accepted a pull request https://github.com/gabime/spdlog/pull/208 which was left behind when moving to the thread-pool based async logger.
If this is fine for you, please accept this request and I'll add some lines to the wiki.

Cheers,
