### PR TITLE
Update #include to deprecated fmt header

### DIFF
--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -15,7 +15,7 @@
 #if defined(SPDLOG_USE_STD_FORMAT)
 #    include <format>
 #elif defined(SPDLOG_FMT_EXTERNAL)
-#    include <fmt/locale.h>
+#    include <fmt/format.h>
 #else
 #    include "spdlog/fmt/bundled/format.h"
 #endif


### PR DESCRIPTION
The `<fmt/locale.h>` header has been marked as deprecated for a while and has finally been removed in fmt v0.9.0:
https://github.com/fmtlib/fmt/commit/5c7d315ded7bdb6cc5bd65daef091eefe

Replace with `<fmt/format.h>` instead, as recommended in the deprecated header.

The vcpkg build with the `benchmark` feature (`./vcpkg install spdlog[core,benchmark]`) is currently broken because of this:

```
[5/16] /usr/bin/c++ -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -I/workspaces/vcpkg/buildtrees/spdlog/src/v1.10.0-3cbe543323/include -isystem /workspaces/vcpkg/installed/x64-linux/include -fPIC -g -std=c++11 -MD -MT bench/CMakeFiles/bench.dir/bench.cpp.o -MF bench/CMakeFiles/bench.dir/bench.cpp.o.d -o bench/CMakeFiles/bench.dir/bench.cpp.o -c /workspaces/vcpkg/buildtrees/spdlog/src/v1.10.0-3cbe543323/bench/bench.cpp
FAILED: bench/CMakeFiles/bench.dir/bench.cpp.o 
/usr/bin/c++ -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -I/workspaces/vcpkg/buildtrees/spdlog/src/v1.10.0-3cbe543323/include -isystem /workspaces/vcpkg/installed/x64-linux/include -fPIC -g -std=c++11 -MD -MT bench/CMakeFiles/bench.dir/bench.cpp.o -MF bench/CMakeFiles/bench.dir/bench.cpp.o.d -o bench/CMakeFiles/bench.dir/bench.cpp.o -c /workspaces/vcpkg/buildtrees/spdlog/src/v1.10.0-3cbe543323/bench/bench.cpp
/workspaces/vcpkg/buildtrees/spdlog/src/v1.10.0-3cbe543323/bench/bench.cpp:18:14: fatal error: fmt/locale.h: No such file or directory
   18 | #    include <fmt/locale.h>
      |              ^~~~~~~~~~~~~~
compilation terminated.
```