### PR TITLE
Fix stdout_sink_base::log's behavior inconsistency

### DIFF
--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -68,6 +68,7 @@ SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const details::log_msg &m
     {
         throw_spdlog_ex("stdout_sink_base: WriteFile() failed. GetLastError(): " + std::to_string(::GetLastError()));
     }
+    FlushFileBuffers(handle_); // flush every line to terminal
 #else
     std::lock_guard<mutex_t> lock(mutex_);
     memory_buf_t formatted;

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -68,14 +68,13 @@ SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const details::log_msg &m
     {
         throw_spdlog_ex("stdout_sink_base: WriteFile() failed. GetLastError(): " + std::to_string(::GetLastError()));
     }
-    FlushFileBuffers(handle_); // flush every line to terminal
 #else
     std::lock_guard<mutex_t> lock(mutex_);
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
     ::fwrite(formatted.data(), sizeof(char), formatted.size(), file_);
-    ::fflush(file_); // flush every line to terminal
 #endif // WIN32
+    ::fflush(file_); // flush every line to terminal
 }
 
 template<typename ConsoleMutex>

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -60,7 +60,6 @@ SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::log(const details::log_msg &m
     std::lock_guard<mutex_t> lock(mutex_);
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
-    ::fflush(file_); // flush in case there is something in this file_ already
     auto size = static_cast<DWORD>(formatted.size());
     DWORD bytes_written = 0;
     bool ok = ::WriteFile(handle_, formatted.data(), size, &bytes_written, nullptr) != 0;


### PR DESCRIPTION
It will flush every time when it if not defined _WIN32, but not in Windows family.
We viewed the commit https://github.com/gabime/spdlog/commit/48d4ed9bc0179792d24621572a9fe40fe9080ebe for fixing issue #1675 . It seems missing this flushing operation in mistake.