### PR TITLE
Fixed issue where msvc_sink did not correctly output Unicode when defining SPDLOG_WCHAR_TO_UTF8_SUPPORT macro.

### DIFF
--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -11,8 +11,15 @@
 
 #    include <mutex>
 #    include <string>
+#    include <memory>
 
 // Avoid including windows.h (https://stackoverflow.com/a/30741042)
+#    ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringW(const wchar_t *lpOutputString);
+extern "C" __declspec(dllimport) int __stdcall MultiByteToWideChar(UINT CodePage, DWORD dwFlags,
+    LPCCH lpMultiByteStr,
+    int cbMultiByte, LPWSTR lpWideCharStr, int cchWideChar);
+#    endif
 extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char *lpOutputString);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 
@@ -39,7 +46,24 @@ protected:
         memory_buf_t formatted;
         base_sink<Mutex>::formatter_->format(msg, formatted);
         formatted.push_back('\0'); // add a null terminator for OutputDebugStringA
-        OutputDebugStringA(formatted.data());
+#    ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+        auto const size{MultiByteToWideChar(CP_UTF8, 0, std::data(formatted), static_cast<int32_t>(std::size(formatted)), nullptr, 0)};
+
+        if (size == 0)
+        {
+            OutputDebugStringA(std::data(formatted));
+
+            return;
+        }
+
+        auto result{std::make_unique<wchar_t[]>(size)};
+
+        MultiByteToWideChar(CP_UTF8, 0, std::data(formatted), static_cast<int32_t>(std::size(formatted)), result.get(), size);
+
+        OutputDebugStringW(result.get());
+#    else
+        OutputDebugStringA(std::data(formatted));
+#    endif
     }
 
     void flush_() override {}

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -27,12 +27,12 @@ class msvc_sink : public base_sink<Mutex>
 public:
     msvc_sink() = default;
     msvc_sink(bool check_debugger_present)
-        : check_debbugger_present_{check_debugger_present} {};
+        : check_debugger_present_{check_debugger_present} {};
 
 protected:
     void sink_it_(const details::log_msg &msg) override
     {
-        if (check_debbugger_present_ && !IsDebuggerPresent())
+        if (check_debugger_present_ && !IsDebuggerPresent())
         {
             return;
         }
@@ -44,7 +44,7 @@ protected:
 
     void flush_() override {}
 
-    bool check_debbugger_present_ = true;
+    bool check_debugger_present_ = true;
 };
 
 using msvc_sink_mt = msvc_sink<std::mutex>;

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -26,8 +26,8 @@ class msvc_sink : public base_sink<Mutex>
 {
 public:
     msvc_sink() = default;
-    msvc_sink(bool check_ebugger_present)
-        : check_debbugger_present_{check_ebugger_present} {};
+    msvc_sink(bool check_debugger_present)
+        : check_debbugger_present_{check_debugger_present} {};
 
 protected:
     void sink_it_(const details::log_msg &msg) override


### PR DESCRIPTION
We should use OutputDebugStringW, instead of OutputDebugStringA.