### PR TITLE
Have logger::set_pattern call sink::set_pattern #2419

### DIFF
--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -100,8 +100,10 @@ SPDLOG_INLINE void logger::set_formatter(std::unique_ptr<formatter> f)
 
 SPDLOG_INLINE void logger::set_pattern(std::string pattern, pattern_time_type time_type)
 {
-    auto new_formatter = details::make_unique<pattern_formatter>(std::move(pattern), time_type);
-    set_formatter(std::move(new_formatter));
+    for (auto it = sinks_.begin(); it != sinks_.end(); ++it)
+    {
+        (*it)->set_pattern(pattern, time_type);
+    }
 }
 
 // create new backtrace sink and move to it all our child sinks

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -73,10 +73,10 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::flush()
 }
 
 template<typename ConsoleMutex>
-SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern)
+SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern, pattern_time_type time_type)
 {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern, time_type));
 }
 
 template<typename ConsoleMutex>

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -41,7 +41,7 @@ public:
 
     void log(const details::log_msg &msg) override;
     void flush() override;
-    void set_pattern(const std::string &pattern) final;
+    void set_pattern(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
 
     // Formatting codes

--- a/include/spdlog/sinks/base_sink-inl.h
+++ b/include/spdlog/sinks/base_sink-inl.h
@@ -37,10 +37,10 @@ void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::flush()
 }
 
 template<typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern(const std::string &pattern)
+void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern(const std::string &pattern, pattern_time_type time_type)
 {
     std::lock_guard<Mutex> lock(mutex_);
-    set_pattern_(pattern);
+    set_pattern_(pattern, time_type);
 }
 
 template<typename Mutex>
@@ -51,9 +51,9 @@ void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_formatter(std::unique_pt
 }
 
 template<typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern_(const std::string &pattern)
+void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern_(const std::string &pattern, pattern_time_type time_type)
 {
-    set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+    set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern, time_type));
 }
 
 template<typename Mutex>

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -31,7 +31,7 @@ public:
 
     void log(const details::log_msg &msg) final;
     void flush() final;
-    void set_pattern(const std::string &pattern) final;
+    void set_pattern(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final;
 
 protected:
@@ -41,7 +41,7 @@ protected:
 
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;
-    virtual void set_pattern_(const std::string &pattern);
+    virtual void set_pattern_(const std::string &pattern, pattern_time_type time_type);
     virtual void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter);
 };
 } // namespace sinks

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -74,9 +74,9 @@ protected:
         }
     }
 
-    void set_pattern_(const std::string &pattern) override
+    void set_pattern_(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) override
     {
-        set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+        set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern, time_type));
     }
 
     void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter) override

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -15,7 +15,7 @@ public:
     virtual ~sink() = default;
     virtual void log(const details::log_msg &msg) = 0;
     virtual void flush() = 0;
-    virtual void set_pattern(const std::string &pattern) = 0;
+    virtual void set_pattern(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) = 0;
     virtual void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) = 0;
 
     void set_level(level::level_enum log_level);

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -85,10 +85,10 @@ SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::flush()
 }
 
 template<typename ConsoleMutex>
-SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::set_pattern(const std::string &pattern)
+SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::set_pattern(const std::string &pattern, pattern_time_type time_type)
 {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern, time_type));
 }
 
 template<typename ConsoleMutex>

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -32,7 +32,7 @@ public:
 
     void log(const details::log_msg &msg) override;
     void flush() override;
-    void set_pattern(const std::string &pattern) override;
+    void set_pattern(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) override;
 
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
 

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -85,10 +85,10 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::flush()
 }
 
 template<typename ConsoleMutex>
-void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern)
+void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern, pattern_time_type time_type)
 {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern, time_type));
 }
 
 template<typename ConsoleMutex>

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -34,7 +34,7 @@ public:
     void set_color(level::level_enum level, std::uint16_t color);
     void log(const details::log_msg &msg) final override;
     void flush() final override;
-    void set_pattern(const std::string &pattern) override final;
+    void set_pattern(const std::string &pattern, pattern_time_type time_type = pattern_time_type::local) override final;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override final;
     void set_color_mode(color_mode mode);
 


### PR DESCRIPTION
Previously it instantiated a new pattern_formatter and called sink::set_formatter
with it, overwriting the old formatter and any custom settings.
Now, if a custom sink inherits base_sink, a call from logger::set_pattern will arrive
at custom_sink::set_pattern_ as expected, instead of custom_sink::set_formatter_.

This PR addresses an actual issue I am having, where I instantiate a pattern_formatter in the constructor of my custom sink, because I need a custom eol string. If, afterwards, `logger::set_pattern` is called, this pattern_formatter is overwritten completely. The best I can do to prevent this subtle error is overwrite `base_sink::set_formatter_` to make it throw, which makes `logger::set_pattern` unusable.