### PR TITLE
Remove obsolete part from cmake configuration files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,7 @@ option(
 option(SPDLOG_DISABLE_DEFAULT_LOGGER "Disable default logger creation" OFF)
 
 # clang-tidy
-if(${CMAKE_VERSION} VERSION_GREATER "3.5")
-    option(SPDLOG_TIDY "run clang-tidy" OFF)
-endif()
+option(SPDLOG_TIDY "run clang-tidy" OFF)
 
 if(SPDLOG_TIDY)
     set(CMAKE_CXX_CLANG_TIDY "clang-tidy")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.10...3.21)
+cmake_minimum_required(VERSION 3.11...3.21)
 
 # ---------------------------------------------------------------------------------------
 # Start spdlog project

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(spdlog_bench CXX)
 
 if(NOT TARGET spdlog)
@@ -12,19 +12,15 @@ find_package(Threads REQUIRED)
 find_package(benchmark CONFIG)
 if(NOT benchmark_FOUND)
     message(STATUS "Using CMake Version ${CMAKE_VERSION}")
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.11.0")
-        # User can fetch googlebenchmark
-        message(STATUS "Downloading GoogleBenchmark")
-        include(FetchContent)
+    # User can fetch googlebenchmark
+    message(STATUS "Downloading GoogleBenchmark")
+    include(FetchContent)
 
-        # disable tests
-        set(BENCHMARK_ENABLE_TESTING OFF CACHE INTERNAL "")
-        # Do not build and run googlebenchmark tests
-        FetchContent_Declare(googlebenchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.6.0)
-        FetchContent_MakeAvailable(googlebenchmark)
-    else()
-        message(FATAL_ERROR "GoogleBenchmark is missing. Use CMake >= 3.11 or download it")
-    endif()
+    # disable tests
+    set(BENCHMARK_ENABLE_TESTING OFF CACHE INTERNAL "")
+    # Do not build and run googlebenchmark tests
+    FetchContent_Declare(googlebenchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.6.0)
+    FetchContent_MakeAvailable(googlebenchmark)
 endif()
 
 add_executable(bench bench.cpp)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(spdlog_examples CXX)
 
 if(NOT TARGET spdlog)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 project(spdlog_utests CXX)
 
 if(NOT TARGET spdlog)


### PR DESCRIPTION
Spdlog requires CMake version 3.10 or higher (by means of `cmake_minimum_required(VERSION 3.10...3.21)`)