### PR TITLE
Use 'SPDLOG_FMT_RUNTIME' to fix compilation error throwed MSVC and fmt 9.1.x

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -78,7 +78,14 @@ struct daily_filename_format_calculator
         // generate fmt datetime format string, e.g. {:%Y-%m-%d}.
         filename_t fmt_filename = fmt::format(SPDLOG_FMT_STRING(SPDLOG_FILENAME_T("{{:{}}}")), filename);
 #    if defined(_MSC_VER) && defined(SPDLOG_WCHAR_FILENAMES) // for some reason msvc doesn't allow fmt::runtime(..) with wchar here
-        return fmt::format(fmt_filename, now_tm);
+#       if FMT_VERSION >= 90101
+            // fmt 9.1.x added compile-time checks for wide strings
+            // so when compiled with MSVC and this or later version of fmt
+            // here should use 'SPDLOG_FMT_RUNTIME' to enable 'fmt::runtime(...)' for wchar to avoid compile error
+            return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
+#       else
+            return fmt::format(fmt_filename, now_tm);
+#       endif
 #    else
         return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
 #    endif

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -77,18 +77,14 @@ struct daily_filename_format_calculator
 #else
         // generate fmt datetime format string, e.g. {:%Y-%m-%d}.
         filename_t fmt_filename = fmt::format(SPDLOG_FMT_STRING(SPDLOG_FILENAME_T("{{:{}}}")), filename);
-#    if defined(_MSC_VER) && defined(SPDLOG_WCHAR_FILENAMES) // for some reason msvc doesn't allow fmt::runtime(..) with wchar here
-#       if FMT_VERSION >= 90101
-            // fmt 9.1.x added compile-time checks for wide strings
-            // so when compiled with MSVC and this or later version of fmt
-            // here should use 'SPDLOG_FMT_RUNTIME' to enable 'fmt::runtime(...)' for wchar to avoid compile error
-            return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
-#       else
-            return fmt::format(fmt_filename, now_tm);
-#       endif
+
+        // MSVC doesn't allow fmt::runtime(..) with wchar, with fmtlib versions < 9.1.x
+#    if defined(_MSC_VER) && defined(SPDLOG_WCHAR_FILENAMES) && FMT_VERSION < 90101
+        return fmt::format(fmt_filename, now_tm);
 #    else
         return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
 #    endif
+
 #endif
     }
 


### PR DESCRIPTION
This is the first time I submit a PR to the open source community. I try to submit code and instructions according to the rules I have learned, but there may be inappropriate places to do it. Please also point out my problems actively, I will try to do it as soon as possible. Learn and correct.

fmt 9.1.x added compile-time checks for wide strings, so when compiled with MSVC and this or later version of fmt(9.1.x), codes belows will throw a compilation error  #(https://github.com/gabime/spdlog/issues/2512).
https://github.com/gabime/spdlog/blob/d011332616464bd0c84817d6255bf5910b7803e9/include/spdlog/sinks/daily_file_sink.h#L80-L84

When compiled with `SPDLOG_WCHAR_FILENAMES` with a newer verision of fmt(9.1.x) using MSVC,  `SPDLOG_FMT_RUNTIME` will solve the problem.
```c++
#    if defined(_MSC_VER) && defined(SPDLOG_WCHAR_FILENAMES) // for some reason msvc doesn't allow fmt::runtime(..) with wchar here
#       if FMT_VERSION >= 90101
            // fmt 9.1.x added compile-time checks for wide strings
            // so when compiled with MSVC and this or later version of fmt
            // here should use 'SPDLOG_FMT_RUNTIME' to enable 'fmt::runtime(...)' for wchar to avoid compile error
            return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
#       else
            return fmt::format(fmt_filename, now_tm);
#       endif
#    else
        return fmt::format(SPDLOG_FMT_RUNTIME(fmt_filename), now_tm);
#    endif
```