### PR TITLE
Use lower-case "windows.h" for case-sensitive file systems

### DIFF
--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,7 +1,7 @@
 #include "includes.h"
 
 #ifdef _WIN32
-#    include <Windows.h>
+#    include <windows.h>
 #else
 #    include <sys/types.h>
 #    include <dirent.h>


### PR DESCRIPTION
The "windows.h" in MinGW-W64 is lower-case. When cross-compiling for Windows on Linux with a case-sensitive file system, the upper-case "Windows.h" file is not found and compilation fails.

Always use lower-case "windows.h" to fix cross-compilation.