### PR TITLE
Expend support for any std::chrono::duration in spdlog::flush_every

### DIFF
--- a/include/spdlog/details/periodic_worker-inl.h
+++ b/include/spdlog/details/periodic_worker-inl.h
@@ -10,27 +10,6 @@
 namespace spdlog {
 namespace details {
 
-SPDLOG_INLINE periodic_worker::periodic_worker(const std::function<void()> &callback_fun, std::chrono::seconds interval)
-{
-    active_ = (interval > std::chrono::seconds::zero());
-    if (!active_)
-    {
-        return;
-    }
-
-    worker_thread_ = std::thread([this, callback_fun, interval]() {
-        for (;;)
-        {
-            std::unique_lock<std::mutex> lock(this->mutex_);
-            if (this->cv_.wait_for(lock, interval, [this] { return !this->active_; }))
-            {
-                return; // active_ == false, so exit this thread
-            }
-            callback_fun();
-        }
-    });
-}
-
 // stop the worker thread and join it
 SPDLOG_INLINE periodic_worker::~periodic_worker()
 {

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -20,7 +20,26 @@ namespace details {
 class SPDLOG_API periodic_worker
 {
 public:
-    periodic_worker(const std::function<void()> &callback_fun, std::chrono::seconds interval);
+    template<typename Rep, typename Period>
+    periodic_worker(const std::function<void()> &callback_fun, std::chrono::duration<Rep, Period> interval) {
+        active_ = (interval > std::chrono::duration<Rep, Period>::zero());
+        if (!active_)
+        {
+            return;
+        }
+
+        worker_thread_ = std::thread([this, callback_fun, interval]() {
+            for (;;)
+            {
+                std::unique_lock<std::mutex> lock(this->mutex_);
+                if (this->cv_.wait_for(lock, interval, [this] { return !this->active_; }))
+                {
+                    return; // active_ == false, so exit this thread
+                }
+                callback_fun();
+            }
+        });
+    }
     periodic_worker(const periodic_worker &) = delete;
     periodic_worker &operator=(const periodic_worker &) = delete;
     // stop the worker thread and join it

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -188,13 +188,6 @@ SPDLOG_INLINE void registry::flush_on(level::level_enum log_level)
     flush_level_ = log_level;
 }
 
-SPDLOG_INLINE void registry::flush_every(std::chrono::seconds interval)
-{
-    std::lock_guard<std::mutex> lock(flusher_mutex_);
-    auto clbk = [this]() { this->flush_all(); };
-    periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
-}
-
 SPDLOG_INLINE void registry::set_error_handler(err_handler handler)
 {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -67,11 +67,6 @@ SPDLOG_INLINE void flush_on(level::level_enum log_level)
     details::registry::instance().flush_on(log_level);
 }
 
-SPDLOG_INLINE void flush_every(std::chrono::seconds interval)
-{
-    details::registry::instance().flush_every(interval);
-}
-
 SPDLOG_INLINE void set_error_handler(void (*handler)(const std::string &msg))
 {
     details::registry::instance().set_error_handler(handler);

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -81,7 +81,11 @@ SPDLOG_API void flush_on(level::level_enum log_level);
 
 // Start/Restart a periodic flusher thread
 // Warning: Use only if all your loggers are thread safe!
-SPDLOG_API void flush_every(std::chrono::seconds interval);
+template<typename Rep, typename Period>
+inline void flush_every(std::chrono::duration<Rep, Period> interval)
+{
+    details::registry::instance().flush_every(interval);
+}
 
 // Set global error handler
 SPDLOG_API void set_error_handler(void (*handler)(const std::string &msg));


### PR DESCRIPTION
This allows things like:

```cpp
spdlog::flush_every(std::chrono::minutes(10));
spdlog::flush_every(std::chrono::milliseconds(100));
```