### PR TITLE
os-inl.h: fix for missing pthread_threadid_np

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -62,6 +62,10 @@
 
 #endif // unix
 
+#if defined __APPLE__
+#    include <AvailabilityMacros.h>
+#endif
+
 #ifndef __has_feature          // Clang - feature checking macros.
 #    define __has_feature(x) 0 // Compatibility with non-clang compilers.
 #endif
@@ -355,7 +359,19 @@ SPDLOG_INLINE size_t _thread_id() SPDLOG_NOEXCEPT
     return static_cast<size_t>(::thr_self());
 #elif __APPLE__
     uint64_t tid;
-    pthread_threadid_np(nullptr, &tid);
+    // There is no pthread_threadid_np prior to 10.6, and it is not supported on any PPC,
+    // including 10.6.8 Rosetta. __POWERPC__ is Apple-specific define encompassing ppc and ppc64.
+#    if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
+        tid = pthread_mach_thread_np(pthread_self());
+#    elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+        if (&pthread_threadid_np) {
+            pthread_threadid_np(nullptr, &tid);
+        } else {
+            tid = pthread_mach_thread_np(pthread_self());
+        }
+#    else
+        pthread_threadid_np(nullptr, &tid);
+#    endif
     return static_cast<size_t>(tid);
 #else // Default to standard C++11 (other Unix)
     return static_cast<size_t>(std::hash<std::thread::id>()(std::this_thread::get_id()));


### PR DESCRIPTION
`pthread_threadid_np` is missing on macOS < 10.6, as well as on any PowerPC (including 10.6 PPC and 10.6.8 Rosetta, therefore additional condition).