### PR TITLE
fix small issue when compiling with C++20 without std::format

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -279,7 +279,7 @@ struct fmt::formatter<my_type> : fmt::formatter<std::string>
 {
     auto format(my_type my, format_context &ctx) -> decltype(ctx.out())
     {
-        return format_to(ctx.out(), "[my_type i={}]", my.i);
+        return fmt::format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };
 


### PR DESCRIPTION
make sure to specify that fmt namespace is in use when calling format_to. It's resolution was ambiguous when compiling with C++20.