### PR TITLE
Set CMAKE_BUILD_TYPE only for single-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(GNUInstallDirs)
 # ---------------------------------------------------------------------------------------
 # Set default build to release
 # ---------------------------------------------------------------------------------------
-if(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
 endif()
 


### PR DESCRIPTION
spdlog currently sets CMAKE_BUILD_TYPE also when a CMake multi-config generator is used (e.g. Visual Studio). This adds an unneccessary CMake cache entry in that case.