### PR TITLE
When built with SPDLOG_FMT_EXTERNAL_HO consumers of the spdlog target…

### DIFF
--- a/cmake/spdlogConfig.cmake.in
+++ b/cmake/spdlogConfig.cmake.in
@@ -6,9 +6,10 @@
 find_package(Threads REQUIRED)
 
 set(SPDLOG_FMT_EXTERNAL @SPDLOG_FMT_EXTERNAL@)
+set(SPDLOG_FMT_EXTERNAL_HO @SPDLOG_FMT_EXTERNAL_HO@)
 set(config_targets_file @config_targets_file@)
 
-if(SPDLOG_FMT_EXTERNAL)
+if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
     include(CMakeFindDependencyMacro)
     find_dependency(fmt CONFIG)
 endif()


### PR DESCRIPTION
…s depend on fmt

The cmake/spdlogConfig.cmake.in file properly takes into account the fmt
package dependency when building with SPDLOG_FMT_EXTERNAL:BOOL=ON but
not when built with SPDLOG_FMT_EXTERNAL_HO:BOOL=ON.

Prior to these changes SPDLOG_FMT_EXTERNAL_HO:BOOL=ON results in
exported targets with INTERFACE_LINK_LIBRARIES that contain
fmt::fmt-header-only.

As such, the installed spdlogConfig.cmake file should attempt to find
that dependency for the consumer.