### PR TITLE
Set c++20 when SPDLOG_USE_STD_FORMAT option is turned on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,11 @@ if(SPDLOG_NO_EXCEPTIONS AND NOT MSVC)
     target_compile_options(spdlog PRIVATE -fno-exceptions)
 endif()
 
+if(SPDLOG_USE_STD_FORMAT)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 # ---------------------------------------------------------------------------------------
 # Build binaries
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Set CMAKE_CXX_STANDARD and CMAKE_CXX_STANDARD_REQUIRED when SPDLOG_USE_STD_FORMAT option is turned on