### PR TITLE
support print utf-8 string to non-unicode windows console.

### DIFF
--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -145,8 +145,14 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::print_range_(const memory_buf_t 
 {
     if (end > start)
     {
-        auto size = static_cast<DWORD>(end - start);
-        auto ignored = ::WriteConsoleA(static_cast<HANDLE>(out_handle_), formatted.data() + start, size, nullptr, nullptr);
+        auto size = end - start;
+#ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+        wmemory_buf_t buf;
+        details::os::utf8_to_wstrbuf(string_view_t(formatted.data() + start, size), buf);
+        auto ignored = ::WriteConsoleW(static_cast<HANDLE>(out_handle_), buf.data(), static_cast<DWORD>(buf.size()), nullptr, nullptr);
+#else
+        auto ignored = ::WriteConsoleA(static_cast<HANDLE>(out_handle_), formatted.data() + start, static_cast<DWORD>(size), nullptr, nullptr);
+#endif
         (void)(ignored);
     }
 }


### PR DESCRIPTION
There are many feature-request about utf-8-supported wincolor-sink like https://github.com/gabime/spdlog/issues/762, https://github.com/gabime/spdlog/issues/1751. So I fixed the wincolor-sink to support output utf-8 string to non-utf8 code page console, which is consistent with win_eventlog_sink's behavior.