### PR TITLE
fix dup_filter_sink lose source_loc

### DIFF
--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -67,7 +67,7 @@ protected:
             auto msg_size = ::snprintf(buf, sizeof(buf), "Skipped %u duplicate messages..", static_cast<unsigned>(skip_counter_));
             if (msg_size > 0 && static_cast<size_t>(msg_size) < sizeof(buf))
             {
-                details::log_msg skipped_msg{msg.logger_name, level::info, string_view_t{buf, static_cast<size_t>(msg_size)}};
+                details::log_msg skipped_msg{msg.source, msg.logger_name, level::info, string_view_t{buf, static_cast<size_t>(msg_size)}};
                 dist_sink<Mutex>::sink_it_(skipped_msg);
             }
         }


### PR DESCRIPTION
Hi, dup_filter_sink lose the source_loc, when I use it like this:

```c++
auto dup_filter = std::make_shared<spdlog::sinks::dup_filter_sink_st>(std::chrono::seconds(5));
dup_filter->set_sinks(spdlog::default_logger()->sinks());
spdlog::default_logger()->sinks() = {std::move(dup_filter)};
spdlog::default_logger()->set_pattern("%Y-%m-%d %H:%M:%S.%e %^%l%$ %t [%s:%#:%!] %v");

for (int i = 0; i < 5; ++i) { SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), "duplicate log"); }
SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), "different log");
```

It's output has none filename/line/functionname but `[::]`:

```
2022-11-22 14:43:54.773 info 13089 [main.cpp:126:test] duplicate log
2022-11-22 14:43:54.773 info 13089 [::] Skipped 4 duplicate messages..
2022-11-22 14:43:54.773 info 13089 [main.cpp:127:test] different log
```
