### PR TITLE
Mongo sink improvements

### DIFF
--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -37,7 +37,7 @@ public:
             db_name_ = db_name;
             coll_name_ = collection_name;
         }
-        catch (const std::exception)
+        catch (const std::exception&)
         {
             throw spdlog_ex("Error opening database");
         }

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -31,15 +31,15 @@ class mongo_sink : public base_sink<Mutex>
 {
 public:
     mongo_sink(const std::string &db_name, const std::string &collection_name, const std::string &uri = "mongodb://localhost:27017")
-    try
-        : mongo_sink(std::make_shared<mongocxx::instance>(), db_name, collection_name, uri)
+    try : mongo_sink(std::make_shared<mongocxx::instance>(), db_name, collection_name, uri)
     {}
     catch (const mongocxx::exception &e)
     {
         throw_spdlog_ex(fmt_lib::format("Error opening database: {}", e.what()));
     }
 
-    mongo_sink(std::shared_ptr<mongocxx::instance> instance, const std::string &db_name, const std::string &collection_name, const std::string &uri = "mongodb://localhost:27017")
+    mongo_sink(std::shared_ptr<mongocxx::instance> instance, const std::string &db_name, const std::string &collection_name,
+        const std::string &uri = "mongodb://localhost:27017")
         : instance_(std::move(instance))
         , db_name_(db_name)
         , coll_name_(collection_name)
@@ -67,10 +67,9 @@ protected:
 
         if (client_ != nullptr)
         {
-            auto doc = document{} << "timestamp" << bsoncxx::types::b_date(msg.time)
-                                  << "level" << level::to_string_view(msg.level).data() << "level_num" << msg.level
-                                  << "message" << std::string(msg.payload.begin(), msg.payload.end()) << "logger_name"
-                                  << std::string(msg.logger_name.begin(), msg.logger_name.end()) << "thread_id"
+            auto doc = document{} << "timestamp" << bsoncxx::types::b_date(msg.time) << "level" << level::to_string_view(msg.level).data()
+                                  << "level_num" << msg.level << "message" << std::string(msg.payload.begin(), msg.payload.end())
+                                  << "logger_name" << std::string(msg.logger_name.begin(), msg.logger_name.end()) << "thread_id"
                                   << static_cast<int>(msg.thread_id) << finalize;
             client_->database(db_name_).collection(coll_name_).insert_one(doc.view());
         }

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -56,7 +56,8 @@ protected:
 
         if (client_ != nullptr)
         {
-            auto doc = document{} << "timestamp" << bsoncxx::types::b_date(msg.time) << "level" << level::to_string_view(msg.level).data()
+            auto doc = document{} << "timestamp" << bsoncxx::types::b_date(msg.time)
+                                  << "level" << level::to_string_view(msg.level).data() << "level_num" << msg.level
                                   << "message" << std::string(msg.payload.begin(), msg.payload.end()) << "logger_name"
                                   << std::string(msg.logger_name.begin(), msg.logger_name.end()) << "thread_id"
                                   << static_cast<int>(msg.thread_id) << finalize;

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -31,8 +31,7 @@ class mongo_sink : public base_sink<Mutex>
 {
 public:
     mongo_sink(const std::string &db_name, const std::string &collection_name, const std::string &uri = "mongodb://localhost:27017")
-    try : mongo_sink(std::make_shared<mongocxx::instance>(), db_name, collection_name, uri) {}
-    catch (...) {} // Re-throws exception
+        : mongo_sink(std::make_shared<mongocxx::instance>(), db_name, collection_name, uri) {}
 
     mongo_sink(const std::shared_ptr<mongocxx::instance> &instance, const std::string &db_name, const std::string &collection_name, const std::string &uri = "mongodb://localhost:27017")
         : instance_(instance)

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -20,7 +20,6 @@
 #include <bsoncxx/view_or_value.hpp>
 
 #include <mongocxx/client.hpp>
-#include <mongocxx/exception/exception.hpp>
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 
@@ -33,7 +32,7 @@ public:
     mongo_sink(const std::string &db_name, const std::string &collection_name, const std::string &uri = "mongodb://localhost:27017")
     try : mongo_sink(std::make_shared<mongocxx::instance>(), db_name, collection_name, uri)
     {}
-    catch (const mongocxx::exception &e)
+    catch (const std::exception &e)
     {
         throw_spdlog_ex(fmt_lib::format("Error opening database: {}", e.what()));
     }


### PR DESCRIPTION
When using the Mongo sink in an application that also uses MongoCXX separately, there's the question of who should own the `mongocxx::instance` object because exactly one may exist in a program, and its lifetime must enclose the lifetimes of all other MongoCXX objects in the program ([MongoCXX docs](http://mongocxx.org/api/current/classmongocxx_1_1instance.html)). Currently, `mongo_sink` has a static field that owns the instance, causing an exception when any other code in the app tries to construct an instance.

I think it makes more sense for the main application to own it for these reasons:
1. The Mongo sink never does anything with it, but the application might have to access or configure it. From MongoCXX's [instance management example](https://github.com/mongodb/mongo-cxx-driver/blob/master/examples/mongocxx/instance_management.cpp):
   > real programs will typically require shared access to a commonly configured instance and connection pool across different translation units and components.

   This is impossible if `mongo_sink` owns the instance.
2. If the app was already using MongoCXX before starting to use Spdlog or `mongo_sink`, it already has code to construct and manage the MongoCXX instance, and that code would now break because an instance was already constructed by `mongo_sink`.

I implemented this by making a non-breaking change that makes `mongo_sink` *optionally* own the instance, only not owning it if one already exists or if an additional optional argument to the constructor is passed. It's still as convenient to use `mongo_sink` if not managing a MongoCXX instance separately, but it's also possible to prevent `mongo_sink` from creating one. Let me know if there's a better way.

A couple other small changes: querying logs by a certain log level or above (e.g., warn, error, critical or debug, warn, error, critical) is a common use case, and this is made much easier by putting the numerical log level in MongoDB along with the string log level. Also removed a G++ warning about catching an exception by value.