### PR TITLE
spdlog fails to build on GCC11 C++20

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -28,7 +28,7 @@ template<class Mutex>
 class registry_t
 {
 public:
-    registry_t<Mutex>(const registry_t<Mutex> &) = delete;
+    registry_t(const registry_t<Mutex> &) = delete;
     registry_t<Mutex> &operator=(const registry_t<Mutex> &) = delete;
 
     void register_logger(std::shared_ptr<logger> logger)
@@ -229,7 +229,7 @@ public:
     }
 
 private:
-    registry_t<Mutex>() = default;
+    registry_t() = default;
 
     void throw_if_exists(const std::string &logger_name)
     {


### PR DESCRIPTION
set options in gcc11:
set(CMAKE_CXX_STANDARD 20)

result:
[build] In file included from E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/details/spdlog_impl.h:11,
[build]                  from E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/spdlog.h:204,
[build]                  from E:\Project\testco\3rd\coroutine\src\Base\Log.cpp:6:
[build] E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/details/registry.h:31:23: error: expected unqualified-id before 'const'
[build]    31 |     registry_t<Mutex>(const registry_t<Mutex> &) = delete;
[build]       |                       ^~~~~
[build] E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/details/registry.h:31:23: error: expected ')' before 'const'
[build]    31 |     registry_t<Mutex>(const registry_t<Mutex> &) = delete;
[build]       |                      ~^~~~~
[build]       |                       )
[build] In file included from E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/details/spdlog_impl.h:11,
[build]                  from E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/spdlog.h:204,
[build]                  from E:\Project\testco\3rd\coroutine\src\Base\Log.cpp:6:
[build] E:/Project/testco/3rd/coroutine/build/_deps/spdlog-src/include/spdlog/details/registry.h:232:23: error: expected unqualified-id before ')' token
[build]   232 |     registry_t<Mutex>() = default;