### PR TITLE
Multi color range

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,10 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     option(SPDLOG_CLOCK_COARSE "Use CLOCK_REALTIME_COARSE instead of the regular clock," OFF)
+    option(SPDLOG_EXTENDED_STLYING "Use the extended styling system and syntax" OFF)
 else()
     set(SPDLOG_CLOCK_COARSE OFF CACHE BOOL "non supported option" FORCE)
+    set(SPDLOG_EXTENDED_STLYING "non supported option" FORCE)
 endif()
 
 option(SPDLOG_PREVENT_CHILD_FD "Prevent from child processes to inherit log file descriptors" OFF)
@@ -245,6 +247,7 @@ foreach(
     SPDLOG_WCHAR_FILENAMES
     SPDLOG_NO_EXCEPTIONS
     SPDLOG_CLOCK_COARSE
+    SPDLOG_EXTENDED_STLYING
     SPDLOG_PREVENT_CHILD_FD
     SPDLOG_NO_THREAD_ID
     SPDLOG_NO_TLS

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -52,7 +52,7 @@ int main(int, char *[])
     spdlog::debug("This message should be displayed..");
 
     // Customize msg format for all loggers
-    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [thread %t] %v");
+    spdlog::set_pattern("[%^%H:%M:%S %z%$] [%^%L%$] [thread %t] %^%v%$");
     spdlog::info("This an info message with custom format");
     spdlog::set_pattern("%+"); // back to default format
     spdlog::set_level(spdlog::level::info);

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -26,6 +26,7 @@ void udp_example();
 void custom_flags_example();
 void file_events_example();
 void replace_default_logger_example();
+void extended_stlying();
 
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"  // support for loading levels from the environment variable
@@ -87,6 +88,7 @@ int main(int, char *[])
         custom_flags_example();
         file_events_example();
         replace_default_logger_example();
+        extended_stlying();
 
         // Flush all *registered* loggers using a worker thread every 3 seconds.
         // note: registered loggers *must* be thread safe for this to work correctly!
@@ -395,4 +397,60 @@ void replace_default_logger_example()
     spdlog::debug("This message should be displayed..");
 
     spdlog::set_default_logger(old_logger);
+}
+
+void extended_stlying()
+{
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    // with extended styling you may use the mutliple color
+    // area formatter "%^" in more than one spot in your pattern.
+    // in addition there are syntax extensions to the color formatter
+    // they are defined by squirley braces { } after the '%' but before
+    // the '^'. (example: "%{bold}^")
+    //
+    // mutliple stylings can apply to a single area by delimiting the key
+    // words with a ';'. (example: "%{bold;fg_blue}^")
+    //
+    // styling key words come in three flavors font style, font foreground
+    // color, and font background color
+    //
+    // font styles:
+    // reset bold dark underline blink reverse
+    //
+    // font foreground colors:
+    // fg_black fg_red fg_green fg_yellow fg_blue fg_magenta fg_cyan fg_white fg_default
+    //
+    // font background colors:
+    // bg_black bg_red bg_green bg_yellow bg_blue bg_magenta bg_cyan bg_white bg_default
+
+
+    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [thread %t] %v");
+    spdlog::info("regular log message");
+
+    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [thread %t] %^%v%$");
+    spdlog::info("multiple color areas");
+
+    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [%{fg_yellow}^thread %t%$] %^%v%$");
+    spdlog::info("multiple color areas with more than one color");
+
+    spdlog::set_pattern("[%{bold;fg_red}^%H:%M:%S %z%$] [%^%L%$] [%{fg_yellow}^thread %t%$] %{bold;fg_cyan}^%v%$");
+    spdlog::info("bold colors?");
+
+    spdlog::set_pattern(
+        "[%{bold;fg_red}^%H:%M:%S %z%$] "
+        "[%^%L%$] [%{fg_yellow}^thread %t%$] "
+        "even %{bold;blink;fg_magenta;bg_black}^%v%$ colors?"
+    );
+    spdlog::info("blinking");
+
+    spdlog::set_pattern("[%{fg_yellow;bold}^%H:%M:%S %z%$] [%^%L%$] [%^thread %t%$] %^%v%$");
+    spdlog::set_level(spdlog::level::trace);
+    spdlog::trace("I work on other levels?");
+    spdlog::debug("I work on other levels?");
+    spdlog::info("I work on other levels?");
+    spdlog::warn("I work on other levels?");
+    spdlog::error("I work on other levels?");
+    spdlog::critical("I work on other levels?");
+    spdlog::set_pattern("%+"); // back to default format
+#endif
 }

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -52,7 +52,7 @@ int main(int, char *[])
     spdlog::debug("This message should be displayed..");
 
     // Customize msg format for all loggers
