### PR TITLE
Using std::source_location.

### DIFF
--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -27,6 +27,13 @@
 
 #include <vector>
 
+#ifdef __has_include
+#    if __has_include(<source_location>) && __cplusplus >= 202002L
+#        include <source_location>
+#        define SPDLOG_SOURCE_LOCATION
+#    endif
+#endif
+
 #ifndef SPDLOG_NO_EXCEPTIONS
 #    define SPDLOG_LOGGER_CATCH(location)                                                                                                  \
         catch (const std::exception &ex)                                                                                                   \
@@ -90,6 +97,14 @@ public:
         log_(loc, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
     }
 
+#ifdef SPDLOG_SOURCE_LOCATION
+    template<typename... Args>
+    void log(std::source_location loc, level::level_enum lvl, format_string_t<Args...> fmt, Args &&... args)
+    {
+        log_(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
+    }
+#endif
+
     template<typename... Args>
     void log(level::level_enum lvl, format_string_t<Args...> fmt, Args &&... args)
     {
@@ -108,6 +123,14 @@ public:
     {
         log(loc, lvl, "{}", msg);
     }
+
+#ifdef SPDLOG_SOURCE_LOCATION
+    template<typename T>
+    void log(std::source_location loc, level::level_enum lvl, const T &msg)
+    {
+        log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, lvl, msg);
+    }
+#endif
 
     void log(log_clock::time_point log_time, source_loc loc, level::level_enum lvl, string_view_t msg)
     {
@@ -182,6 +205,14 @@ public:
     {
         log_(loc, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
     }
+
+#   ifdef SPDLOG_SOURCE_LOCATION
+    template<typename... Args>
+    void log(std::source_location loc, level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&... args)
+    {
+        log_(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
+    }
+#   endif
 
     template<typename... Args>
     void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&... args)

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -19,6 +19,9 @@
 #include <functional>
 #include <memory>
 #include <string>
+#if __cplusplus >= 202002L
+#include <source_location>
+#endif
 
 namespace spdlog {
 
@@ -164,11 +167,25 @@ inline void debug(format_string_t<Args...> fmt, Args &&... args)
     default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
 }
 
+#if __cplusplus >= 202002L
+template<typename... Args>
+struct info
+{
+    info(format_string_t<Args...> fmt, Args &&...args, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::info, fmt, std::forward<Args>(args)...);
+    }
+};
+
+template <typename... Args>
+info(format_string_t<Args...> fmt, Args &&... args) -> info<Args...>;
+#else
 template<typename... Args>
 inline void info(format_string_t<Args...> fmt, Args &&... args)
 {
     default_logger_raw()->info(fmt, std::forward<Args>(args)...);
 }
+#endif
 
 template<typename... Args>
 inline void warn(format_string_t<Args...> fmt, Args &&... args)
@@ -260,12 +277,6 @@ template<typename T>
 inline void debug(const T &msg)
 {
     default_logger_raw()->debug(msg);
-}
-
-template<typename T>
-inline void info(const T &msg)
-{
-    default_logger_raw()->info(msg);
 }
 
 template<typename T>

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -21,7 +21,7 @@
 #include <string>
 
 #ifdef __has_include
-#    if __has_include(<source_location>)
+#    if __has_include(<source_location>) && __cplusplus >= 202002L
 #        include <source_location>
 #        define SPDLOG_SOURCE_LOCATION
 #    endif
@@ -194,6 +194,42 @@ template<typename... Args>
 inline void critical(format_string_t<Args...> fmt, Args &&... args)
 {
     default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+}
+
+template<typename T>
+inline void trace(const T &msg)
+{
+    default_logger_raw()->trace(msg);
+}
+
+template<typename T>
+inline void debug(const T &msg)
+{
+    default_logger_raw()->debug(msg);
+}
+
+template<typename T>
+inline void info(const T &msg)
+{
+    default_logger_raw()->info(msg);
+}
+
+template<typename T>
+inline void warn(const T &msg)
+{
+    default_logger_raw()->warn(msg);
+}
+
+template<typename T>
+inline void error(const T &msg)
+{
+    default_logger_raw()->error(msg);
+}
+
+template<typename T>
+inline void critical(const T &msg)
+{
+    default_logger_raw()->critical(msg);
 }
 #endif
 
@@ -395,6 +431,108 @@ error(wformat_string_t<Args...> fmt, Args &&... args) -> error<Args...>;
 template <typename... Args>
 critical(wformat_string_t<Args...> fmt, Args &&... args) -> critical<Args...>;
 #   endif
+
+template<typename T>
+struct trace<T>
+{
+    trace(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::trace, msg);
+    }
+
+    trace(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::trace, fmt, std::forward<T>(arg));
+    }
+};
+
+template<typename T>
+struct debug<T>
+{
+    debug(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::debug, msg);
+    }
+
+    debug(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::debug, fmt, std::forward<T>(arg));
+    }
+};
+
+template<typename T>
+struct info<T>
+{
+    info(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::info, msg);
+    }
+
+    info(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::info, fmt, std::forward<T>(arg));
+    }
+};
+
+template<typename T>
+struct warn<T>
+{
+    warn(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::warn, msg);
+    }
+
+    warn(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::warn, fmt, std::forward<T>(arg));
+    }
+};
+
+template<typename T>
+struct error<T>
+{
+    error(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::err, msg);
+    }
+
+    error(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::err, fmt, std::forward<T>(arg));
+    }
+};
+
+template<typename T>
+struct critical<T>
+{
+    critical(const T &msg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::critical, msg);
+    }
+
+    critical(format_string_t<T> fmt, T&& arg, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::critical, fmt, std::forward<T>(arg));
+    }
+};
+
+template <typename T>
+trace(const T &msg) -> trace<T>;
+
+template <typename T>
+debug(const T &msg) -> debug<T>;
+
+template <typename T>
+info(const T &msg) -> info<T>;
+
+template <typename T>
+warn(const T &msg) -> warn<T>;
+
+template <typename T>
+error(const T &msg) -> error<T>;
+
+template <typename T>
+critical(const T &msg) -> critical<T>;
 #endif
 
 } // namespace spdlog

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -175,16 +175,36 @@ struct info
     {
         default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::info, fmt, std::forward<Args>(args)...);
     }
