### PR TITLE
Added `apply_logger_env_levels`

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -287,6 +287,14 @@ SPDLOG_INLINE registry &registry::instance()
     return s_instance;
 }
 
+SPDLOG_INLINE void registry::apply_logger_env_levels(std::shared_ptr<logger> new_logger)
+{
+    std::lock_guard<std::mutex> lock(logger_map_mutex_);
+    auto it = log_levels_.find(new_logger->name());
+    auto new_level = it != log_levels_.end() ? it->second : global_log_level_;
+    new_logger->set_level(new_level);
+}
+
 SPDLOG_INLINE void registry::throw_if_exists_(const std::string &logger_name)
 {
     if (loggers_.find(logger_name) != loggers_.end())

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -91,6 +91,8 @@ public:
 
     static registry &instance();
 
+    void apply_logger_env_levels(std::shared_ptr<logger> new_logger);
+
 private:
     registry();
     ~registry();

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -117,4 +117,9 @@ SPDLOG_INLINE void set_default_logger(std::shared_ptr<spdlog::logger> default_lo
     details::registry::instance().set_default_logger(std::move(default_logger));
 }
 
+SPDLOG_INLINE void apply_logger_env_levels(std::shared_ptr<logger> logger)
+{
+    details::registry::instance().apply_logger_env_levels(std::move(logger));
+}
+
 } // namespace spdlog

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -131,6 +131,15 @@ SPDLOG_API spdlog::logger *default_logger_raw();
 
 SPDLOG_API void set_default_logger(std::shared_ptr<spdlog::logger> default_logger);
 
+// Initialize logger level based on environment configs.
+//
+// Useful for applying SPDLOG_LEVEL to manually created loggers.
+//
+// Example:
+//   auto mylogger = std::make_shared<spdlog::logger>("mylogger", ...);
+//   spdlog::apply_logger_env_levels(mylogger);
+SPDLOG_API void apply_logger_env_levels(std::shared_ptr<logger> logger);
+
 template<typename... Args>
 inline void log(source_loc source, level::level_enum lvl, format_string_t<Args...> fmt, Args &&... args)
 {


### PR DESCRIPTION
This method applies levels which is set by environment variable `SPDLOG_LEVEL` to the a single logger. Useful for loading configuration into manually created loggers.