### PR TITLE
implemented async_logger::sync() to solve issue #1696

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <string>
 
+#include <chrono>
+
 SPDLOG_INLINE spdlog::async_logger::async_logger(
     std::string logger_name, sinks_init_list sinks_list, std::weak_ptr<details::thread_pool> tp, async_overflow_policy overflow_policy)
     : async_logger(std::move(logger_name), sinks_list.begin(), sinks_list.end(), std::move(tp), overflow_policy)
@@ -87,4 +89,36 @@ SPDLOG_INLINE std::shared_ptr<spdlog::logger> spdlog::async_logger::clone(std::s
     auto cloned = std::make_shared<spdlog::async_logger>(*this);
     cloned->name_ = std::move(new_name);
     return cloned;
+}
+
+SPDLOG_INLINE bool spdlog::async_logger::sync(int intervalMs, int timeoutMs)
+{
+    using namespace std::chrono;
+
+    auto tp=thread_pool_.lock();
+    assert(tp);
+
+    if (tp->queue_size()==0)
+        return true;
+      
+    auto start=steady_clock::now();
+    bool synced=false;
+    bool indef=(timeoutMs<=0);
+    do
+    {
+        if (!indef && intervalMs>timeoutMs)
+            intervalMs=timeoutMs;  
+
+        std::this_thread::sleep_for(milliseconds(intervalMs));
+        synced=(tp->queue_size()==0);
+
+        if (!indef)
+        {
+            auto now=steady_clock::now();
+            auto passedMs=duration_cast<milliseconds>(now-start);
+            start=now;
+            timeoutMs-=passedMs.count();
+        }
+    } while ((!indef && timeoutMs>0 || indef) && !synced);
+    return synced;
 }

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -51,14 +51,6 @@ public:
 
     std::shared_ptr<logger> clone(std::string new_name) override;
 
-    /**
-     * @brief block until all messages in thread_pool_ are processed
-     * @param intervalMs check whether should return or not on every 'intervalMs' milliseconds
-     * @param timeoutMs timeout in milliseconds. -1 means to wait indefinitely
-     * @return true: all messages in thread_pool_ are processed, false: otherwise
-    */
-    bool sync(int intervalMs=100, int timeoutMs=-1);
-
 protected:
     void sink_it_(const details::log_msg &msg) override;
     void flush_() override;

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -51,6 +51,14 @@ public:
 
     std::shared_ptr<logger> clone(std::string new_name) override;
 
+    /**
+     * @brief block until all messages in thread_pool_ are processed
+     * @param intervalMs check whether should return or not on every 'intervalMs' milliseconds
+     * @param timeoutMs timeout in milliseconds. -1 means to wait indefinitely
+     * @return true: all messages in thread_pool_ are processed, false: otherwise
+    */
+    bool sync(int intervalMs=100, int timeoutMs=-1);
+
 protected:
     void sink_it_(const details::log_msg &msg) override;
     void flush_() override;

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -85,6 +85,32 @@ size_t SPDLOG_INLINE thread_pool::queue_size()
     return q_.size();
 }
 
+SPDLOG_INLINE bool thread_pool::sync(int intervalMs, int timeoutMs)
+{
+    using namespace std::chrono;
+
+    auto start=steady_clock::now();
+    bool synced=false;
+    bool indef=(timeoutMs<=0);
+    do
+    {
+        if (!indef && intervalMs>timeoutMs)
+            intervalMs=timeoutMs;  
+
+        std::this_thread::sleep_for(milliseconds(intervalMs));
+        synced=(q_.size()==0);
+
+        if (!indef)
+        {
+            auto now=steady_clock::now();
+            auto passedMs=duration_cast<milliseconds>(now-start);
+            start=now;
+            timeoutMs-=static_cast<int>(passedMs.count());
+        }
+    } while (((!indef && timeoutMs>0) || indef) && !synced);
+    return synced;
+}
+
 void SPDLOG_INLINE thread_pool::post_async_msg_(async_msg &&new_msg, async_overflow_policy overflow_policy)
 {
     if (overflow_policy == async_overflow_policy::block)

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -100,6 +100,9 @@ public:
     void reset_overrun_counter();
     size_t queue_size();
 
+    // block until all messages in thread pool are processed or the timer goes off.
+    bool sync(int intervalMs=100, int timeoutMs=-1);
+
 private:
     q_type q_;
 


### PR DESCRIPTION
This pr is to solve issue  #1696 and `async_logger::sync()` allows users to wait for the completion of logging, so they can make sure everything they want to log is safe and can be passed for further processing.

You can use it like this:
```
    auto thrpool=std::make_shared<spdlog::details::thread_pool>(100, 2);
    auto aloger=std::make_shared<spdlog::async_logger>("aloger", std::make_shared<spdlog::sinks::stdout_color_sink_mt>(), thrpool);

    aloger->info(std::string(1000,'i')); // log something large

    bool fin=aloger->sync(100,1000); // call sync() to wait until logging is flushed

    std::cout << (fin ? "done\n" : "undone\n"); // this shows after the logging on console
```

```
    /**
     * @brief block until all messages in thread_pool_ are processed
     * @param intervalMs check whether should return or not on every 'intervalMs' milliseconds
     * @param timeoutMs timeout in milliseconds. -1 means to wait indefinitely
     * @return true: all messages in thread_pool_ are processed, false: otherwise
    */
    bool sync(int intervalMs=100, int timeoutMs=-1);
```