### PR TITLE
Add default file-event_handler callbacks. #2374

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -306,6 +306,13 @@ struct source_loc
 
 struct file_event_handlers
 {
+    file_event_handlers()
+        : before_open([](spdlog::filename_t) {})
+        , after_open ([](spdlog::filename_t, std::FILE*) {})
+        , before_close([](spdlog::filename_t, std::FILE*) {})
+        , after_close([](spdlog::filename_t) {})
+    {}
+
     std::function<void(const filename_t &filename)> before_open;
     std::function<void(const filename_t &filename, std::FILE *file_stream)> after_open;
     std::function<void(const filename_t &filename, std::FILE *file_stream)> before_close;


### PR DESCRIPTION
Prevents undefined reference errors seen in issue #2374.