### PR TITLE
ignore vscode and clangd cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ spdlogConfigVersion.cmake
 
 # idea
 .idea/
+.cache/
+.vscode/
 cmake-build-*/
 *.db
 *.ipch


### PR DESCRIPTION
I'm not sure if many people use vscode as a development environment for C++, when I use vscode to open the project, there are a lot of caches, which annoys me, it would be nice if I could ignore these files in the .gitignore file, .vscode file The personal environment configuration file is stored in the folder, and the cache generated by clangd analysis code is stored in the .cache folder.