-    spdlog::set_pattern("[%^%H:%M:%S %z%$] [%^%L%$] [thread %t] %^%v%$");
+    spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [thread %t] %v");
     spdlog::info("This an info message with custom format");
     spdlog::set_pattern("%+"); // back to default format
     spdlog::set_level(spdlog::level::info);

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -5,7 +5,6 @@
 
 #include <spdlog/common.h>
 #include <string>
-#include <vector>
 
 namespace spdlog {
 namespace details {
@@ -26,8 +25,6 @@ struct SPDLOG_API log_msg
     // wrapping the formatted text with color (updated by pattern_formatter).
     mutable size_t color_range_start{0};
     mutable size_t color_range_end{0};
-    mutable std::vector<size_t>color_ranges_start = {};
-    mutable std::vector<size_t>color_ranges_end   = {};
 
     source_loc source;
     string_view_t payload;

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -5,6 +5,7 @@
 
 #include <spdlog/common.h>
 #include <string>
+#include <vector>
 
 namespace spdlog {
 namespace details {
@@ -25,6 +26,8 @@ struct SPDLOG_API log_msg
     // wrapping the formatted text with color (updated by pattern_formatter).
     mutable size_t color_range_start{0};
     mutable size_t color_range_end{0};
+    mutable std::vector<size_t>color_ranges_start = {};
+    mutable std::vector<size_t>color_ranges_end   = {};
 
     source_loc source;
     string_view_t payload;

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -6,15 +6,16 @@
 #include <spdlog/common.h>
 #include <string>
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+#   include <vector>
+#   include <array>
+#endif
+
 
 namespace spdlog {
 namespace details {
 
 #if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
-
-#include <vector>
-#include <array>
-
 enum class style_type
 {
     // reservation for data structures

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -6,8 +6,49 @@
 #include <spdlog/common.h>
 #include <string>
 
+
 namespace spdlog {
 namespace details {
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+
+#include <vector>
+#include <array>
+
+enum class style_type
+{
+    // reservation for data structures
+    null_style,
+    // font style
+    reset, bold, dark, underline, blink, reverse,
+    // font foreground colors
+    fg_black, fg_red, fg_green, fg_yellow, fg_blue, fg_magenta, fg_cyan, fg_white, fg_default,
+    // font  background colors
+    bg_black, bg_red, bg_green, bg_yellow, bg_blue, bg_magenta, bg_cyan, bg_white, bg_default,
+};
+
+#if !defined(SPDLOG_ANSI_STLYE_COUNT)
+#   define SPDLOG_ANSI_STLYE_COUNT 25
+    using styles_array  = std::array<details::style_type, SPDLOG_ANSI_STLYE_COUNT>;
+    using style_strings = std::array<std::string, SPDLOG_ANSI_STLYE_COUNT>;
+    using style_codes   = std::array<string_view_t, SPDLOG_ANSI_STLYE_COUNT>;
+#endif
+
+// styling info.
+struct styling_info
+{
+    styling_info() = default;
+    styling_info(details::styles_array styles)
+        : styles(styles)
+        , is_start(true)
+    {}
+
+    bool is_start   = false;
+    size_t position = 0;
+    details::styles_array styles{};
+};
+#endif
+
 struct SPDLOG_API log_msg
 {
     log_msg() = default;
@@ -25,6 +66,11 @@ struct SPDLOG_API log_msg
     // wrapping the formatted text with color (updated by pattern_formatter).
     mutable size_t color_range_start{0};
     mutable size_t color_range_end{0};
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    // for ansi console styling
+    mutable std::vector<styling_info> styling_ranges;
+#endif
 
     source_loc source;
     string_view_t payload;

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -736,7 +736,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        msg.color_range_start = dest.size();
+        msg.color_ranges_start.push_back(dest.size());
     }
 };
 
@@ -749,7 +749,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        msg.color_range_end = dest.size();
+        msg.color_ranges_end.push_back(dest.size());
     }
 };
 
@@ -990,10 +990,11 @@ public:
 
         dest.push_back('[');
         // wrap the level name with color
-        msg.color_range_start = dest.size();
+        msg.color_ranges_start.push_back(dest.size());
+
         // fmt_helper::append_string_view(level::to_c_str(msg.level), dest);
         fmt_helper::append_string_view(level::to_string_view(msg.level), dest);
-        msg.color_range_end = dest.size();
+        msg.color_ranges_end.push_back(dest.size());
         dest.push_back(']');
         dest.push_back(' ');
 

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -736,7 +736,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        msg.color_ranges_start.push_back(dest.size());
+        msg.color_range_start = dest.size();
     }
 };
 
@@ -749,7 +749,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        msg.color_ranges_end.push_back(dest.size());
+        msg.color_range_end = dest.size();
     }
 };
 
@@ -990,11 +990,11 @@ public:
 
         dest.push_back('[');
         // wrap the level name with color
-        msg.color_ranges_start.push_back(dest.size());
+        msg.color_range_start = dest.size();
 
         // fmt_helper::append_string_view(level::to_c_str(msg.level), dest);
         fmt_helper::append_string_view(level::to_string_view(msg.level), dest);
-        msg.color_ranges_end.push_back(dest.size());
+        msg.color_range_end = dest.size();
         dest.push_back(']');
         dest.push_back(' ');
 

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -781,7 +781,7 @@ public:
 
     void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override
     {
-        msg.color_range_stop = dest.size();
+        msg.color_range_end = dest.size();
     }
 };
 #endif

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -727,7 +727,7 @@ private:
 };
 
 #if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
