### PR TITLE
stopwatch: change to system_clock

### DIFF
--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -27,7 +27,7 @@
 namespace spdlog {
 class stopwatch
 {
-    using clock = std::chrono::steady_clock;
+    using clock = std::chrono::system_clock;
     std::chrono::time_point<clock> start_tp_;
 
 public:


### PR DESCRIPTION
test_stopwatch fails on MinGW, most likely because its steady_clock implementation is faulty.

Fixes: https://github.com/gabime/spdlog/issues/2404