### PR TITLE
Add a trivial callback sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,34 @@ void multi_sink_example()
 ```
 
 ---
+#### Logger with a custom callback function that receives the logs
+```c++
+
+// create logger with a lambda function callback, the callback will be called
+// each time something is logged to the logger
+void callback_example()
+{
+    spdlog::custom_log_callbacks callbacks;
+    callbacks.on_log_formatted = [](std::string msg){
+        // for example you can be notified by sending an email to yourself
+    };
+    // or you can catch the log_msg object
+    // callbacks.on_log = [](spdlog::details::log_msg msg){
+    // };
+    
+    auto callback_sink = std::make_shared<spdlog::sinks::callback_sink_mt>(callbacks);
+    callback_sink->set_level(spdlog::level::err);
+
+    auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    spdlog::logger logger("custom_callback_logger", {console_sink, callback_sink});
+
+    logger.info("some info log");
+    logger.debug("some debug log");
+    logger.error("critical issue"); // will notify you
+}
+```
+
+---
 #### Asynchronous logging
 ```c++
 #include "spdlog/async.h"

--- a/README.md
+++ b/README.md
@@ -240,15 +240,9 @@ void multi_sink_example()
 // each time something is logged to the logger
 void callback_example()
 {
-    spdlog::custom_log_callbacks callbacks;
-    callbacks.on_log_formatted = [](std::string msg){
-        // for example you can be notified by sending an email to yourself
-    };
-    // or you can catch the log_msg object
-    // callbacks.on_log = [](spdlog::details::log_msg msg){
-    // };
-    
-    auto callback_sink = std::make_shared<spdlog::sinks::callback_sink_mt>(callbacks);
+    auto callback_sink = std::make_shared<spdlog::sinks::callback_sink_mt>([](const spdlog::details::log_msg &msg) {
+         // for example you can be notified by sending an email to yourself
+    });
     callback_sink->set_level(spdlog::level::err);
 
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -142,7 +142,7 @@ void daily_example()
 void callback_example()
 {
     // Create the logger
-    auto logger = spdlog::callback_logger_mt("custom_callback_logger", [](const spdlog::details::log_msg &msg) {
+    auto logger = spdlog::callback_logger_mt("custom_callback_logger", [](const spdlog::details::log_msg &/*msg*/) {
         // do what you need to do with msg
     });
 }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -12,6 +12,7 @@ void stdout_logger_example();
 void basic_example();
 void rotating_example();
 void daily_example();
+void callback_example();
 void async_example();
 void binary_example();
 void vector_example();
@@ -72,6 +73,7 @@ int main(int, char *[])
         basic_example();
         rotating_example();
         daily_example();
+        callback_example();
         async_example();
         binary_example();
         vector_example();
@@ -134,6 +136,22 @@ void daily_example()
 {
     // Create a daily logger - a new file is created every day on 2:30am.
     auto daily_logger = spdlog::daily_logger_mt("daily_logger", "logs/daily.txt", 2, 30);
+}
+
+#include "spdlog/sinks/callback_sink.h"
+void callback_example()
+{
+    // Define the callbacks
+    spdlog::custom_log_callbacks callbacks;
+    callbacks.on_log_formatted = [](std::string str){
+        // do what you need to do with str
+    };
+    callbacks.on_log = [](spdlog::details::log_msg msg){
+        // do what you need to do with msg
+    };
+    
+    // Create the logger
+    auto logger = spdlog::callback_logger_mt("custom_callback_logger", callbacks);
 }
 
 #include "spdlog/cfg/env.h"

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -141,17 +141,10 @@ void daily_example()
 #include "spdlog/sinks/callback_sink.h"
 void callback_example()
 {
-    // Define the callbacks
-    spdlog::custom_log_callbacks callbacks;
-    callbacks.on_log_formatted = [](std::string /*str*/){
-        // do what you need to do with str
-    };
-    callbacks.on_log = [](spdlog::details::log_msg /*msg*/){
-        // do what you need to do with msg
-    };
-    
     // Create the logger
-    auto logger = spdlog::callback_logger_mt("custom_callback_logger", callbacks);
+    auto logger = spdlog::callback_logger_mt("custom_callback_logger", [](const spdlog::details::log_msg &msg) {
+        // do what you need to do with msg
+    });
 }
 
 #include "spdlog/cfg/env.h"

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -143,10 +143,10 @@ void callback_example()
 {
     // Define the callbacks
     spdlog::custom_log_callbacks callbacks;
-    callbacks.on_log_formatted = [](std::string str){
+    callbacks.on_log_formatted = [](std::string /*str*/){
         // do what you need to do with str
     };
-    callbacks.on_log = [](spdlog::details::log_msg msg){
+    callbacks.on_log = [](spdlog::details::log_msg /*msg*/){
         // do what you need to do with msg
     };
     

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -15,14 +15,13 @@ namespace spdlog {
 // callbacks struct
 struct custom_log_callbacks
 {
-
     custom_log_callbacks()
         : on_log(nullptr)
         , on_log_formatted(nullptr)
     {}
 
-    std::function<void(const std::string &mag_str)> on_log_formatted;
     std::function<void(const details::log_msg &msg)> on_log;
+    std::function<void(const std::string &mag_str)> on_log_formatted;
 };
 
 namespace sinks {

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -1,0 +1,80 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/synchronous_factory.h>
+
+#include <mutex>
+#include <string>
+
+namespace spdlog {
+
+// callbacks struct
+struct custom_log_callbacks
+{
+
+    custom_log_callbacks()
+        : on_log(nullptr)
+        , on_log_formatted(nullptr)
+    {}
+
+    std::function<void(const std::string &mag_str)> on_log_formatted;
+    std::function<void(const details::log_msg &msg)> on_log;
+};
+
+namespace sinks {
+/*
+ * Trivial callback sink, gets a callback function and calls it on each log
+ */
+template<typename Mutex>
+class callback_sink final : public base_sink<Mutex>
+{
+public:
+    explicit callback_sink(const custom_log_callbacks &callbacks)
+        : callbacks_{callbacks}
+    {}
+
+protected:
+    void sink_it_(const details::log_msg &msg) override
+    {
+        if (callbacks_.on_log)
+            callbacks_.on_log(msg);
+        if (callbacks_.on_log_formatted)
+        {
+            memory_buf_t formatted;
+            base_sink<Mutex>::formatter_->format(msg, formatted);
+            auto eol_len = strlen(details::os::default_eol);
+            std::string str(formatted.data(), formatted.size() - eol_len);
+            callbacks_.on_log_formatted(str);
+        }
+    }
+    void flush_() override{};
+
+private:
+    custom_log_callbacks callbacks_;
+};
+
+using callback_sink_mt = callback_sink<std::mutex>;
+using callback_sink_st = callback_sink<details::null_mutex>;
+
+} // namespace sinks
+
+//
+// factory functions
+//
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> callback_logger_mt(const std::string &logger_name, const custom_log_callbacks &callbacks)
+{
+    return Factory::template create<sinks::callback_sink_mt>(logger_name, callbacks);
+}
+
+template<typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> callback_logger_st(const std::string &logger_name, const custom_log_callbacks &callbacks)
+{
+    return Factory::template create<sinks::callback_sink_st>(logger_name, callbacks);
+}
+
+} // namespace spdlog

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SPDLOG_UTESTS_SOURCES
     test_stdout_api.cpp
     test_backtrace.cpp
     test_create_dir.cpp
+    test_custom_callbacks.cpp
     test_cfg.cpp
     test_time_point.cpp
     test_stopwatch.cpp)

--- a/tests/test_custom_callbacks.cpp
+++ b/tests/test_custom_callbacks.cpp
@@ -1,0 +1,31 @@
+/*
+ * This content is released under the MIT License as specified in https://raw.githubusercontent.com/gabime/spdlog/master/LICENSE
+ */
+#include "includes.h"
+#include "test_sink.h"
+#include "spdlog/sinks/callback_sink.h"
+#include "spdlog/async.h"
+
+
+TEST_CASE("custom_callback_logger", "[custom_callback_logger]]")
+{
+    spdlog::custom_log_callbacks callbacks;
+    std::vector<std::string> lines;
+    callbacks.on_log_formatted = [&](std::string str) { lines.push_back(str); };
+
+    auto callback_logger = std::make_shared<spdlog::sinks::callback_sink_mt>(callbacks);
+    std::shared_ptr<spdlog::sinks::test_sink_st> test_sink(new spdlog::sinks::test_sink_st);
+
+    spdlog::logger logger("test-callback", {callback_logger, test_sink});
+
+    logger.info("test message 1");
+    logger.info("test message 2");
+    logger.info("test message 3");
+
+    std::vector<std::string> ref_lines = test_sink->lines();
+
+    REQUIRE(lines[0] == ref_lines[0]);
+    REQUIRE(lines[1] == ref_lines[1]);
+    REQUIRE(lines[2] == ref_lines[2]);
+    spdlog::drop_all();
+}


### PR DESCRIPTION
I needed such a functionality, to receive logs in a callback function, so I added this sink to the library.
The new sink, will call a custom callback, each time something is logged. 
The code was initially cloned from `basic_file_sink.h`. 
Required test, example and readme sample, added.