### PR TITLE
Added function to get the names of all registered loggers

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -92,6 +92,17 @@ SPDLOG_INLINE std::shared_ptr<logger> registry::get(const std::string &logger_na
     return found == loggers_.end() ? nullptr : found->second;
 }
 
+SPDLOG_INLINE std::vector<std::string> registry::get_logger_names(void)
+{
+    std::lock_guard<std::mutex> lock(logger_map_mutex_);
+    std::vector<std::string> logger_names;
+    for (auto &l : loggers_)
+    {
+      logger_names.push_back(l.first);
+    }
+    return logger_names;
+}
+
 SPDLOG_INLINE std::shared_ptr<logger> registry::default_logger()
 {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include <mutex>
 
 namespace spdlog {
@@ -34,6 +35,7 @@ public:
     void register_logger(std::shared_ptr<logger> new_logger);
     void initialize_logger(std::shared_ptr<logger> new_logger);
     std::shared_ptr<logger> get(const std::string &logger_name);
+    std::vector<std::string> get_logger_names(void);
     std::shared_ptr<logger> default_logger();
 
     // Return raw ptr to the default logger.

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -22,6 +22,12 @@ SPDLOG_INLINE std::shared_ptr<logger> get(const std::string &name)
     return details::registry::instance().get(name);
 }
 
+SPDLOG_INLINE std::vector<std::string> get_logger_names(void)
+{
+    return details::registry::instance().get_logger_names();
+}
+
+
 SPDLOG_INLINE void set_formatter(std::unique_ptr<spdlog::formatter> formatter)
 {
     details::registry::instance().set_formatter(std::move(formatter));

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace spdlog {
 
@@ -50,6 +51,9 @@ SPDLOG_API void initialize_logger(std::shared_ptr<logger> logger);
 // exist.
 // example: spdlog::get("my_logger")->info("hello {}", "world");
 SPDLOG_API std::shared_ptr<logger> get(const std::string &name);
+
+// Return a list with the names of all registered loggers
+SPDLOG_API std::vector<std::string> get_logger_names(void);
 
 // Set global formatter. Each sink in each logger will get a clone of this object
 SPDLOG_API void set_formatter(std::unique_ptr<spdlog::formatter> formatter);


### PR DESCRIPTION
It'd like to find out from my application at runtime which loggers are registered, so that I can manipulate them (e.g. set the logging level) dynamically by their name.
For this purpose I have added a new top-level interface that returns a `std::vector` containing the keys of the private `registry::loggers_`.