### PR TITLE
Support newlib C library configurations without tm_gmtoff field

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -286,7 +286,7 @@ SPDLOG_INLINE int utc_minutes_offset(const std::tm &tm)
     return offset;
 #else
 
-#    if defined(sun) || defined(__sun) || defined(_AIX) || (!defined(_BSD_SOURCE) && !defined(_GNU_SOURCE))
+#    if defined(sun) || defined(__sun) || defined(_AIX) || (defined(__NEWLIB__) && !defined(__TM_GMTOFF)) || (!defined(_BSD_SOURCE) && !defined(_GNU_SOURCE))
     // 'tm_gmtoff' field is BSD extension and it's missing on SunOS/Solaris
     struct helper
     {


### PR DESCRIPTION
[Newlib C library](https://sourceware.org/newlib/) has a [configuration option](https://github.com/bminor/newlib/blob/ad3f9820b16a3dc5ea6237106436f565fcb2ed3e/newlib/libc/include/time.h#L48-L50) to add tm_gmtoff field to the `tm` structure.

Not all the platforms supported by newlib enable this option, and spdlog doesn't compile on such platforms due to missing `tm_gmtoff` field.

This PR fixes this by checking for `__NEWLIB__` and `__TM_GMTOFF` and enabling `calculate_gmt_offset`.