### PR TITLE
fix:Modify the bug of qtextedit;

### DIFF
--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -162,7 +162,7 @@ protected:
 
         const string_view_t str = string_view_t(formatted.data(), formatted.size());
         // apply the color to the color range in the formatted message.
-        auto payload = QString::fromLatin1(str.data(), static_cast<int>(str.size()));
+        auto payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
 
         invoke_params params{max_lines_,             // max lines
             qt_text_edit_,                           // text edit to append to
@@ -215,6 +215,7 @@ protected:
         // insert the text after the color range with default format
         cursor.setCharFormat(params.default_color);
         cursor.insertText(params.payload.mid(params.color_range_end));
+        params.q_text_edit->setTextCursor(cursor);
     }
 
     QTextEdit *qt_text_edit_;


### PR DESCRIPTION
    1.Modifying qtextedit cannot display Chinese problems;
    2.When modifying the qtextedit display, it will not automatically scroll to the bottom problem.