### PR TITLE
Fix os namespace in systemd_sink.h

### DIFF
--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -77,7 +77,7 @@ protected:
             // Note: function call inside '()' to avoid macro expansion
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
 #ifndef SPDLOG_NO_THREAD_ID
-                "TID=%zu", spdlog::details::os::thread_id(),
+                "TID=%zu", details::os::thread_id(),
 #endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), nullptr);
         }
@@ -85,7 +85,7 @@ protected:
         {
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
 #ifndef SPDLOG_NO_THREAD_ID
-                "TID=%zu", spdlog::details::os::thread_id(),
+                "TID=%zu", details::os::thread_id(),
 #endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), "CODE_FILE=%s",
                 msg.source.filename, "CODE_LINE=%d", msg.source.line, "CODE_FUNC=%s", msg.source.funcname, nullptr);

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -77,7 +77,7 @@ protected:
             // Note: function call inside '()' to avoid macro expansion
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
 #ifndef SPDLOG_NO_THREAD_ID
-                "TID=%zu", os::thread_id(),
+                "TID=%zu", spdlog::details::os::thread_id(),
 #endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), nullptr);
         }
@@ -85,7 +85,7 @@ protected:
         {
             err = (sd_journal_send)("MESSAGE=%.*s", static_cast<int>(length), payload.data(), "PRIORITY=%d", syslog_level(msg.level),
 #ifndef SPDLOG_NO_THREAD_ID
-                "TID=%zu", os::thread_id(),
+                "TID=%zu", spdlog::details::os::thread_id(),
 #endif
                 "SYSLOG_IDENTIFIER=%.*s", static_cast<int>(syslog_identifier.size()), syslog_identifier.data(), "CODE_FILE=%s",
                 msg.source.filename, "CODE_LINE=%d", msg.source.line, "CODE_FUNC=%s", msg.source.funcname, nullptr);


### PR DESCRIPTION
#2619  added `os::thread_id()` function calls to `spdlog/sinks/systemd_sink.h`.

But access to `os::thread_id()` is not valid, as the full namespace is `spdlog::details::os`, while the current code is in the namespace `spdlog::sinks` and thus the namespace `os::` is not directly accessible.

As a side note: The [test_systemd.cpp](https://github.com/gabime/spdlog/blob/v1.x/tests/test_systemd.cpp) is currently not built in the pipeline, because it fails to find systemd in the cmake configuration step. Mabye it is sufficient to install the `libsystemd-dev` package in the container?