-// mark the color range. expect it to be in the form of "%^colored text%$"
+// mark the style range. expect it to be in the form of "%^colored text%$" or "%{style_spec}^styled text%$"
 class color_start_formatter final : public flag_formatter
 {
 public:

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -144,8 +144,6 @@ private:
     custom_flags custom_handlers_;
 
     std::tm get_time_(const details::log_msg &msg);
-    template<typename Padder>
-    void handle_flag_(char flag, details::padding_info padding, details::styling_info styling);
 
     // Extract given pad spec (e.g. %8X)
     // Advance the given it pass the end of the padding spec found (if any)
@@ -153,11 +151,16 @@ private:
     static details::padding_info handle_padspec_(std::string::const_iterator &it, std::string::const_iterator end);
 
 #if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    template<typename Padder>
+    void handle_flag_(char flag, details::padding_info padding, details::styling_info styling);
+
     // Extract given style spec (e.g. %{style}^X, %{style;style}^X, etc...)
     // Advance the given it pass the end of the style spec found (if any)
     // Return style.
     static details::styling_info handle_stylespec_(std::string::const_iterator &it, std::string::const_iterator end);
 #endif
+    template<typename Padder>
+    void handle_flag_(char flag, details::padding_info padding);
     void compile_pattern_(const std::string &pattern);
 };
 } // namespace spdlog

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -47,6 +47,37 @@ struct padding_info
     bool enabled_ = false;
 };
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+
+class SPDLOG_API flag_formatter
+{
+public:
+    explicit flag_formatter(padding_info padinfo)
+        : padinfo_(padinfo)
+    {}
+    explicit flag_formatter(padding_info padinfo, styling_info style_info)
+        : padinfo_(padinfo)
+        , styleinfo_(style_info)
+    {}
+    flag_formatter() = default;
+    virtual ~flag_formatter() = default;
+    virtual void format(const details::log_msg &msg, const std::tm &tm_time, memory_buf_t &dest) = 0;
+
+protected:
+    padding_info padinfo_;
+    styling_info styleinfo_;
+};
+
+static const details::style_strings style_type_table
+{
+    "null_style",
+    "reset", "bold", "dark", "underline", "blink", "reverse",
+    "fg_black", "fg_red", "fg_green", "fg_yellow", "fg_blue", "fg_magenta", "fg_cyan", "fg_white", "fg_default",
+    "bg_black", "bg_red", "bg_green", "bg_yellow", "bg_blue", "bg_magenta", "bg_cyan", "bg_white", "bg_default"
+};
+
+#else
+
 class SPDLOG_API flag_formatter
 {
 public:
@@ -60,6 +91,8 @@ public:
 protected:
     padding_info padinfo_;
 };
+
+#endif
 
 } // namespace details
 
@@ -112,13 +145,19 @@ private:
 
     std::tm get_time_(const details::log_msg &msg);
     template<typename Padder>
-    void handle_flag_(char flag, details::padding_info padding);
+    void handle_flag_(char flag, details::padding_info padding, details::styling_info styling);
 
     // Extract given pad spec (e.g. %8X)
     // Advance the given it pass the end of the padding spec found (if any)
     // Return padding.
     static details::padding_info handle_padspec_(std::string::const_iterator &it, std::string::const_iterator end);
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    // Extract given style spec (e.g. %{style}^X, %{style;style}^X, etc...)
+    // Advance the given it pass the end of the style spec found (if any)
+    // Return style.
+    static details::styling_info handle_stylespec_(std::string::const_iterator &it, std::string::const_iterator end);
+#endif
     void compile_pattern_(const std::string &pattern);
 };
 } // namespace spdlog

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -45,29 +45,17 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg
     std::lock_guard<mutex_t> lock(mutex_);
     msg.color_range_start = 0;
     msg.color_range_end   = 0;
