### PR TITLE
Allow overriding need_localtime for custom formatter

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1051,7 +1051,9 @@ SPDLOG_INLINE std::unique_ptr<formatter> pattern_formatter::clone() const
     {
         cloned_custom_formatters[it.first] = it.second->clone();
     }
-    return details::make_unique<pattern_formatter>(pattern_, pattern_time_type_, eol_, std::move(cloned_custom_formatters));
+    auto cloned = details::make_unique<pattern_formatter>(pattern_, pattern_time_type_, eol_, std::move(cloned_custom_formatters));
+    cloned->need_localtime(need_localtime_);
+    return cloned;
 }
 
 SPDLOG_INLINE void pattern_formatter::format(const details::log_msg &msg, memory_buf_t &dest)

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1081,6 +1081,11 @@ SPDLOG_INLINE void pattern_formatter::set_pattern(std::string pattern)
     compile_pattern_(pattern_);
 }
 
+SPDLOG_INLINE void pattern_formatter::need_localtime(bool need)
+{
+    need_localtime_ = need;
+}
+
 SPDLOG_INLINE std::tm pattern_formatter::get_time_(const details::log_msg &msg)
 {
     if (pattern_time_type_ == pattern_time_type::local)

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -98,6 +98,7 @@ public:
         return *this;
     }
     void set_pattern(std::string pattern);
+    void need_localtime(bool need = true);
 
 private:
     std::string pattern_;

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -475,7 +475,7 @@ TEST_CASE("custom flags-exception", "[pattern_formatter]")
 
 TEST_CASE("override need_localtime", "[pattern_formatter]")
 {
-    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    auto formatter = std::make_shared<spdlog::pattern_formatter>(spdlog::pattern_time_type::local, "\n");
     formatter->add_flag<custom_test_flag>('t', "time").set_pattern("%t> %v");
 
     {

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -330,11 +330,17 @@ public:
         : some_txt{std::move(txt)}
     {}
 
-    void format(const spdlog::details::log_msg &, const std::tm &, spdlog::memory_buf_t &dest) override
+    void format(const spdlog::details::log_msg &, const std::tm &tm, spdlog::memory_buf_t &dest) override
     {
         if (some_txt == "throw_me")
         {
             throw spdlog::spdlog_ex("custom_flag_exception_test");
+        }
+        else if (some_txt == "time")
+        {
+            auto formatted = spdlog::fmt_lib::format("{:d}:{:02d}{:s}", tm.tm_hour % 12, tm.tm_min, tm.tm_hour / 12 ? "PM" : "AM");
+            dest.append(formatted.data(), formatted.data() + formatted.size());
+            return;
         }
         some_txt = std::string(padinfo_.width_, ' ') + some_txt;
         dest.append(some_txt.data(), some_txt.data() + some_txt.size());
@@ -465,4 +471,31 @@ TEST_CASE("custom flags-exception", "[pattern_formatter]")
     memory_buf_t formatted;
     spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message");
     CHECK_THROWS_AS(formatter->format(msg, formatted), spdlog::spdlog_ex);
+}
+
+TEST_CASE("override need_localtime", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    formatter->add_flag<custom_test_flag>('t', "time").set_pattern("%t> %v");
+
+    {
+        memory_buf_t formatted;
+        spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message");
+        formatter->format(msg, formatted);
+        REQUIRE(to_string_view(formatted) == "0:00AM> some message\n");
+    }
+
+    {
+        formatter->need_localtime();
+
+        auto now_tm = spdlog::details::os::localtime();
+        std::stringstream oss;
+        oss << (now_tm.tm_hour % 12) << ":" << std::setfill('0') << std::setw(2) << now_tm.tm_min << (now_tm.tm_hour / 12 ? "PM" : "AM")
+            << "> some message\n";
+
+        memory_buf_t formatted;
+        spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message");
+        formatter->format(msg, formatted);
+        REQUIRE(to_string_view(formatted) == oss.str());
+    }
 }


### PR DESCRIPTION
If user wants to use the pattern with no builtin flags related to time, but custom formatter that needs time information, there is no way to make pattern_formatter pass the updated `const std::tm&` to `format()` of custom formatter. This PR allows user to override `need_localtime` so that custom formatter can utilize cached_tm with the pattern not enabling `need_localtime` by default.