### PR TITLE
Fix fopen_s error reporting with PREVENT_CHILD_FD

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -145,7 +145,7 @@ SPDLOG_INLINE bool fopen_s(FILE **fp, const filename_t &filename, const filename
     const int fd = ::open((filename.c_str()), O_CREAT | O_WRONLY | O_CLOEXEC | mode_flag, mode_t(0644));
     if (fd == -1)
     {
-        return false;
+        return true;
     }
     *fp = ::fdopen(fd, mode.c_str());
     if (*fp == nullptr)

--- a/tests/test_file_helper.cpp
+++ b/tests/test_file_helper.cpp
@@ -154,3 +154,15 @@ TEST_CASE("file_event_handlers", "[file_helper]")
     REQUIRE(events == std::vector<flags>{flags::before_close, flags::after_close});
     REQUIRE(file_contents(TEST_FILENAME) == "after_open\nbefore_close\n");
 }
+
+TEST_CASE("file_helper_open", "[file_helper]")
+{
+    prepare_logdir();
+    spdlog::filename_t target_filename = SPDLOG_FILENAME_T(TEST_FILENAME);
+    file_helper helper;
+    helper.open(target_filename);
+    helper.close();
+
+    target_filename += SPDLOG_FILENAME_T("/invalid");
+    REQUIRE_THROWS_AS(helper.open(target_filename), spdlog::spdlog_ex);
+}


### PR DESCRIPTION
`open()` failure was incorrectly reported as a success under *nix with `SPDLOG_PREVENT_CHILD_FD` enabled, leaving `*fp` untouched.