### PR TITLE
fix build: fix for freebsd

### DIFF
--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <netinet/in.h>
 
 #include <string>
 


### PR DESCRIPTION
The build error was:
  include/spdlog/details/tcp_client.h:106:31: error: use of undeclared identifier 'IPPROTO_TCP'