### PR TITLE
Removes special format handling for fmt. 

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -18,7 +18,6 @@
 #include <ctime>
 #include <mutex>
 #include <string>
-#include <vector>
 
 namespace spdlog {
 namespace sinks {
@@ -58,12 +57,12 @@ struct daily_filename_format_calculator
         // https://github.com/fmtlib/fmt/issues/2238
         tm_format.push_back(' ');
 
-        const size_t MIN_SIZE = 10;
-        std::vector<char> buf;
+        const size_t MIN_SIZE = 64;
+        filename_t buf;
         buf.resize(MIN_SIZE);
         for (;;)
         {
-            size_t count = strftime(buf.data(), buf.size(), tm_format.c_str(), &now_tm);
+            size_t count = strftime(&buf[0], buf.size(), tm_format.c_str(), &now_tm);
             if (count != 0)
             {
                 // Remove the extra space.
@@ -73,7 +72,7 @@ struct daily_filename_format_calculator
             buf.resize(buf.size() * 2);
         }
 
-        return std::string(buf.cbegin(), buf.cend());
+	return buf;
     }
 
 private:

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -46,12 +46,12 @@ struct daily_filename_calculator
  */
 struct daily_filename_format_calculator
 {
-    static filename_t calc_filename(const filename_t &filename, const tm &now_tm)
+    static filename_t calc_filename(const filename_t &filepath, const tm &now_tm)
     {
         // adapted from fmtlib: https://github.com/fmtlib/fmt/blob/8.0.1/include/fmt/chrono.h#L522-L546
 
         filename_t tm_format;
-        tm_format.append(filename);
+        tm_format.append(filepath);
         // By appending an extra space we can distinguish an empty result that
         // indicates insufficient buffer size from a guaranteed non-empty result
         // https://github.com/fmtlib/fmt/issues/2238
@@ -69,7 +69,12 @@ struct daily_filename_format_calculator
                 buf.resize(count - 1);
                 break;
             }
-            buf.resize(buf.size() * 2);
+            buf.resize(buf.size() + 255);
+
+	    if (buf.size() > 4096)
+            {
+                throw spdlog_ex("daily_file_sink: calc_filename() - strftime error or file name too big");
+	    }
         }
 
 	return buf;


### PR DESCRIPTION
Regains test compatibility with fmt 1.10.0.

Most of the patch was provided by @tt4g.

fixes #2735