### PR TITLE
Added missing square bracket to fix the level_to_string_view test

### DIFF
--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -43,7 +43,7 @@ TEST_CASE("log_levels", "[log_levels]")
     REQUIRE(log_info("Hello", spdlog::level::trace) == "Hello");
 }
 
-TEST_CASE("level_to_string_view", "[convert_to_string_view")
+TEST_CASE("level_to_string_view", "[convert_to_string_view]")
 {
     REQUIRE(spdlog::level::to_string_view(spdlog::level::trace) == "trace");
     REQUIRE(spdlog::level::to_string_view(spdlog::level::debug) == "debug");


### PR DESCRIPTION
Added missing square bracket to fix the test:

```
Test project /builddir/build/BUILD/spdlog-1.12.0/redhat-linux-build
    Start 1: spdlog-utests
1/1 Test #1: spdlog-utests ....................***Failed    0.01 sec
Errors occurred during startup!
  Found an unclosed tag while registering test case 'level_to_string_view' at /
  builddir/build/BUILD/spdlog-1.12.0/tests/test_misc.cpp:46
0% tests passed, 1 tests failed out of 1
Total Test time (real) =   0.01 sec
The following tests FAILED:
	  1 - spdlog-utests (Failed)
Errors while running CTest
```