### PR TITLE
Do not use LFS64 functions on linux/musl

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -236,8 +236,8 @@ SPDLOG_INLINE size_t filesize(FILE *f)
 #    else
     int fd = ::fileno(f);
 #    endif
-// 64 bits(but not in osx or cygwin, where fstat64 is deprecated)
-#    if (defined(__linux__) || defined(__sun) || defined(_AIX)) && (defined(__LP64__) || defined(_LP64))
+// 64 bits(but not in osx, linux/musl or cygwin, where fstat64 is deprecated)
+#    if ((defined(__linux__) && defined(__GLIBC__)) || defined(__sun) || defined(_AIX)) && (defined(__LP64__) || defined(_LP64))
     struct stat64 st;
     if (::fstat64(fd, &st) == 0)
     {


### PR DESCRIPTION
On musl, off_t is 64bit always ( even on 32bit platforms ), therefore using LFS64 funcitons is not needed on such platforms. Moreover, musl has stopped providing aliases for these functions [1] which means it wont compile on newer musl systems. Therefore only use it on 32bit glibc/linux platforms and exclude musl like cygwin or OSX

[1] https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4
Signed-off-by: Khem Raj <raj.khem@gmail.com>