+
+#   ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+    info(wformat_string_t<Args...> fmt, Args &&... args, const std::source_location &loc = std::source_location::current())
+    {
+        default_logger_raw()->log(spdlog::source_loc{loc.file_name(), static_cast<int>(loc.line()), loc.function_name()}, level::info, fmt, std::forward<Args>(args)...);
+    }
+#   endif
 };
 
 template <typename... Args>
 info(format_string_t<Args...> fmt, Args &&... args) -> info<Args...>;
+
+#   ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+template <typename... Args>
+info(wformat_string_t<Args...> fmt, Args &&... args) -> info<Args...>;
+#   endif
 #else
 template<typename... Args>
 inline void info(format_string_t<Args...> fmt, Args &&... args)
 {
     default_logger_raw()->info(fmt, std::forward<Args>(args)...);
 }
+
+#   ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
+template<typename... Args>
+inline void info(wformat_string_t<Args...> fmt, Args &&... args)
+{
+    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+}
+#   endif
 #endif
 
 template<typename... Args>
@@ -240,12 +260,6 @@ template<typename... Args>
 inline void debug(wformat_string_t<Args...> fmt, Args &&... args)
 {
     default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
-}
-
-template<typename... Args>
-inline void info(wformat_string_t<Args...> fmt, Args &&... args)
-{
-    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
 }
 
 template<typename... Args>

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -255,11 +255,11 @@ TEST_CASE("default logger API", "[default logger]")
     REQUIRE(oss.str() == "*** Hello again 2" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");
-    spdlog::error("{}", 123);
+    spdlog::error(123);
     REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");
-    spdlog::critical("some string");
+    spdlog::critical(std::string("some string"));
     REQUIRE(oss.str() == "*** some string" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -255,11 +255,11 @@ TEST_CASE("default logger API", "[default logger]")
     REQUIRE(oss.str() == "*** Hello again 2" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");
-    spdlog::error(123);
+    spdlog::error("{}", 123);
     REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");
-    spdlog::critical(std::string("some string"));
+    spdlog::critical("some string");
     REQUIRE(oss.str() == "*** some string" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -259,6 +259,18 @@ TEST_CASE("default logger API", "[default logger]")
     REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
 
     oss.str("");
+    spdlog::log(spdlog::level::err, 123);
+    REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
+
+    oss.str("");
+    spdlog::log(spdlog::level::err, "{}", 123);
+    REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
+
+    oss.str("");
+    spdlog::log(spdlog::level::err, "{}{}{}", 1, 2, 3);
+    REQUIRE(oss.str() == "*** 123" + std::string(spdlog::details::os::default_eol));
+
+    oss.str("");
     spdlog::critical(std::string("some string"));
     REQUIRE(oss.str() == "*** some string" + std::string(spdlog::details::os::default_eol));
 


### PR DESCRIPTION
It would be great to have support for std::source_location without using the macro version when compiling for C++ 20 (related issue at #1823).

I drafted an idea on how to implement that. 

The only issue with this implementation is that it would introduce a small breaking change:

`spdlog::info(1)` 

would not compile anymore. However, that does not work with fmt anyway.