### PR TITLE
Allow forward-declaration of level_enum

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -208,7 +208,7 @@ using level_t = std::atomic<int>;
 
 // Log level enum
 namespace level {
-enum level_enum
+enum level_enum : int
 {
     trace = SPDLOG_LEVEL_TRACE,
     debug = SPDLOG_LEVEL_DEBUG,

--- a/include/spdlog/fwd.h
+++ b/include/spdlog/fwd.h
@@ -11,4 +11,8 @@ namespace sinks {
 class sink;
 }
 
+namespace level {
+enum level_enum : int;
+}
+
 } // namespace spdlog

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -34,7 +34,7 @@ template<typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color(level::level_enum color_level, string_view_t color)
 {
     std::lock_guard<mutex_t> lock(mutex_);
-    colors_[color_level] = to_string_(color);
+    colors_[static_cast<size_t>(color_level)] = to_string_(color);
 }
 
 template<typename ConsoleMutex>
@@ -52,7 +52,7 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg
         // before color range
         print_range_(formatted, 0, msg.color_range_start);
         // in color range
-        print_ccode_(colors_[msg.level]);
+        print_ccode_(colors_[static_cast<size_t>(msg.level)]);
         print_range_(formatted, msg.color_range_start, msg.color_range_end);
         print_ccode_(reset);
         // after color range


### PR DESCRIPTION
spdlog::level::level_enum cannot be forward-declared at present, as
the definition does not specify an underlying type.

To allow users to make use of <spdlog/fwd.h> to refer to
level::level_enum without pulling in all of <spdlog/common.h> (which
can be quite costly), specify an underlying type (int) for
level::level_enum, then add a forward-declaration for it to
spdlog/fwd.h.

Note this required explicitly casting level_enum to size_t within ansicolor_sink due to sign-conversion errors:

    implicit conversion changes signedness: 'const level::level_enum' to 'std::__1::array::size_type' (aka 'unsigned long') [-Wsign-conversion]

It would appear that an enum with an unspecified underlying type is in
some kind of superposition - it can be treated as both signed _and_
unsigned - using an underlying type of 'unsigned int' triggers even
more warnings of this kind...