### PR TITLE
Fixed compiler error when building on Windows with #define UNICODE

### DIFF
--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -64,7 +64,7 @@ public:
         addr_.sin_family = PF_INET;
         addr_.sin_port = htons(port);
         addr_.sin_addr.s_addr = INADDR_ANY;
-        if (InetPton(PF_INET, TEXT(host.c_str()), &addr_.sin_addr.s_addr) != 1)
+        if (InetPtonA(PF_INET, host.c_str(), &addr_.sin_addr.s_addr) != 1)
         {
             int last_error = ::WSAGetLastError();
             ::WSACleanup();


### PR DESCRIPTION
The original `InetPton` expands to `InetPtonW` when building with UNICODE defined and expects the string parameter to be wchar_t. On the other hand macro `TEXT()` just adds prefix `L` to a string literal (just making it wchar_t literal). The proper way here would be converting `host.c_str()` result from UTF-8(?) into wchar_t (UNICODE) string, but this seems to be an overkill since the host is typically an IP address or a host/domain name. So assuming an ASCII input should be reasonably safe.