### PR TITLE
Fix encoding issue in qt_sinks

### DIFF
--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -164,10 +164,13 @@ protected:
         // apply the color to the color range in the formatted message.
         auto payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
         // convert color ranges from byte index to character index.
+        int color_range_start, color_range_end;
+        color_range_start = static_cast<int>(msg.color_range_start);
+        color_range_end = static_cast<int>(msg.color_range_end);
         if (msg.color_range_start < msg.color_range_end) {
             QByteArray bytes(str.data(), str.size());
-            msg.color_range_start = QString::fromUtf8(bytes.left(msg.color_range_start)).size();
-            msg.color_range_end = QString::fromUtf8(bytes.left(msg.color_range_end)).size();
+            color_range_start = QString::fromUtf8(bytes.left(msg.color_range_start)).size();
+            color_range_end = QString::fromUtf8(bytes.left(msg.color_range_end)).size();
         }
 
         invoke_params params{max_lines_,             // max lines
@@ -175,8 +178,8 @@ protected:
             std::move(payload),                      // text to append
             default_color_,                          // default color
             colors_.at(msg.level),                   // color to apply
-            static_cast<int>(msg.color_range_start), // color range start
-            static_cast<int>(msg.color_range_end)};  // color range end
+            color_range_start,                       // color range start
+            color_range_end};                        // color range end
 
         QMetaObject::invokeMethod(
             qt_text_edit_, [params]() { invoke_method_(params); }, Qt::AutoConnection);

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -66,14 +66,15 @@ private:
 // Color location is determined by the sink log pattern like in the rest of spdlog sinks.
 // Colors can be modified if needed using sink->set_color(level, qtTextCharFormat).
 // max_lines is the maximum number of lines that the sink will hold before removing the oldest lines.