-    msg.color_ranges_start.clear();
-    msg.color_ranges_end.clear();
 
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
-    if (should_do_colors_ && msg.color_ranges_start.size() == msg.color_ranges_end.size())
+    if (should_do_colors_ && msg.color_range_end > msg.color_range_start)
     {
-        size_t before_color_range = 0;
-        for(int i = 0; i < msg.color_ranges_start.size(); i++) {
-            msg.color_range_start = msg.color_ranges_start[i];
-            msg.color_range_end   = msg.color_ranges_end[i];
-
-            // before color range
-            print_range_(formatted, before_color_range, msg.color_range_start);
-
-            // in color range
-            print_ccode_(colors_.at(static_cast<size_t>(msg.level)));
-            print_range_(formatted, msg.color_range_start, msg.color_range_end);
-            print_ccode_(reset);
-
-            // get new location outside color ranges
-            before_color_range = msg.color_range_end;
-        }
+        // before color range
+        print_range_(formatted, 0, msg.color_range_start);
+        // in color range
+        print_ccode_(colors_.at(static_cast<size_t>(msg.level)));
+        print_range_(formatted, msg.color_range_start, msg.color_range_end);
+        print_ccode_(reset);
         // after all color ranges
         print_range_(formatted, msg.color_range_end, formatted.size());
     }

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -21,6 +21,15 @@ SPDLOG_INLINE ansicolor_sink<ConsoleMutex>::ansicolor_sink(FILE *target_file, co
 
 {
     set_color_mode(mode);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    colors_.at(level::trace)    = details::styles_array{details::style_type::fg_white};
+    colors_.at(level::debug)    = details::styles_array{details::style_type::fg_cyan};
+    colors_.at(level::info)     = details::styles_array{details::style_type::fg_green};
+    colors_.at(level::warn)     = details::styles_array{details::style_type::bold,details::style_type::fg_yellow};
+    colors_.at(level::err)      = details::styles_array{details::style_type::bold,details::style_type::fg_red};
+    colors_.at(level::critical) = details::styles_array{details::style_type::bold,details::style_type::bg_red};
+    colors_.at(level::off)      = details::styles_array{details::style_type::reset};
+#else
     colors_.at(level::trace) = to_string_(white);
     colors_.at(level::debug) = to_string_(cyan);
     colors_.at(level::info) = to_string_(green);
@@ -28,14 +37,24 @@ SPDLOG_INLINE ansicolor_sink<ConsoleMutex>::ansicolor_sink(FILE *target_file, co
     colors_.at(level::err) = to_string_(red_bold);
     colors_.at(level::critical) = to_string_(bold_on_red);
     colors_.at(level::off) = to_string_(reset);
+#endif
 }
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+template<typename ConsoleMutex>
+SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color(level::level_enum color_level, details::styles_array color)
+{
+    std::lock_guard<mutex_t> lock(mutex_);
+    colors_.at(static_cast<size_t>(color_level)) = color;
+}
+#else
 template<typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color(level::level_enum color_level, string_view_t color)
 {
     std::lock_guard<mutex_t> lock(mutex_);
     colors_.at(static_cast<size_t>(color_level)) = to_string_(color);
 }
+#endif
 
 template<typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg)
@@ -46,8 +65,86 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg
     msg.color_range_start = 0;
     msg.color_range_end   = 0;
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    msg.styling_ranges.clear();
+#endif
+
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    if (should_do_colors_ && msg.styling_ranges.size() > 0)
+    {
+        string_view_t reset = details::styling_table[(int)details::style_type::reset];
+
+        size_t open_styles_count  = 0;
+        size_t before_style_range = 0;
+
+        for(auto info = msg.styling_ranges.begin(); info != msg.styling_ranges.end(); info++)
+        {
+            if (info->is_start)
+            {
+                // this stlying formatter is the first occurrance past the previous closing formatter
+                // all of the preceding characters if any are outside color the range
+                if (msg.color_range_end <= info->position && open_styles_count == 0)
+                {
+                    msg.color_range_start = info->position;
+                    // before style range
+                    print_range_(formatted, before_style_range, msg.color_range_start);
+                }
+                open_styles_count++;
+
+                // each styling formatter can contain multiple styles in its style spec
+                // loop through each style and print the style code
+                auto styles = info->styles;
+
+                // it is possible to not provide a style spec with the formatter, in that
+                // case the first style spec will be null_style therefore default to the
+                // generic log level style
+                if (styles[0] == details::style_type::null_style)
+                {
+                    styles = colors_.at(msg.level);
+                }
+
+                try
+                {
+                    for(int i = 0; styles[i] != details::style_type::null_style ; i++)
+                    {
+                        //  in style range
+                        print_ccode_(details::styling_table.at((int)styles[i]));
+                    }
+                }
+                catch (const std::out_of_range &ex)
+                {   // full style spec output looks either amazing or trash
+                }
+            }
+            else {
+                // this closing styling formatter is the first occurrance past the previous
+                // n opening styling formatters, because a reset ends all preceding styling
+                // this position is the true closing formatter in the event more closing
+                // formatters are declared
+                if (open_styles_count > 0)
+                {
+                    msg.color_range_end = info->position;
+                    // style range has fully been defined
+                    print_range_(formatted, msg.color_range_start, msg.color_range_end);
+                    print_ccode_(reset);
+                    // get new location outside style ranges
+                    before_style_range = msg.color_range_end;
+                    // reset open styles count
+                    open_styles_count  = 0;
+                }
+            }
+        }
+        // after all style ranges
+        print_range_(formatted, msg.color_range_end, formatted.size());
+
+        // printing a reset code at the very end of the log clears all dangling
+        // open formatters and will not be visible on the output line in the
+        // event there are no dangling formatters
+        print_ccode_(reset);
+    }
+#else
     if (should_do_colors_ && msg.color_range_end > msg.color_range_start)
     {
         // before color range
@@ -56,9 +153,10 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg
         print_ccode_(colors_.at(static_cast<size_t>(msg.level)));
         print_range_(formatted, msg.color_range_start, msg.color_range_end);
         print_ccode_(reset);
-        // after all color ranges
+        // after color range
         print_range_(formatted, msg.color_range_end, formatted.size());
     }
+#endif
     else // no color
     {
         print_range_(formatted, 0, formatted.size());

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -35,7 +35,12 @@ public:
     ansicolor_sink &operator=(const ansicolor_sink &other) = delete;
     ansicolor_sink &operator=(ansicolor_sink &&other) = delete;
 
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    void set_color(level::level_enum color_level, details::styles_array color);
+#else
     void set_color(level::level_enum color_level, string_view_t color);
+#endif
+
     void set_color_mode(color_mode mode);
     bool should_color();
 
@@ -84,7 +89,13 @@ private:
     mutex_t &mutex_;
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    std::array<details::styles_array, level::n_levels> colors_;
+#else
     std::array<std::string, level::n_levels> colors_;
+#endif
+
     void print_ccode_(const string_view_t &color_code);
     void print_range_(const memory_buf_t &formatted, size_t start, size_t end);
     static std::string to_string_(const string_view_t &sv);
@@ -111,6 +122,46 @@ using ansicolor_stderr_sink_mt = ansicolor_stderr_sink<details::console_mutex>;
 using ansicolor_stderr_sink_st = ansicolor_stderr_sink<details::console_nullmutex>;
 
 } // namespace sinks
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+namespace details {
+    static details::style_codes styling_table
+    {
+        "",         // null_style
+
+                    // font style
+        "\033[0m",  // reset
+        "\033[1m",  // bold
+        "\033[2m",  // dark
+        "\033[4m",  // underline
+        "\033[5m",  // blink
+        "\033[7m",  // reverse
+
+                    // font foreground colors
+        "\033[30m", // fg_black
+        "\033[31m", // fg_red
+        "\033[32m", // fg_green
+        "\033[33m", // fg_yellow
+        "\033[34m", // fg_blue
+        "\033[35m", // fg_magenta
+        "\033[36m", // fg_cyan
+        "\033[37m", // fg_white
+        "\033[39m", // fg_default
+
+                    // font  background colors
+        "\033[40m", // bg_black
+        "\033[41m", // bg_red
+        "\033[42m", // bg_green
+        "\033[43m", // bg_yellow
+        "\033[44m", // bg_blue
+        "\033[45m", // bg_magenta
+        "\033[46m", // bg_cyan
+        "\033[47m", // bg_white
+        "\033[49m", // bg_default
+    };
+} // namespace details
+#endif
+
 } // namespace spdlog
 
 #ifdef SPDLOG_HEADER_ONLY

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -59,27 +59,17 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::log(const details::log_msg &msg)
     std::lock_guard<mutex_t> lock(mutex_);
     msg.color_range_start = 0;
     msg.color_range_end   = 0;
