### PR TITLE
pattern_formatter-inl: fix reorder-ctor warning

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1024,9 +1024,9 @@ SPDLOG_INLINE pattern_formatter::pattern_formatter(
     : pattern_(std::move(pattern))
     , eol_(std::move(eol))
     , pattern_time_type_(time_type)
+    , need_localtime_(false)
     , last_log_secs_(0)
     , custom_handlers_(std::move(custom_user_flags))
-    , need_localtime_(false)
 {
     std::memset(&cached_tm_, 0, sizeof(cached_tm_));
     compile_pattern_(pattern_);
@@ -1037,8 +1037,8 @@ SPDLOG_INLINE pattern_formatter::pattern_formatter(pattern_time_type time_type, 
     : pattern_("%+")
     , eol_(std::move(eol))
     , pattern_time_type_(time_type)
-    , last_log_secs_(0)
     , need_localtime_(true)
+    , last_log_secs_(0)
 {
     std::memset(&cached_tm_, 0, sizeof(cached_tm_));
     formatters_.push_back(details::make_unique<details::full_formatter>(details::padding_info{}));


### PR DESCRIPTION
Fix `Wreorder-ctor` warning, as it broke my `-Wall -Wextra -Werror` build.

```
spdlog/pattern_formatter-inl.h:1028:7: error: field 'custom_handlers_' will be initialized after field 'need_localtime_' [-Werror,-Wreorder-ctor]
    , custom_handlers_(std::move(custom_user_flags))
      ^
```

Move the initialization of `need_localtime_(true)` right after `pattern_time_type_` as expected.