### PR TITLE
Workaround deprecation warning on Clang with C++20

### DIFF
--- a/include/spdlog/fmt/chrono.h
+++ b/include/spdlog/fmt/chrono.h
@@ -15,7 +15,14 @@
 #                define FMT_HEADER_ONLY
 #            endif
 #        endif
+#        if __cplusplus >= 202002L && defined(__clang__)
+#            pragma clang diagnostic push
+#            pragma clang diagnostic ignored "-Wdeprecated" // Workaround for Clang C++20; remove once fmt >= 9.x
+#        endif
 #        include <spdlog/fmt/bundled/chrono.h>
+#        if __cplusplus >= 202002L && defined(__clang__)
+#            pragma clang diagnostic pop
+#        endif
 #    else
 #        include <fmt/chrono.h>
 #    endif


### PR DESCRIPTION
Compilation on Clang with C++20 (or later) and bundled *fmt* 8.x causes a deprecation warning:

```
In file included from […]/spdlog/example/example.cpp:132:
In file included from […]/spdlog/include/spdlog/sinks/daily_file_sink.h:10:
In file included from […]/spdlog/include/spdlog/fmt/chrono.h:18:
[…]/spdlog/include/spdlog/fmt/bundled/chrono.h:324:24: fatal error: 'codecvt<char32_t, char, __mbstate_t>' is deprecated [-Wdeprecated-declarations]
  using codecvt = std::codecvt<CodeUnit, char, std::mbstate_t>;
                       ^
[…]/spdlog/include/spdlog/fmt/bundled/chrono.h:358:5: note: in instantiation of function template specialization 'fmt::detail::write_codecvt<char32_t>' requested here
    write_codecvt(unit, in, loc);
    ^
```

This has been fixed in *fmt* 9.x according to it's upstream PR (https://github.com/fmtlib/fmt/pull/2725) 


#### Related

- https://github.com/fmtlib/fmt/pull/2725
- https://github.com/fmtlib/fmt/issues/2408
- #2471 