### PR TITLE
msvc_sink: support utf8

### DIFF
--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -48,7 +48,7 @@ protected:
         formatted.push_back('\0'); // add a null terminator for OutputDebugString
 #if defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
         wmemory_buf_t wformatted;
-        details::os::utf8_to_wstrbuf({formatted.data(), formatted.size()}, wformatted);
+        details::os::utf8_to_wstrbuf(string_view_t(formatted.data(), formatted.size()), wformatted);
         OutputDebugStringW(wformatted.data());
 #else
         OutputDebugStringA(formatted.data());

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -7,13 +7,20 @@
 #if defined(_WIN32)
 
 #    include <spdlog/details/null_mutex.h>
+#    if defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
+#        include <spdlog/details/os.h>
+#    endif
 #    include <spdlog/sinks/base_sink.h>
 
 #    include <mutex>
 #    include <string>
 
 // Avoid including windows.h (https://stackoverflow.com/a/30741042)
+#if defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringW(const wchar_t *lpOutputString);
+#else
 extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char *lpOutputString);
+#endif
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 
 namespace spdlog {
@@ -38,8 +45,14 @@ protected:
         }
         memory_buf_t formatted;
         base_sink<Mutex>::formatter_->format(msg, formatted);
-        formatted.push_back('\0'); // add a null terminator for OutputDebugStringA
+        formatted.push_back('\0'); // add a null terminator for OutputDebugString
+#if defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
+        wmemory_buf_t wformatted;
+        details::os::utf8_to_wstrbuf({formatted.data(), formatted.size()}, wformatted);
+        OutputDebugStringW(wformatted.data());
+#else
         OutputDebugStringA(formatted.data());
+#endif
     }
 
     void flush_() override {}


### PR DESCRIPTION
Here's a workaround I'm using in my own project, about this issue: #2012.

This time I added an option for developers to decide whether to enable this feature.

I think this is very helpful for users who use Visual Studio but cannot modify the built-in debug output window encoding. I believe this improvement has reason to be merged.