### PR TITLE
Make file_event_handlers an aggregate

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -311,12 +311,6 @@ struct file_event_handlers
     std::function<void(const filename_t &filename, std::FILE *file_stream)> after_open;
     std::function<void(const filename_t &filename, std::FILE *file_stream)> before_close;
     std::function<void(const filename_t &filename)> after_close;
-    file_event_handlers()
-        : before_open{nullptr}
-        , after_open{nullptr}
-        , before_close{nullptr}
-        , after_close{nullptr}
-    {}
 };
 
 namespace details {


### PR DESCRIPTION
Just making file_event_handlers an aggregate to allow designated initialization