### PR TITLE
Fixing deprecation warning Wdeprecated-literal-operator on LLVM 16.0.6

### DIFF
--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -4165,7 +4165,7 @@ template <detail_exported::fixed_string Str> constexpr auto operator""_a() {
   return detail::udl_arg<char_t, sizeof(Str.data) / sizeof(char_t), Str>();
 }
 #  else
-constexpr auto operator"" _a(const char* s, size_t) -> detail::udl_arg<char> {
+constexpr auto operator""_a(const char* s, size_t) -> detail::udl_arg<char> {
   return {s};
 }
 #  endif


### PR DESCRIPTION
See https://reviews.llvm.org/rG5ce5e983f82c802e44faa8ed42d605d70c045ba9

Since LLVM 16.0.6 (which I am using via Emscripten), the following code can generate a warning due to use the deprecated syntax of the literal operator.

This fixed the issue in my project. Please let me know if my PR is improperly formatted or there's anything else I need to do.