### PR TITLE
Export targets file to build directory at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,10 @@ if(SPDLOG_INSTALL)
     # ---------------------------------------------------------------------------------------
     # Install CMake config files
     # ---------------------------------------------------------------------------------------
+    export(
+      TARGETS spdlog
+      NAMESPACE spdlog::
+      FILE "${CMAKE_CURRENT_BINARY_DIR}/${config_targets_file}")
     install(EXPORT spdlog DESTINATION ${export_dest_dir} NAMESPACE spdlog:: FILE ${config_targets_file})
 
     include(CMakePackageConfigHelpers)


### PR DESCRIPTION
Addresses issue https://github.com/gabime/spdlog/issues/2514. Namely, an exported targets file `spdlogConfigTargets.cmake` will be written to the build directory at configure time. 

N.B. the exported targets file that will be placed in the build directory is _not_ the one that will be installed at install-time; that one is generated by the `install(...)` command, and has not been touched.