### PR TITLE
[FEAT] add api: set_thread_name, used in periodic_worker and thread_pool

### DIFF
--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -72,6 +72,9 @@ SPDLOG_API size_t _thread_id() SPDLOG_NOEXCEPT;
 // Return current thread id as size_t (from thread local storage)
 SPDLOG_API size_t thread_id() SPDLOG_NOEXCEPT;
 
+// Set thread name for different platforms
+SPDLOG_API void set_thread_name(const char *thread_name);
+
 // This is avoid msvc issue in sleep_for that happens if the clock changes.
 // See https://github.com/gabime/spdlog/issues/609
 SPDLOG_API void sleep_for_millis(unsigned int milliseconds) SPDLOG_NOEXCEPT;

--- a/include/spdlog/details/periodic_worker-inl.h
+++ b/include/spdlog/details/periodic_worker-inl.h
@@ -7,6 +7,8 @@
 #    include <spdlog/details/periodic_worker.h>
 #endif
 
+#include <spdlog/details/os.h>
+
 namespace spdlog {
 namespace details {
 
@@ -19,6 +21,7 @@ SPDLOG_INLINE periodic_worker::periodic_worker(const std::function<void()> &call
     }
 
     worker_thread_ = std::thread([this, callback_fun, interval]() {
+        os::set_thread_name("spdlog_periodic");
         for (;;)
         {
             std::unique_lock<std::mutex> lock(this->mutex_);

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <spdlog/common.h>
+#include <spdlog/details/os.h>
 #include <cassert>
 
 namespace spdlog {
@@ -24,8 +25,10 @@ SPDLOG_INLINE thread_pool::thread_pool(
     }
     for (size_t i = 0; i < threads_n; i++)
     {
-        threads_.emplace_back([this, on_thread_start, on_thread_stop] {
+        threads_.emplace_back([this, on_thread_start, on_thread_stop, i] {
             on_thread_start();
+            std::string thread_name = "spdlog_pool_" + std::to_string(i);
+            os::set_thread_name(thread_name.c_str());
             this->thread_pool::worker_loop_();
             on_thread_stop();
         });


### PR DESCRIPTION
We use spdlog in our LogService and will see same thread name when debuging
It may be nice to give a name for spdlog thread rather than using it's parent thread name

I only test this PR in Linux/Ubuntu21.10 and MacOS M1
> I have no device for testing other platforms, thanks ci/cd