-    msg.color_ranges_start.clear();
-    msg.color_ranges_end.clear();
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
-    if (should_do_colors_ && msg.color_ranges_start.size() == msg.color_ranges_end.size())
+    if (should_do_colors_ && msg.color_range_end > msg.color_range_start)
     {
-        size_t before_color_range = 0;
-        for(int i = 0; i < msg.color_ranges_start.size(); i++) {
-            msg.color_range_start = msg.color_ranges_start[i];
-            msg.color_range_end   = msg.color_ranges_end[i];
-
-            // before color range
-            print_range_(formatted, before_color_range, msg.color_range_start);
-            // in color range
-            auto orig_attribs = static_cast<WORD>(set_foreground_color_(colors_[static_cast<size_t>(msg.level)]));
-            print_range_(formatted, msg.color_range_start, msg.color_range_end);
-            // reset to orig colors
-            ::SetConsoleTextAttribute(static_cast<HANDLE>(out_handle_), orig_attribs);
-            // get new location outside color ranges
-            before_color_range = msg.color_range_end;
-        }
+        // before color range
+        print_range_(formatted, 0, msg.color_range_start);
+        // in color range
+        auto orig_attribs = static_cast<WORD>(set_foreground_color_(colors_[static_cast<size_t>(msg.level)]));
+        print_range_(formatted, msg.color_range_start, msg.color_range_end);
+        // reset to orig colors
+        ::SetConsoleTextAttribute(static_cast<HANDLE>(out_handle_), orig_attribs);
         print_range_(formatted, msg.color_range_end, formatted.size());
     }
     else // print without colors if color range is invalid (or color is disabled)

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -70,8 +70,8 @@ TEST_CASE("color range test1", "[pattern_formatter]")
     std::string logger_name = "test";
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, spdlog::string_view_t(buf.data(), buf.size()));
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start[0] == 0);
-    REQUIRE(msg.color_ranges_end[0]   == 5);
+    REQUIRE(msg.color_range_start == 0);
+    REQUIRE(msg.color_range_end == 5);
     REQUIRE(log_to_str("hello", "%^%v%$", spdlog::pattern_time_type::local, "\n") == "hello\n");
 }
 
