### PR TITLE
Add optional TID definition to the systemd sink send

### DIFF
--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <spdlog/sinks/base_sink.h>
+#include <spdlog/details/os.h>
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/synchronous_factory.h>
 
@@ -75,11 +76,17 @@ protected:
         {
             // Note: function call inside '()' to avoid macro expansion
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
+#ifndef SPDLOG_NO_THREAD_ID
+                "TID=%zu", os::thread_id(),
+#endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), nullptr);
         }
         else
         {
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
+#ifndef SPDLOG_NO_THREAD_ID
+                "TID=%zu", os::thread_id(),
+#endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), "CODE_FILE=%s",
                 msg.source.filename, "CODE_LINE=%d", msg.source.line, "CODE_FUNC=%s", msg.source.funcname, nullptr);
         }


### PR DESCRIPTION
From the systemd.journal-fields the TID is a user defined field passed directly from the clients and stored in the journal. Adding the arguement in the journal send to support that storage option in the journal.