### PR TITLE
Removing IPv4 limitation from tcp_client

### DIFF
--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -83,7 +83,7 @@ public:
         {};
         ZeroMemory(&hints, sizeof(hints));
 
-        hints.ai_family = AF_INET;       // IPv4
+        hints.ai_family = AF_UNSPEC;     // To work with IPv4, IPv6, and so on
         hints.ai_socktype = SOCK_STREAM; // TCP
         hints.ai_flags = AI_NUMERICSERV; // port passed as as numeric value
         hints.ai_protocol = 0;

--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -57,7 +57,7 @@ public:
         struct addrinfo hints
         {};
         memset(&hints, 0, sizeof(struct addrinfo));
-        hints.ai_family = AF_INET;       // IPv4
+        hints.ai_family = AF_UNSPEC;     // To work with IPv4, IPv6, and so on
         hints.ai_socktype = SOCK_STREAM; // TCP
         hints.ai_flags = AI_NUMERICSERV; // port passed as as numeric value
         hints.ai_protocol = 0;


### PR DESCRIPTION
For the issue: https://github.com/gabime/spdlog/issues/2784.