### PR TITLE
Add log about dropped messages

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -7,6 +7,7 @@
 #    include <spdlog/async_logger.h>
 #endif
 
+#include <spdlog/spdlog.h>
 #include <spdlog/sinks/sink.h>
 #include <spdlog/details/thread_pool.h>
 
@@ -63,6 +64,15 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
                 sink->log(msg);
             }
             SPDLOG_LOGGER_CATCH(msg.source)
+        }
+    }
+
+    if (auto pool_ptr = thread_pool_.lock())
+    {
+        auto lost_messages = pool_ptr->overrun_counter();
+        if (lost_messages > 0) {
+            spdlog::warn("Lost {} messages.", lost_messages);
+            pool_ptr->reset_overrun_counter();
         }
     }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -71,7 +71,7 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
     {
         auto lost_messages = pool_ptr->overrun_counter();
         if (lost_messages > 0) {
-            spdlog::warn("Lost {} messages.", lost_messages);
+            spdlog::debug("Lost {} messages.", lost_messages);
             pool_ptr->reset_overrun_counter();
         }
     }

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -7,7 +7,6 @@
 #    include <spdlog/async_logger.h>
 #endif
 
-#include <spdlog/spdlog.h>
 #include <spdlog/sinks/sink.h>
 #include <spdlog/details/thread_pool.h>
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -67,18 +67,18 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
         }
     }
 
+    if (should_flush_(msg))
+    {
+        backend_flush_();
+    }
+
     if (auto pool_ptr = thread_pool_.lock())
     {
         auto lost_messages = pool_ptr->overrun_counter();
         if (lost_messages > 0) {
-            spdlog::debug("Lost {} messages.", lost_messages);
+            err_handler_(fmt::format("Lost {} messages.", lost_messages));
             pool_ptr->reset_overrun_counter();
         }
-    }
-
-    if (should_flush_(msg))
-    {
-        backend_flush_();
     }
 }
 

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -62,16 +62,6 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
             SPDLOG_TRY
             {
                 sink->log(msg);
-
-                if (auto pool_ptr = thread_pool_.lock())
-                {
-                    auto lost_messages = pool_ptr->overrun_counter();
-                    if (lost_messages > 0) {
-                        sink->log(details::log_msg{name(), level::warn, fmt::format("Lost {} messages", lost_messages)});
-                        sink->flush();
-                        pool_ptr->reset_overrun_counter();
-                    }
-                }
             }
             SPDLOG_LOGGER_CATCH(msg.source)
         }

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -62,6 +62,16 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
             SPDLOG_TRY
             {
                 sink->log(msg);
+
+                if (auto pool_ptr = thread_pool_.lock())
+                {
+                    auto lost_messages = pool_ptr->overrun_counter();
+                    if (lost_messages > 0) {
+                        sink->log(details::log_msg{name(), level::warn, fmt::format("Lost {} messages", lost_messages)});
+                        sink->flush();
+                        pool_ptr->reset_overrun_counter();
+                    }
+                }
             }
             SPDLOG_LOGGER_CATCH(msg.source)
         }
@@ -70,15 +80,6 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
     if (should_flush_(msg))
     {
         backend_flush_();
-    }
-
-    if (auto pool_ptr = thread_pool_.lock())
-    {
-        auto lost_messages = pool_ptr->overrun_counter();
-        if (lost_messages > 0) {
-            err_handler_(fmt::format("Lost {} messages.", lost_messages));
-            pool_ptr->reset_overrun_counter();
-        }
     }
 }
 

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -117,6 +117,13 @@ bool SPDLOG_INLINE thread_pool::process_next_msg_()
     switch (incoming_async_msg.msg_type)
     {
     case async_msg_type::log: {
+        auto lost_messages = overrun_counter();
+        if (lost_messages > 0)
+        {
+            incoming_async_msg.worker_ptr->backend_sink_it_(
+                details::log_msg{incoming_async_msg.worker_ptr->name(), level::debug, fmt::format("Lost {} messages", lost_messages)});
+            reset_overrun_counter();
+        }
         incoming_async_msg.worker_ptr->backend_sink_it_(incoming_async_msg);
         return true;
     }

--- a/tests/test_async.cpp
+++ b/tests/test_async.cpp
@@ -40,7 +40,6 @@ TEST_CASE("discard policy ", "[async]")
         logger->info("Hello message");
     }
     REQUIRE(test_sink->msg_counter() < messages);
-    REQUIRE(tp->overrun_counter() > 0);
 }
 
 TEST_CASE("discard policy using factory ", "[async]")


### PR DESCRIPTION
Tracking dropped messages as the drops happen would be very useful in cases where someone is inspecting the logs and wonders if the program just skipped some parts that were supposed to be logged or if the logging was just slow.

The API was already there (overrun_counter), but in this PR it's used from the same thread that does the actual logging to the sink. Otherwise, the user would have to poll the thread_pool's overrun_counter from a different thread, which I think is not as nice.

