### PR TITLE
Fix -Wshadow warnings in spdlog::sinks::dist_sink

### DIFF
--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -31,16 +31,16 @@ public:
     dist_sink(const dist_sink &) = delete;
     dist_sink &operator=(const dist_sink &) = delete;
 
-    void add_sink(std::shared_ptr<sink> sink)
+    void add_sink(std::shared_ptr<sink> sub_sink)
     {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
-        sinks_.push_back(sink);
+        sinks_.push_back(sub_sink);
     }
 
-    void remove_sink(std::shared_ptr<sink> sink)
+    void remove_sink(std::shared_ptr<sink> sub_sink)
     {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
-        sinks_.erase(std::remove(sinks_.begin(), sinks_.end(), sink), sinks_.end());
+        sinks_.erase(std::remove(sinks_.begin(), sinks_.end(), sub_sink), sinks_.end());
     }
 
     void set_sinks(std::vector<std::shared_ptr<sink>> sinks)


### PR DESCRIPTION
This is similar to fbba6dff20b0c04a0694515168914a62161999d7 but fixes a few member functions missed in that commit.

```
spdlog/sinks/dist_sink.h:34:41: error: declaration of 'sink' shadows a member of 'spdlog::sinks::dist_sink<std::mutex>' [-Werror=shadow]
   34 |     void add_sink(std::shared_ptr<sink> sink)
      |                   ~~~~~~~~~~~~~~~~~~~~~~^~~~
In file included from spdlog/sinks/base_sink.h:14,
                 from spdlog/sinks/dist_sink.h:6:
spdlog/sinks/sink.h:13:1: note: shadowed declaration is here
   13 | {
      | ^
```