### PR TITLE
Remove redundant std::move at return 

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1053,7 +1053,7 @@ SPDLOG_INLINE std::unique_ptr<formatter> pattern_formatter::clone() const
     }
     auto cloned = details::make_unique<pattern_formatter>(pattern_, pattern_time_type_, eol_, std::move(cloned_custom_formatters));
     cloned->need_localtime(need_localtime_);
-    return std::move(cloned);
+    return cloned;
 }
 
 SPDLOG_INLINE void pattern_formatter::format(const details::log_msg &msg, memory_buf_t &dest)


### PR DESCRIPTION
The statement triggers -Wredundant-move in GCC. Return value optimization already moves/constructs in place if target allows it.