### PR TITLE
Remove `try_lock` from null_mutex.

### DIFF
--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -13,10 +13,6 @@ struct null_mutex
 {
     void lock() const {}
     void unlock() const {}
-    bool try_lock() const
-    {
-        return true;
-    }
 };
 
 struct null_atomic_int


### PR DESCRIPTION
Only `std::unique_lock` and `std::lock_guard` are used on member variable `mutex_`. Both of them should meet the [BasicLockable](https://en.cppreference.com/w/cpp/named_req/BasicLockable) requirements, which means `lock()` and `unlock` are enough.