### PR TITLE
Workaround GCC 12 warning

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,11 @@ function(spdlog_prepare_test test_target spdlog_lib)
     endif()
     add_test(NAME ${test_target} COMMAND ${test_target})
     set_tests_properties(${test_target} PROPERTIES RUN_SERIAL ON)
+
+    # Workaround GCC 12 false positive
+    if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" MATCHES "^12\..*")
+        target_compile_options(${test_target} PRIVATE "-Wno-maybe-uninitialized")
+    endif()
 endfunction()
 
 # The compiled library tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,11 +57,6 @@ function(spdlog_prepare_test test_target spdlog_lib)
     endif()
     add_test(NAME ${test_target} COMMAND ${test_target})
     set_tests_properties(${test_target} PROPERTIES RUN_SERIAL ON)
-
-    # Workaround GCC 12 false positive
-    if( CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND "${CMAKE_CXX_COMPILER_VERSION}" MATCHES "^12\..*")
-        target_compile_options(${test_target} PRIVATE "-Wno-maybe-uninitialized")
-    endif()
 endfunction()
 
 # The compiled library tests

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -1,6 +1,15 @@
 #pragma once
 
+
+#if defined (__GNUC__) && __GNUC__ == 12
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // Workaround for GCC 12 
+#endif
 #include "catch.hpp"
+#if defined (__GNUC__) && __GNUC__ == 12
+# pragma GCC diagnostic pop
+#endif
+
 #include "utils.h"
 #include <chrono>
 #include <cstdio>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,2 +1,11 @@
+#if defined (__GNUC__) && __GNUC__ == 12
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // Workaround for GCC 12 
+#endif
+
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
+
+#if defined (__GNUC__) && __GNUC__ == 12
+# pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Building tests on GCC 12 fails due to a false positive in `functional` header:

```
In file included from /usr/local/include/c++/12.2.0/functional:59,
                 from […]/spdlog/tests/catch.hpp:3481,
                 from […]/spdlog/tests/includes.h:3,
                 from […]/spdlog/tests/test_daily_logger.cpp:4:
In constructor 'std::function<_Res(_ArgTypes ...)>::function(std::function<_Res(_ArgTypes ...)>&&) [with _Res = bool; _ArgTypes = {char}]',
    inlined from 'std::__detail::_State<_Char_type>::_State(std::__detail::_State<_Char_type>&&) [with _Char_type = char]' at /usr/local/include/c++/12.2.0/bits/regex_automaton.h:149:4,
    inlined from 'std::__detail::_State<_Char_type>::_State(std::__detail::_State<_Char_type>&&) [with _Char_type = char]' at /usr/local/include/c++/12.2.0/bits/regex_automaton.h:146:7,
    inlined from 'std::__detail::_StateIdT std::__detail::_NFA<_TraitsT>::_M_insert_subexpr_end() [with _TraitsT = std::__cxx11::regex_traits<char>]' at /usr/local/include/c++/12.2.0/bits/regex_automaton.h:290:24:
/usr/local/include/c++/12.2.0/bits/std_function.h:405:42: error: '*(std::function<bool(char)>*)((char*)&__tmp + offsetof(std::__detail::_StateT, std::__detail::_State<char>::<unnamed>.std::__detail::_State_base::<unnamed>)).std::function<bool(char)>::_M_invoker' may be used uninitialized [-Werror=maybe-uninitialized]
  405 |       : _Function_base(), _M_invoker(__x._M_invoker)
      |                                      ~~~~^~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```

- https://github.com/catchorg/Catch2/issues/2423
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562