@@ -82,8 +82,8 @@ TEST_CASE("color range test2", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start[0] == 0);
-    REQUIRE(msg.color_ranges_end[0]   == 0);
+    REQUIRE(msg.color_range_start == 0);
+    REQUIRE(msg.color_range_end == 0);
     REQUIRE(log_to_str("", "%^%$", spdlog::pattern_time_type::local, "\n") == "\n");
 }
 
@@ -94,8 +94,8 @@ TEST_CASE("color range test3", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start[0] == 0);
-    REQUIRE(msg.color_ranges_end[0]   == 3);
+    REQUIRE(msg.color_range_start == 0);
+    REQUIRE(msg.color_range_end == 3);
 }
 
 TEST_CASE("color range test4", "[pattern_formatter]")
@@ -106,8 +106,8 @@ TEST_CASE("color range test4", "[pattern_formatter]")
 
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start[0] == 2);
-    REQUIRE(msg.color_ranges_end[0]   == 5);
+    REQUIRE(msg.color_range_start == 2);
+    REQUIRE(msg.color_range_end == 5);
     REQUIRE(log_to_str("ignored", "XX%^YYY%$", spdlog::pattern_time_type::local, "\n") == "XXYYY\n");
 }
 
@@ -118,8 +118,8 @@ TEST_CASE("color range test5", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start[0]   == 2);
-    REQUIRE(msg.color_ranges_end.size() == 0);
+    REQUIRE(msg.color_range_start[0] == 2);
+    REQUIRE(msg.color_range_end == 0);
 }
 
 TEST_CASE("color range test6", "[pattern_formatter]")
@@ -129,8 +129,8 @@ TEST_CASE("color range test6", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_ranges_start.size() == 0);
-    REQUIRE(msg.color_ranges_end[0] == 2);
+    REQUIRE(msg.color_range_start == 0);
+    REQUIRE(msg.color_range_end[0] == 2);
 }
 
 //

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -70,8 +70,13 @@ TEST_CASE("color range test1", "[pattern_formatter]")
     std::string logger_name = "test";
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, spdlog::string_view_t(buf.data(), buf.size()));
     formatter->format(msg, formatted);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(1).position == 5);
+#else
     REQUIRE(msg.color_range_start == 0);
     REQUIRE(msg.color_range_end == 5);
+#endif
     REQUIRE(log_to_str("hello", "%^%v%$", spdlog::pattern_time_type::local, "\n") == "hello\n");
 }
 
@@ -82,8 +87,13 @@ TEST_CASE("color range test2", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(1).position == 0);
+#else
     REQUIRE(msg.color_range_start == 0);
     REQUIRE(msg.color_range_end == 0);
+#endif
     REQUIRE(log_to_str("", "%^%$", spdlog::pattern_time_type::local, "\n") == "\n");
 }
 
@@ -94,8 +104,13 @@ TEST_CASE("color range test3", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(1).position == 3);
+#else
     REQUIRE(msg.color_range_start == 0);
     REQUIRE(msg.color_range_end == 3);
+#endif
 }
 
 TEST_CASE("color range test4", "[pattern_formatter]")
