### PR TITLE
Fix MinGW build issue on example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
 target_include_directories(spdlog ${SPDLOG_INCLUDES_LEVEL} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(spdlog PUBLIC Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
+target_link_libraries(spdlog PUBLIC Threads::Threads)
 spdlog_enable_warnings(spdlog)
 
 set_target_properties(spdlog PROPERTIES VERSION ${SPDLOG_VERSION} SOVERSION ${SPDLOG_VERSION_MAJOR}.${SPDLOG_VERSION_MINOR})
@@ -198,7 +198,7 @@ add_library(spdlog::spdlog_header_only ALIAS spdlog_header_only)
 
 target_include_directories(spdlog_header_only ${SPDLOG_INCLUDES_LEVEL} INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                                         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(spdlog_header_only INTERFACE Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
+target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
 
 # ---------------------------------------------------------------------------------------
 # Use fmt package if using external fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,11 +176,10 @@ if(SPDLOG_SYSTEM_INCLUDES)
     set(SPDLOG_INCLUDES_LEVEL "SYSTEM")
 endif()
 
-
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
 target_include_directories(spdlog ${SPDLOG_INCLUDES_LEVEL} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(spdlog PUBLIC Threads::Threads)
+target_link_libraries(spdlog PUBLIC Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
 spdlog_enable_warnings(spdlog)
 
 set_target_properties(spdlog PROPERTIES VERSION ${SPDLOG_VERSION} SOVERSION ${SPDLOG_VERSION_MAJOR}.${SPDLOG_VERSION_MINOR})
@@ -199,7 +198,7 @@ add_library(spdlog::spdlog_header_only ALIAS spdlog_header_only)
 
 target_include_directories(spdlog_header_only ${SPDLOG_INCLUDES_LEVEL} INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                                         "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(spdlog_header_only INTERFACE Threads::Threads)
+target_link_libraries(spdlog_header_only INTERFACE Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
 
 # ---------------------------------------------------------------------------------------
 # Use fmt package if using external fmt

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Example of using pre-compiled library
 # ---------------------------------------------------------------------------------------
 add_executable(example example.cpp)
-target_link_libraries(example PRIVATE spdlog::spdlog $<$<BOOL:MINGW>:ws2_32>)
+target_link_libraries(example PRIVATE spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>)
 
 # ---------------------------------------------------------------------------------------
 # Example of using header-only library

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Example of using pre-compiled library
 # ---------------------------------------------------------------------------------------
 add_executable(example example.cpp)
-target_link_libraries(example PRIVATE spdlog::spdlog)
+target_link_libraries(example PRIVATE spdlog::spdlog $<$<BOOL:MINGW>:ws2_32>)
 
 # ---------------------------------------------------------------------------------------
 # Example of using header-only library

--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -15,9 +15,11 @@
 #include <stdio.h>
 #include <string>
 
-#pragma comment(lib, "Ws2_32.lib")
-#pragma comment(lib, "Mswsock.lib")
-#pragma comment(lib, "AdvApi32.lib")
+#if defined(_MSC_VER)
+#	pragma comment(lib, "Ws2_32.lib")
+#	pragma comment(lib, "Mswsock.lib")
+#	pragma comment(lib, "AdvApi32.lib")
+#endif
 
 namespace spdlog {
 namespace details {
@@ -25,7 +27,7 @@ class udp_client
 {
     static constexpr int TX_BUFFER_SIZE = 1024 * 10;
     SOCKET socket_ = INVALID_SOCKET;
-    sockaddr_in addr_ = {0};
+    sockaddr_in addr_ = {};
 
     static void init_winsock_()
     {


### PR DESCRIPTION
Fix build issue #2638 on example by adding ```ws2_32``` in these two target_include_directories if the type of compiler is from MinGW. 
```cmake
target_link_libraries(spdlog PUBLIC Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
target_link_libraries(spdlog_header_only INTERFACE Threads::Threads $<$<BOOL:${MINGW}>: ws2_32>)
```
I also made some little changes to "udp_client-windows.h" which uses pragma comment macros only when the Visual C++ compiler is used.
```c++
#if defined(_MSC_VER)
#	pragma comment(lib, "Ws2_32.lib")
#	pragma comment(lib, "Mswsock.lib")
#	pragma comment(lib, "AdvApi32.lib")
#endif
```
