### PR TITLE
Update fmtlib fixed issues

### DIFF
--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -1354,8 +1354,8 @@ template <typename Float> constexpr int num_significand_bits() {
 template <typename Float>
 constexpr auto exponent_mask() ->
     typename dragonbox::float_info<Float>::carrier_uint {
-  using uint = typename dragonbox::float_info<Float>::carrier_uint;
-  return ((uint(1) << dragonbox::float_info<Float>::exponent_bits) - 1)
+  using carrier_uint = typename dragonbox::float_info<Float>::carrier_uint;
+  return ((carrier_uint(1) << dragonbox::float_info<Float>::exponent_bits) - 1)
          << num_significand_bits<Float>();
 }
 template <typename Float> constexpr auto exponent_bias() -> int {
@@ -3248,9 +3248,9 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
 
   constexpr auto specs = basic_format_specs<Char>();
   using floaty = conditional_t<std::is_same<T, long double>::value, double, T>;
-  using uint = typename dragonbox::float_info<floaty>::carrier_uint;
-  uint mask = exponent_mask<floaty>();
-  if ((bit_cast<uint>(value) & mask) == mask)
+  using carrier_uint = typename dragonbox::float_info<floaty>::carrier_uint;
+  carrier_uint mask = exponent_mask<floaty>();
+  if ((bit_cast<carrier_uint>(value) & mask) == mask)
     return write_nonfinite(out, std::isnan(value), specs, fspecs);
 
   auto dec = dragonbox::to_decimal(static_cast<floaty>(value));


### PR DESCRIPTION
Because fmtlib fixes this problem, it hasn't been released yet. The spdlog lib binds it. In order to better use sdplog, I want to fix the error.

To fix [fmtlib/fmt#3137](https://github.com/fmtlib/fmt/pull/3137)

I know it is not a wise choice, but I can't think of a better way for people to avoid this mistake