### PR TITLE
fix error: cannot bind lvalue to right reference

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1053,7 +1053,7 @@ SPDLOG_INLINE std::unique_ptr<formatter> pattern_formatter::clone() const
     }
     auto cloned = details::make_unique<pattern_formatter>(pattern_, pattern_time_type_, eol_, std::move(cloned_custom_formatters));
     cloned->need_localtime(need_localtime_);
-    return cloned;
+    return std::move(cloned);
 }
 
 SPDLOG_INLINE void pattern_formatter::format(const details::log_msg &msg, memory_buf_t &dest)


### PR DESCRIPTION
before fix error:
![image](https://user-images.githubusercontent.com/22406984/169327553-df89a2fa-41d0-4153-8eb6-916ed13608ec.png)


this commit is verify with gcc4.8.5 and gcc8.3.1