### PR TITLE
cmake: prevent leak of libfmt dependency into spdlog users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,9 @@ if(SPDLOG_FMT_EXTERNAL OR SPDLOG_FMT_EXTERNAL_HO)
         target_link_libraries(spdlog_header_only INTERFACE fmt::fmt)
     endif()
 
-    set(PKG_CONFIG_REQUIRES fmt) # add dependency to pkg-config
+    if(NOT SPDLOG_BUILD_SHARED)
+        set(PKG_CONFIG_REQUIRES fmt) # add dependency to pkg-config
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
When linking dynamically against spdlog there is no need for the user of the shared library to itself link against the dependencies of that spdlog. Doing it anyway causes problems when one of the dependencies gets a soname bump, because now the library user needs to be rebuild despite not using a single symbol of the updated dependency.