@@ -106,8 +121,13 @@ TEST_CASE("color range test4", "[pattern_formatter]")
 
     memory_buf_t formatted;
     formatter->format(msg, formatted);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 2);
+    REQUIRE(msg.styling_ranges.at(1).position == 5);
+#else
     REQUIRE(msg.color_range_start == 2);
     REQUIRE(msg.color_range_end == 5);
+#endif
     REQUIRE(log_to_str("ignored", "XX%^YYY%$", spdlog::pattern_time_type::local, "\n") == "XXYYY\n");
 }
 
@@ -118,8 +138,14 @@ TEST_CASE("color range test5", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start[0] == 2);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 2);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.size() == 1);
+#else
+    REQUIRE(msg.color_range_start == 2);
     REQUIRE(msg.color_range_end == 0);
+#endif
 }
 
 TEST_CASE("color range test6", "[pattern_formatter]")
@@ -129,9 +155,139 @@ TEST_CASE("color range test6", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+    REQUIRE(msg.styling_ranges.at(0).position == 2);
+    REQUIRE(msg.styling_ranges.at(0).is_start == false);
+    REQUIRE(msg.styling_ranges.size() == 1);
+#else
     REQUIRE(msg.color_range_start == 0);
-    REQUIRE(msg.color_range_end[0] == 2);
+    REQUIRE(msg.color_range_end == 2);
+#endif
 }
+
+#if !defined(_WIN32) && defined(SPDLOG_EXTENDED_STLYING)
+
+TEST_CASE("color range test7", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("%^*%$%^*%$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 4);
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(0));
+    REQUIRE(msg.styling_ranges.at(1).position == 1);
+    REQUIRE(msg.styling_ranges.at(1).is_start == false);
+    REQUIRE(msg.styling_ranges.at(1).styles.at(0) == spdlog::details::style_type(0));
+
+    REQUIRE(msg.styling_ranges.at(2).position == 1);
+    REQUIRE(msg.styling_ranges.at(2).is_start == true);
+    REQUIRE(msg.styling_ranges.at(2).styles.at(0) == spdlog::details::style_type(0));
+    REQUIRE(msg.styling_ranges.at(3).position == 2);
+    REQUIRE(msg.styling_ranges.at(3).is_start == false);
+    REQUIRE(msg.styling_ranges.at(3).styles.at(0) == spdlog::details::style_type(0));
+}
+
+TEST_CASE("color range test8", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("%{bold}^*%$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 2);
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(2));
+    REQUIRE(msg.styling_ranges.at(1).position == 1);
+    REQUIRE(msg.styling_ranges.at(1).is_start == false);
+    REQUIRE(msg.styling_ranges.at(1).styles.at(0) == spdlog::details::style_type(0));
+}
+
+TEST_CASE("color range test9", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("%{bold;fg_red}^*%$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 2);
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(2));
+    REQUIRE(msg.styling_ranges.at(0).styles.at(1) == spdlog::details::style_type(8));
+    REQUIRE(msg.styling_ranges.at(1).position == 1);
+    REQUIRE(msg.styling_ranges.at(1).is_start == false);
+    REQUIRE(msg.styling_ranges.at(1).styles.at(0) == spdlog::details::style_type(0));
+}
+
+TEST_CASE("color range test10", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("%{bold;fg_red;bg_black}^*%$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 2);
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(2));
+    REQUIRE(msg.styling_ranges.at(0).styles.at(1) == spdlog::details::style_type(8));
+    REQUIRE(msg.styling_ranges.at(0).styles.at(2) == spdlog::details::style_type(16));
+    REQUIRE(msg.styling_ranges.at(1).position == 1);
+    REQUIRE(msg.styling_ranges.at(1).is_start == false);
+    REQUIRE(msg.styling_ranges.at(1).styles.at(0) == spdlog::details::style_type(0));
+}
+
+TEST_CASE("color range test11", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("%{bold;fg_red;fake}^*");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 1);
+    REQUIRE(msg.styling_ranges.at(0).position == 0);
+    REQUIRE(msg.styling_ranges.at(0).is_start == true);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(2));
+    REQUIRE(msg.styling_ranges.at(0).styles.at(1) == spdlog::details::style_type(8));
+    REQUIRE(msg.styling_ranges.at(0).styles.at(2) == spdlog::details::style_type(0));
+}
+
+TEST_CASE("color range test12", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("*%$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 1);
+    REQUIRE(msg.styling_ranges.at(0).position == 1);
+    REQUIRE(msg.styling_ranges.at(0).is_start == false);
+}
+
+TEST_CASE("color range test13", "[pattern_formatter]")
+{
+    auto formatter = std::make_shared<spdlog::pattern_formatter>("*%{bold}$");
+    std::string logger_name = "test";
+    spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
+    memory_buf_t formatted;
+    formatter->format(msg, formatted);
+
+    REQUIRE(msg.styling_ranges.size() == 1);
+    REQUIRE(msg.styling_ranges.at(0).position == 1);
+    REQUIRE(msg.styling_ranges.at(0).is_start == false);
+    REQUIRE(msg.styling_ranges.at(0).styles.at(0) == spdlog::details::style_type(0));
+}
+#endif
 
 //
 // Test padding

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -70,8 +70,8 @@ TEST_CASE("color range test1", "[pattern_formatter]")
     std::string logger_name = "test";
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, spdlog::string_view_t(buf.data(), buf.size()));
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 0);
-    REQUIRE(msg.color_range_end == 5);
+    REQUIRE(msg.color_ranges_start[0] == 0);
+    REQUIRE(msg.color_ranges_end[0]   == 5);
     REQUIRE(log_to_str("hello", "%^%v%$", spdlog::pattern_time_type::local, "\n") == "hello\n");
 }
 
