### PR TITLE
Enable systemd_sink tests in linux pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Setup
         run: |
-          apt-get update && apt-get install -y curl git libsystemd-dev
+          apt-get update && apt-get install -y curl git pkg-config libsystemd-dev
           CMAKE_VERSION="3.24.2"
           curl -sSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh -o install-cmake.sh
           chmod +x install-cmake.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@main
       - name: Setup
         run: |
-          apt-get update && apt-get install -y curl git
+          apt-get update && apt-get install -y curl git libsystemd-dev
           CMAKE_VERSION="3.24.2"
           curl -sSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh -o install-cmake.sh
           chmod +x install-cmake.sh


### PR DESCRIPTION
As mentioned in #2668, the [test_systemd.cpp](https://github.com/gabime/spdlog/blob/v1.x/tests/test_systemd.cpp) tests are not build and executed in the linux pipeline, as pkg-config and libsystemd-dev packages are not installed.

In [tests/CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/tests/CMakeLists.txt):
```
find_package(PkgConfig)
if(PkgConfig_FOUND)
    pkg_check_modules(systemd libsystemd)
endif()

...

if(systemd_FOUND)
    list(APPEND SPDLOG_UTESTS_SOURCES test_systemd.cpp)
endif()
```

By installing the two packages, the `test_systemd.cpp` tests should be built.

Note: Without #2668 the tests will not compile.