### PR TITLE
dup_filter_sink adds parameters to enable setting the level of skipped logs

### DIFF
--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -41,9 +41,9 @@ class dup_filter_sink : public dist_sink<Mutex>
 {
 public:
     template<class Rep, class Period>
-    explicit dup_filter_sink(std::chrono::duration<Rep, Period> max_skip_duration, level::level_enum level = level::info)
+    explicit dup_filter_sink(std::chrono::duration<Rep, Period> max_skip_duration, level::level_enum notification_level = level::info)
         : max_skip_duration_{max_skip_duration}
-        , log_level_{level}
+        , log_level_{notification_level}
     {}
 
 protected:

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -20,7 +20,7 @@
 //     #include <spdlog/sinks/dup_filter_sink.h>
 //
 //     int main() {
-//         auto dup_filter = std::make_shared<dup_filter_sink_st>(std::chrono::seconds(5));
+//         auto dup_filter = std::make_shared<dup_filter_sink_st>(std::chrono::seconds(5), level::info);
 //         dup_filter->add_sink(std::make_shared<stdout_color_sink_mt>());
 //         spdlog::logger l("logger", dup_filter);
 //         l.info("Hello");
@@ -41,8 +41,9 @@ class dup_filter_sink : public dist_sink<Mutex>
 {
 public:
     template<class Rep, class Period>
-    explicit dup_filter_sink(std::chrono::duration<Rep, Period> max_skip_duration)
+    explicit dup_filter_sink(std::chrono::duration<Rep, Period> max_skip_duration, level::level_enum level = level::info)
         : max_skip_duration_{max_skip_duration}
+        , log_level_{level}
     {}
 
 protected:
@@ -50,6 +51,7 @@ protected:
     log_clock::time_point last_msg_time_;
     std::string last_msg_payload_;
     size_t skip_counter_ = 0;
+    level::level_enum log_level_;
 
     void sink_it_(const details::log_msg &msg) override
     {
@@ -67,7 +69,7 @@ protected:
             auto msg_size = ::snprintf(buf, sizeof(buf), "Skipped %u duplicate messages..", static_cast<unsigned>(skip_counter_));
             if (msg_size > 0 && static_cast<size_t>(msg_size) < sizeof(buf))
             {
-                details::log_msg skipped_msg{msg.source, msg.logger_name, level::info, string_view_t{buf, static_cast<size_t>(msg_size)}};
+                details::log_msg skipped_msg{msg.source, msg.logger_name, log_level_, string_view_t{buf, static_cast<size_t>(msg_size)}};
                 dist_sink<Mutex>::sink_it_(skipped_msg);
             }
         }


### PR DESCRIPTION
By default, dup_filter_sink uses the info level to output duplicate messages.In some scenarios, users don't care about the messages and want to keep them at a lower level so they can ignore them.