@@ -82,8 +82,8 @@ TEST_CASE("color range test2", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 0);
-    REQUIRE(msg.color_range_end == 0);
+    REQUIRE(msg.color_ranges_start[0] == 0);
+    REQUIRE(msg.color_ranges_end[0]   == 0);
     REQUIRE(log_to_str("", "%^%$", spdlog::pattern_time_type::local, "\n") == "\n");
 }
 
@@ -94,8 +94,8 @@ TEST_CASE("color range test3", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 0);
-    REQUIRE(msg.color_range_end == 3);
+    REQUIRE(msg.color_ranges_start[0] == 0);
+    REQUIRE(msg.color_ranges_end[0]   == 3);
 }
 
 TEST_CASE("color range test4", "[pattern_formatter]")
@@ -106,8 +106,8 @@ TEST_CASE("color range test4", "[pattern_formatter]")
 
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 2);
-    REQUIRE(msg.color_range_end == 5);
+    REQUIRE(msg.color_ranges_start[0] == 2);
+    REQUIRE(msg.color_ranges_end[0]   == 5);
     REQUIRE(log_to_str("ignored", "XX%^YYY%$", spdlog::pattern_time_type::local, "\n") == "XXYYY\n");
 }
 
@@ -118,8 +118,8 @@ TEST_CASE("color range test5", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 2);
-    REQUIRE(msg.color_range_end == 0);
+    REQUIRE(msg.color_ranges_start[0]   == 2);
+    REQUIRE(msg.color_ranges_end.size() == 0);
 }
 
 TEST_CASE("color range test6", "[pattern_formatter]")
@@ -129,8 +129,8 @@ TEST_CASE("color range test6", "[pattern_formatter]")
     spdlog::details::log_msg msg(logger_name, spdlog::level::info, "ignored");
     memory_buf_t formatted;
     formatter->format(msg, formatted);
-    REQUIRE(msg.color_range_start == 0);
-    REQUIRE(msg.color_range_end == 2);
+    REQUIRE(msg.color_ranges_start.size() == 0);
+    REQUIRE(msg.color_ranges_end[0] == 2);
 }
 
 //


### PR DESCRIPTION
### Why

So while _implementing a custom formatter_, I really wanted the ability to set multiple color ranges. Patterns clearly state only one set of delimiters can be used, and trying to set multiple color ranges using the data members in the `log_msg` struct would just reset the color range to the last one specified. After looking behind the curtain I discovered  why that was the case. I would like to see the ability to define multiple color ranges across both area and color dimensions.

Anyways I was just curious if this type of feature once stable would be welcomed to merge into the main branch. I am working on this in my free time, so I am just writing this idea out to disk.


### How

This set of commits represents the naive approach as I am not fully acquainted with the code base. After getting half a proof of concept completed, I realized the actual challenge to this problem. The special case that needs to be considered for a stable feature is nesting of color ranges. Color range really isn't the correct word, because you can do more than just adjust the font color, but also style such as bold. These commits solves the multiple, discrete and regions. It does not however handle nesting of styled regions. I think it should be possible to solve for that with a FIFO data structure like a queue. Storing the position and type (opening or closing) should allow for branching when consuming the tokens. There would probably need to be some bookkeeping to trigger when to set the next un-formatted region (i.e add for opening delimiters and subtract for closing, when at  zero the start of the next region was found). But all of that is a future set of commits.


### What

I have only tested the changes from `ansicolor_sink-inl.h` because I develop on linux, but the Windows stuff should work as it is very similar. I don't have a version of Qt5.15 so I left `qt_sink` unchanged. The unit tests reflect where the values are being stored, and handle the condition of a malformed pattern. `example.cpp` demonstrates multiple discrete color ranges.  