### PR TITLE
Reset current size if rotated files on open

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -36,6 +36,7 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
     if (rotate_on_open && current_size_ > 0)
     {
         rotate_();
+        current_size_ = 0;
     }
 }
 


### PR DESCRIPTION
If rotated files on open, `file_helper_` will open an empty file and `current_size_` should be reset to 0.

This PR fixed the bug.