### PR TITLE
sinks: android: handle when message is not loggable

### DIFF
--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -56,6 +56,10 @@ protected:
 
         // See system/core/liblog/logger_write.c for explanation of return value
         int ret = android_log(priority, tag_.c_str(), msg_output);
+        if (ret == -EPERM)
+        {
+            return; // !__android_log_is_loggable
+        }
         int retry_count = 0;
         while ((ret == -11 /*EAGAIN*/) && (retry_count < SPDLOG_ANDROID_RETRIES))
         {


### PR DESCRIPTION
Android logger (since API 30) checks the per-tag property `log.tag.<tag>` to determine if a log message is loggable. See https://developer.android.com/ndk/reference/group/logging#__android_log_is_loggable . For example, `__android_log_buf_write` for a VERBOSE message will call `__android_log_is_loggable` and return `-EPERM` if the log message will not be printed because `log.tag.<tag>` is set to `INFO`.

Instead of erroring with the following, the Android sink should handle `-EPERM`. It is not an error to disable a log via the run-time property.

```
[*** LOG ERROR #0001 ***] [2023-06-29 00:50:26] [logcat] logging to Android failed: Unknown error -1 [/path/to/file.cpp(123)]
```