### PR TITLE
Add sync to file_helper

### DIFF
--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -90,6 +90,14 @@ SPDLOG_INLINE void file_helper::flush()
     }
 }
 
+SPDLOG_INLINE void file_helper::sync()
+{
+    if(!os::fsync(fd_))
+    {
+        throw_spdlog_ex("Failed to fsync file " + os::filename_to_str(filename_), errno);
+    }
+}
+
 SPDLOG_INLINE void file_helper::close()
 {
     if (fd_ != nullptr)

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -26,6 +26,7 @@ public:
     void open(const filename_t &fname, bool truncate = false);
     void reopen(bool truncate);
     void flush();
+    void sync();
     void close();
     void write(const memory_buf_t &buf);
     size_t size() const;

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -23,9 +23,10 @@
 
 #ifdef _WIN32
 
-#    include <io.h>      // _get_osfhandle and _isatty support
-#    include <process.h> //  _get_pid support
+#    include <io.h>      // for _get_osfhandle, _isatty, _fileno
+#    include <process.h> // for _get_pid
 #    include <spdlog/details/windows_include.h>
+#    include <fileapi.h> // for FlushFileBuffers
 
 #    ifdef __MINGW32__
 #        include <share.h>
@@ -598,6 +599,17 @@ std::string SPDLOG_INLINE getenv(const char *field)
 #else // revert to getenv
     char *buf = ::getenv(field);
     return buf ? buf : std::string{};
+#endif
+}
+
+// Do fsync by FILE descriptor
+// Return true on success
+SPDLOG_INLINE bool fsync(FILE *fd)
+{
+#ifdef _WIN32
+    return FlushFileBuffers(reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(fd)))) != 0;
+#else
+    return ::fsync(fileno(fd)) == 0;
 #endif
 }
 

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -109,6 +109,10 @@ SPDLOG_API bool create_dir(const filename_t &path);
 // return empty string if field not found
 SPDLOG_API std::string getenv(const char *field);
 
+// Do fsync by FILE descriptor
+// Return true on success
+SPDLOG_API bool fsync(FILE * fd);
+
 } // namespace os
 } // namespace details
 } // namespace spdlog


### PR DESCRIPTION
Since file_helper already works well for managing file sinks and generally can be reused, it seems reasonable to me to implement fsync there which is required in some cases.
This adds `sync()` method to file_helper. It doesn't affect existing sinks and doesn't touch public interfaces.