### PR TITLE
Reduce warnings with pedantic compiler `-Wuseless-cast`

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -321,24 +321,15 @@ struct file_event_handlers
 
 namespace details {
 
-// to avoid useless casts (see https://github.com/nlohmann/json/issues/2893#issuecomment-889152324)
-template<typename T, typename U, std::enable_if_t<!std::is_same<T, U>::value, int> = 0>
-constexpr T conditional_static_cast(U value)
-{
-    return static_cast<T>(value);
-}
-
-template<typename T, typename U, std::enable_if_t<std::is_same<T, U>::value, int> = 0>
-constexpr T conditional_static_cast(U value)
-{
-    return value;
-}
-
 // make_unique support for pre c++14
 
 #if __cplusplus >= 201402L // C++14 and beyond
+using std::enable_if_t;
 using std::make_unique;
 #else
+template<bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args &&...args)
 {
@@ -346,6 +337,20 @@ std::unique_ptr<T> make_unique(Args &&...args)
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 #endif
+
+// to avoid useless casts (see https://github.com/nlohmann/json/issues/2893#issuecomment-889152324)
+template<typename T, typename U, enable_if_t<!std::is_same<T, U>::value, int> = 0>
+constexpr T conditional_static_cast(U value)
+{
+    return static_cast<T>(value);
+}
+
+template<typename T, typename U, enable_if_t<std::is_same<T, U>::value, int> = 0>
+constexpr T conditional_static_cast(U value)
+{
+    return value;
+}
+
 } // namespace details
 } // namespace spdlog
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -30,7 +30,7 @@
 #                define SPDLOG_API __declspec(dllimport)
 #            endif
 #        else // !defined(_WIN32)
-#            define SPDLOG_API __attribute__((visibility ("default")))
+#            define SPDLOG_API __attribute__((visibility("default")))
 #        endif
 #    else // !defined(SPDLOG_SHARED_LIB)
 #        define SPDLOG_API
@@ -320,13 +320,27 @@ struct file_event_handlers
 };
 
 namespace details {
+
+// to avoid useless casts (see https://github.com/nlohmann/json/issues/2893#issuecomment-889152324)
+template<typename T, typename U, std::enable_if_t<!std::is_same<T, U>::value, int> = 0>
+constexpr T conditional_static_cast(U value)
+{
+    return static_cast<T>(value);
+}
+
+template<typename T, typename U, std::enable_if_t<std::is_same<T, U>::value, int> = 0>
+constexpr T conditional_static_cast(U value)
+{
+    return value;
+}
+
 // make_unique support for pre c++14
 
 #if __cplusplus >= 201402L // C++14 and beyond
 using std::make_unique;
 #else
 template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args &&... args)
+std::unique_ptr<T> make_unique(Args &&...args)
 {
     static_assert(!std::is_array<T>::value, "arrays not supported");
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -405,9 +405,9 @@ SPDLOG_INLINE int pid() SPDLOG_NOEXCEPT
 {
 
 #ifdef _WIN32
-    return static_cast<int>(::GetCurrentProcessId());
+    return conditional_static_cast<int>(::GetCurrentProcessId());
 #else
-    return static_cast<int>(::getpid());
+    return conditional_static_cast<int>(::getpid());
 #endif
 }
 

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -407,7 +407,7 @@ SPDLOG_INLINE int pid() SPDLOG_NOEXCEPT
 #ifdef _WIN32
     return static_cast<int>(::GetCurrentProcessId());
 #else
-    return ::getpid();
+    return static_cast<int>(::getpid());
 #endif
 }
 

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -407,7 +407,7 @@ SPDLOG_INLINE int pid() SPDLOG_NOEXCEPT
 #ifdef _WIN32
     return static_cast<int>(::GetCurrentProcessId());
 #else
-    return static_cast<int>(::getpid());
+    return ::getpid();
 #endif
 }
 


### PR DESCRIPTION
on unix systems `getpid` returns `pid_t` which refers to `signed` type same as `int`