-// Note: Only ascii (latin1) is supported by this sink.
+// By default, only ascii (latin1) is supported by this sink. Set is_utf8 to true if utf8 support is needed.
 template<typename Mutex>
 class qt_color_sink : public base_sink<Mutex>
 {
 public:
-    qt_color_sink(QTextEdit *qt_text_edit, int max_lines, bool dark_colors=false)
+    qt_color_sink(QTextEdit *qt_text_edit, int max_lines, bool dark_colors=false, bool is_utf8=false)
         : qt_text_edit_(qt_text_edit)
         , max_lines_(max_lines)
+        , is_utf8_(is_utf8)
     {
         if (!qt_text_edit_)
         {
@@ -162,14 +163,19 @@ protected:
 
         const string_view_t str = string_view_t(formatted.data(), formatted.size());
         // apply the color to the color range in the formatted message.
-        auto payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
-        // convert color ranges from byte index to character index.
+        QString payload;
         int color_range_start, color_range_end;
         color_range_start = static_cast<int>(msg.color_range_start);
         color_range_end = static_cast<int>(msg.color_range_end);
-        if (msg.color_range_start < msg.color_range_end) {
-            color_range_start = QString::fromUtf8(str.data(), msg.color_range_start).size();
-            color_range_end = QString::fromUtf8(str.data(), msg.color_range_end).size();
+        if (is_utf8_) {
+            payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
+            // convert color ranges from byte index to character index.
+            if (msg.color_range_start < msg.color_range_end) {
+                color_range_start = QString::fromUtf8(str.data(), msg.color_range_start).size();
+                color_range_end = QString::fromUtf8(str.data(), msg.color_range_end).size();
+            }
+        } else {
+            payload = QString::fromLatin1(str.data(), static_cast<int>(str.size()));
         }
 
         invoke_params params{max_lines_,             // max lines
@@ -227,6 +233,7 @@ protected:
 
     QTextEdit *qt_text_edit_;
     int max_lines_;
+    bool is_utf8_;
     QTextCharFormat default_color_;
     std::array<QTextCharFormat, level::n_levels> colors_;
 };
@@ -286,15 +293,15 @@ inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name, QObj
 
 // log to QTextEdit with colorize output
 template<typename Factory = spdlog::synchronous_factory>
-inline std::shared_ptr<logger> qt_color_logger_mt(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines)
+inline std::shared_ptr<logger> qt_color_logger_mt(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines, bool is_utf8 = false)
 {
-    return Factory::template create<sinks::qt_color_sink_mt>(logger_name, qt_text_edit, max_lines);
+    return Factory::template create<sinks::qt_color_sink_mt>(logger_name, qt_text_edit, max_lines, is_utf8);
 }
 
 template<typename Factory = spdlog::synchronous_factory>
-inline std::shared_ptr<logger> qt_color_logger_st(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines)
+inline std::shared_ptr<logger> qt_color_logger_st(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines, bool is_utf8 = false)
 {
-    return Factory::template create<sinks::qt_color_sink_st>(logger_name, qt_text_edit, max_lines);
+    return Factory::template create<sinks::qt_color_sink_st>(logger_name, qt_text_edit, max_lines, is_utf8);
 }
 
 } // namespace spdlog

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -162,7 +162,7 @@ protected:
 
         const string_view_t str = string_view_t(formatted.data(), formatted.size());
         // apply the color to the color range in the formatted message.
-        auto payload = QString::fromLatin1(str.data(), static_cast<int>(str.size()));
+        auto payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
 
         invoke_params params{max_lines_,             // max lines
             qt_text_edit_,                           // text edit to append to

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -168,9 +168,8 @@ protected:
         color_range_start = static_cast<int>(msg.color_range_start);
         color_range_end = static_cast<int>(msg.color_range_end);
         if (msg.color_range_start < msg.color_range_end) {
-            QByteArray bytes(str.data(), str.size());
-            color_range_start = QString::fromUtf8(bytes.left(msg.color_range_start)).size();
-            color_range_end = QString::fromUtf8(bytes.left(msg.color_range_end)).size();
+            color_range_start = QString::fromUtf8(str.data(), msg.color_range_start).size();
+            color_range_end = QString::fromUtf8(str.data(), msg.color_range_end).size();
         }
 
         invoke_params params{max_lines_,             // max lines

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -295,13 +295,13 @@ inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name, QObj
 template<typename Factory = spdlog::synchronous_factory>
 inline std::shared_ptr<logger> qt_color_logger_mt(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines, bool is_utf8 = false)
 {
-    return Factory::template create<sinks::qt_color_sink_mt>(logger_name, qt_text_edit, max_lines, is_utf8);
+    return Factory::template create<sinks::qt_color_sink_mt>(logger_name, qt_text_edit, max_lines, false, is_utf8);
 }
 
 template<typename Factory = spdlog::synchronous_factory>
 inline std::shared_ptr<logger> qt_color_logger_st(const std::string &logger_name, QTextEdit *qt_text_edit, int max_lines, bool is_utf8 = false)
 {
-    return Factory::template create<sinks::qt_color_sink_st>(logger_name, qt_text_edit, max_lines, is_utf8);
+    return Factory::template create<sinks::qt_color_sink_st>(logger_name, qt_text_edit, max_lines, false, is_utf8);
 }
 
 } // namespace spdlog

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -163,6 +163,12 @@ protected:
         const string_view_t str = string_view_t(formatted.data(), formatted.size());
         // apply the color to the color range in the formatted message.
         auto payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
+        // convert color ranges from byte index to character index.
+        if (msg.color_range_start < msg.color_range_end) {
+            QByteArray bytes(str.data(), str.size());
+            msg.color_range_start = QString::fromUtf8(bytes.left(msg.color_range_start)).size();
+            msg.color_range_end = QString::fromUtf8(bytes.left(msg.color_range_end)).size();
+        }
 
         invoke_params params{max_lines_,             // max lines
             qt_text_edit_,                           // text edit to append to


### PR DESCRIPTION
`QString::fromLatin1` doesn't handle non-latin characters properly. When applied to Chinese characters, the message appeared in QTextEdit looks like corrupted.
![image](https://github.com/gabime/spdlog/assets/14328402/b61cf7cb-68d3-4cf6-8c73-9586e2df71e2)

This PR fixes this issue.
![image](https://github.com/gabime/spdlog/assets/14328402/94f758d9-40ad-42b6-b515-50f799945cc7)

