### PR TITLE
C++14 build fixes for older gcc #2333

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -262,15 +262,16 @@ struct my_type
         : i(i){};
 };
 
-namespace fmt_lib = spdlog::fmt_lib;
+FMTLIB_BEGIN_NAMESPACE
 template<>
-struct fmt_lib::formatter<my_type> : fmt_lib::formatter<std::string>
+struct formatter<my_type> : formatter<std::string>
 {
     auto format(my_type my, format_context &ctx) -> decltype(ctx.out())
     {
-        return fmt_lib::format_to(ctx.out(), "[my_type i={}]", my.i);
+        return format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };
+FMTLIB_END_NAMESPACE
 
 void user_defined_example()
 {

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -262,7 +262,14 @@ struct my_type
         : i(i){};
 };
 
-FMTLIB_BEGIN_NAMESPACE
+
+// Using a namespace alias like fmt_lib is not allowed when extending an existing namespace,
+// but the correct namespace can still be selected with the SPDLOG_USE_STD_FORMAT macro.
+#ifdef SPDLOG_USE_STD_FORMAT
+    namespace std {
+#else
+    namespace fmt {
+#endif
 template<>
 struct formatter<my_type> : formatter<std::string>
 {
@@ -271,7 +278,7 @@ struct formatter<my_type> : formatter<std::string>
         return format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };
-FMTLIB_END_NAMESPACE
+}
 
 void user_defined_example()
 {

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -126,13 +126,6 @@ using sink_ptr = std::shared_ptr<sinks::sink>;
 using sinks_init_list = std::initializer_list<sink_ptr>;
 using err_handler = std::function<void(const std::string &err_msg)>;
 #ifdef SPDLOG_USE_STD_FORMAT
-#    ifndef FMTLIB_BEGIN_NAMESPACE
-#        define FMTLIB_BEGIN_NAMESPACE \
-           namespace std {
-#        define FMTLIB_END_NAMESPACE \
-           }
-#    endif
-
 namespace fmt_lib = std;
 
 using string_view_t = std::string_view;
@@ -153,16 +146,7 @@ template<typename... Args>
 using wformat_string_t = std::wstring_view;
 #    endif
 #    define SPDLOG_BUF_TO_STRING(x) x
-
 #else // use fmt lib instead of std::format
-
-#    ifndef FMTLIB_BEGIN_NAMESPACE
-#        define FMTLIB_BEGIN_NAMESPACE \
-           namespace fmt {
-#        define FMTLIB_END_NAMESPACE \
-           }
-#    endif
-
 namespace fmt_lib = fmt;
 
 using string_view_t = fmt::basic_string_view<char>;

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -126,6 +126,13 @@ using sink_ptr = std::shared_ptr<sinks::sink>;
 using sinks_init_list = std::initializer_list<sink_ptr>;
 using err_handler = std::function<void(const std::string &err_msg)>;
 #ifdef SPDLOG_USE_STD_FORMAT
+#    ifndef FMTLIB_BEGIN_NAMESPACE
+#        define FMTLIB_BEGIN_NAMESPACE \
+           namespace std {
+#        define FMTLIB_END_NAMESPACE \
+           }
+#    endif
+
 namespace fmt_lib = std;
 
 using string_view_t = std::string_view;
@@ -146,7 +153,16 @@ template<typename... Args>
 using wformat_string_t = std::wstring_view;
 #    endif
 #    define SPDLOG_BUF_TO_STRING(x) x
+
 #else // use fmt lib instead of std::format
+
+#    ifndef FMTLIB_BEGIN_NAMESPACE
+#        define FMTLIB_BEGIN_NAMESPACE \
+           namespace fmt {
+#        define FMTLIB_END_NAMESPACE \
+           }
+#    endif
+
 namespace fmt_lib = fmt;
 
 using string_view_t = fmt::basic_string_view<char>;

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -8,8 +8,10 @@
 #include <cctype>
 #include <spdlog/common.h>
 
-#if defined(__has_include) && __has_include(<version>)
-#    include <version>
+#if defined(__has_include)
+#    if __has_include(<version>)
+#        include <version>
+#    endif
 #endif
 
 #if __cpp_lib_span >= 202002L


### PR DESCRIPTION
@gabime  I'm unable to test that the changes for `__has_include` in bin_to_hex.h work for @aengusjiang, but the approach I've followed matches the recommended pattern in the [gcc documentation for __has_include](https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005finclude.html).

I have tested the rest of the changes on my machine with gcc version `gcc (Ubuntu 5.5.0-12ubuntu1~14.04) 5.5.0 20171010`. I get the overloaded formatter used as seen in the output from the example program:

> [2022-05-11 18:22:25.008] [info] user defined type: [my_type i=14]


The problem seems to be caused by this clause in the [namespace specification](https://en.cppreference.com/w/cpp/language/namespace) (emphasis added):
>To reopen an existing namespace (formally, to be an extension-namespace-definition), the lookup for the identifier used in the namespace definition must resolve to a namespace name (**_not a namespace alias_**), that was declared as a member of the enclosing namespace or of an inline namespace within an enclosing namespace.

The approach I've taken here is the same approach used within `fmt` for the `FMT_BEGIN_NAMESPACE` macro defined in include/spdlog/fmt/bundled/core.h.