### PR TITLE
Fix pkg-config generation with unconventional `CMAKE_INSTALL_*DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,11 @@ if(SPDLOG_INSTALL)
     # ---------------------------------------------------------------------------------------
     # Install pkg-config file
     # ---------------------------------------------------------------------------------------
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    else()
+        set(PKG_CONFIG_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif()
     get_target_property(PKG_CONFIG_DEFINES spdlog INTERFACE_COMPILE_DEFINITIONS)
     string(REPLACE ";" " -D" PKG_CONFIG_DEFINES "${PKG_CONFIG_DEFINES}")
     string(CONCAT PKG_CONFIG_DEFINES "-D" "${PKG_CONFIG_DEFINES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,11 @@ if(SPDLOG_INSTALL)
     # ---------------------------------------------------------------------------------------
     # Install pkg-config file
     # ---------------------------------------------------------------------------------------
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+        set(PKG_CONFIG_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    else()
+        set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif()
     if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
         set(PKG_CONFIG_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
     else()

--- a/cmake/spdlog.pc.in
+++ b/cmake/spdlog.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@PKG_CONFIG_LIBDIR@
 
 Name: lib@PROJECT_NAME@
 Description: Fast C++ logging library.

--- a/cmake/spdlog.pc.in
+++ b/cmake/spdlog.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-includedir=${prefix}/include
+includedir=@PKG_CONFIG_INCLUDEDIR@
 libdir=@PKG_CONFIG_LIBDIR@
 
 Name: lib@PROJECT_NAME@


### PR DESCRIPTION
Fixes #2380 and a further issue where the pkg-config template blindly assumed that CMAKE_INSTALL_INCLUDEDIR was equal to `include` even though it’s externally configurable and the actual installation process respected it.