### PR TITLE
Fix unexpected delimiter at start of line in to_hex formatter

### DIFF
--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -196,7 +196,7 @@ struct formatter<spdlog::details::dump_info<T>, char>
                 continue;
             }
 
-            if (put_delimiters)
+            if (put_delimiters && i != the_range.get_begin())
             {
                 *inserter++ = delimiter;
             }


### PR DESCRIPTION
When formatting as single line, there is an extra space at the beginning of the line. I think it's unexpected, not by design.

```cpp
std::vector<int> vec{1, 2, 3, 4, 5, 6, 7};

// single line
spdlog::info("[{:n}]", spdlog::to_hex(vec.begin(), vec.end()));

// multi-line
spdlog::info("[{}]", spdlog::to_hex(vec.begin(), vec.end(), 3));
spdlog::info("[{:a}]", spdlog::to_hex(vec.begin(), vec.end(), 3));
```