### PR TITLE
Allow other builders running after build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         config:
           - { compiler: gcc, version: 4.9, build_type: Release, cppstd: 11, examples: OFF, asan: OFF }


### PR DESCRIPTION
Allow other builders running after build failures. This will prevent issues like #2656 from happening in the future.