### PR TITLE
Added a function to add callbacks that are called when a logger is registered

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -259,6 +259,22 @@ SPDLOG_INLINE void registry::register_logger_(std::shared_ptr<logger> new_logger
     auto logger_name = new_logger->name();
     throw_if_exists_(logger_name);
     loggers_[logger_name] = std::move(new_logger);
+
+    const auto& logger = loggers_[logger_name];
+    for (const auto& on_registration_callback : on_registration_callbacks_) {
+        on_registration_callback(logger);
+    }
+}
+
+SPDLOG_INLINE void registry::add_on_registration_callback(
+    const std::function<void(const std::shared_ptr<logger>&)>& callback) {
+    std::lock_guard<std::mutex> lock(logger_map_mutex_);
+    on_registration_callbacks_.push_back(callback);
+}
+
+SPDLOG_INLINE void registry::drop_all_on_registration_callbacks() {
+    std::lock_guard<std::mutex> lock(logger_map_mutex_);
+    on_registration_callbacks_.clear();
 }
 
 }  // namespace details

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -267,7 +267,7 @@ SPDLOG_INLINE void registry::register_logger_(std::shared_ptr<logger> new_logger
 }
 
 SPDLOG_INLINE void registry::add_on_registration_callback(
-    const std::function<void(const std::shared_ptr<logger>&)>& callback) {
+    const std::function<void(std::shared_ptr<logger>)>& callback) {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);
     on_registration_callbacks_.push_back(callback);
 }

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -92,7 +92,7 @@ public:
 
     void apply_logger_env_levels(std::shared_ptr<logger> new_logger);
 
-    void add_on_registration_callback(const std::function<void(const std::shared_ptr<logger>&)>& callback);
+    void add_on_registration_callback(const std::function<void(std::shared_ptr<logger>)>& callback);
 
     void drop_all_on_registration_callbacks();
 
@@ -116,7 +116,7 @@ private:
     std::shared_ptr<logger> default_logger_;
     bool automatic_registration_ = true;
     size_t backtrace_n_messages_ = 0;
-    std::vector<std::function<void(const std::shared_ptr<logger>&)>> on_registration_callbacks_;
+    std::vector<std::function<void(std::shared_ptr<logger>)>> on_registration_callbacks_;
 };
 
 }  // namespace details

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -92,6 +92,10 @@ public:
 
     void apply_logger_env_levels(std::shared_ptr<logger> new_logger);
 
+    void add_on_registration_callback(const std::function<void(const std::shared_ptr<logger>&)>& callback);
+
+    void drop_all_on_registration_callbacks();
+
 private:
     registry();
     ~registry();
@@ -112,6 +116,7 @@ private:
     std::shared_ptr<logger> default_logger_;
     bool automatic_registration_ = true;
     size_t backtrace_n_messages_ = 0;
+    std::list<std::function<void(const std::shared_ptr<logger>&)>> on_registration_callbacks_;
 };
 
 }  // namespace details

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -116,7 +116,7 @@ private:
     std::shared_ptr<logger> default_logger_;
     bool automatic_registration_ = true;
     size_t backtrace_n_messages_ = 0;
-    std::list<std::function<void(const std::shared_ptr<logger>&)>> on_registration_callbacks_;
+    std::vector<std::function<void(const std::shared_ptr<logger>&)>> on_registration_callbacks_;
 };
 
 }  // namespace details

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace spdlog {
 class logger;

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -89,4 +89,12 @@ SPDLOG_INLINE void apply_logger_env_levels(std::shared_ptr<logger> logger) {
     details::registry::instance().apply_logger_env_levels(std::move(logger));
 }
 
+SPDLOG_INLINE void add_on_registration_callback(const std::function<void(const std::shared_ptr<logger>&)>& callback) {
+    details::registry::instance().add_on_registration_callback(callback);
+}
+
+SPDLOG_INLINE void drop_all_on_registration_callbacks() {
+    details::registry::instance().drop_all_on_registration_callbacks();
+}
+
 }  // namespace spdlog

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -140,6 +140,21 @@ SPDLOG_API void set_default_logger(std::shared_ptr<spdlog::logger> default_logge
 //   spdlog::apply_logger_env_levels(mylogger);
 SPDLOG_API void apply_logger_env_levels(std::shared_ptr<logger> logger);
 
+// Add a callback that is called whenever a logger is registered
+//
+// Useful for intercepting loggers that are dynamically created during the application's lifetime
+// (e.g. from dynamically loaded libraries, etc.)
+// Example:
+// void my_on_registration_callback(const std::shared_ptr<spdlog::logger>& logger) {
+//     logger->do_stuff();
+// }
+// ...
+// spdlog::add_on_registration_callback(my_on_registration_callback);
+SPDLOG_API void add_on_registration_callback(const std::function<void(const std::shared_ptr<logger>&)>& callback);
+
+// Clear all callbacks that were added to intercept registrations (see "add_on_registration_callback")
+SPDLOG_API void drop_all_on_registration_callbacks();
+
 template <typename... Args>
 inline void log(source_loc source,
                 level::level_enum lvl,

--- a/tests/test_registry.cpp
+++ b/tests/test_registry.cpp
@@ -110,3 +110,29 @@ TEST_CASE("disable automatic registration", "[registry]") {
     spdlog::set_level(spdlog::level::info);
     spdlog::set_automatic_registration(true);
 }
+
+TEST_CASE("add_on_registration_callback", "[registry]") {
+    std::list<std::string> registered_logger_names;
+    auto on_registration_callback = [&](const std::shared_ptr<spdlog::logger>& logger)
+    {
+        registered_logger_names.push_back(logger->name());
+    };
+    spdlog::add_on_registration_callback(on_registration_callback);
+
+    auto captured_registration_logger1 = spdlog::create<spdlog::sinks::stdout_color_sink_mt>("captured_registration_logger1");
+
+    spdlog::set_automatic_registration(false);
+    auto non_captured_registration_logger1 = spdlog::create<spdlog::sinks::stdout_color_sink_mt>("non_captured_registration_logger1");
+
+    auto captured_registration_logger2 = spdlog::create<spdlog::sinks::stdout_color_sink_mt>("captured_registration_logger2");
+    spdlog::register_logger(captured_registration_logger2);
+
+    spdlog::drop_all_on_registration_callbacks();
+    auto non_captured_registration_logger2 = spdlog::create<spdlog::sinks::stdout_color_sink_mt>("non_captured_registration_logger2");
+
+    // Check that only the automatically registered logged and the manually registered logger were captured
+    REQUIRE(registered_logger_names == std::list<std::string>({"captured_registration_logger1", "captured_registration_logger2"}));
+
+    spdlog::set_level(spdlog::level::info);
+    spdlog::set_automatic_registration(true);
+}

--- a/tests/test_registry.cpp
+++ b/tests/test_registry.cpp
@@ -113,7 +113,7 @@ TEST_CASE("disable automatic registration", "[registry]") {
 
 TEST_CASE("add_on_registration_callback", "[registry]") {
     std::vector<std::string> registered_logger_names;
-    auto on_registration_callback = [&](const std::shared_ptr<spdlog::logger>& logger)
+    auto on_registration_callback = [&](std::shared_ptr<spdlog::logger> logger)
     {
         registered_logger_names.push_back(logger->name());
     };

--- a/tests/test_registry.cpp
+++ b/tests/test_registry.cpp
@@ -129,6 +129,7 @@ TEST_CASE("add_on_registration_callback", "[registry]") {
 
     spdlog::drop_all_on_registration_callbacks();
     auto non_captured_registration_logger2 = spdlog::create<spdlog::sinks::stdout_color_sink_mt>("non_captured_registration_logger2");
+    spdlog::register_logger(non_captured_registration_logger2);
 
     // Check that only the automatically registered logged and the manually registered logger were captured
     REQUIRE(registered_logger_names == std::list<std::string>({"captured_registration_logger1", "captured_registration_logger2"}));

--- a/tests/test_registry.cpp
+++ b/tests/test_registry.cpp
@@ -112,7 +112,7 @@ TEST_CASE("disable automatic registration", "[registry]") {
 }
 
 TEST_CASE("add_on_registration_callback", "[registry]") {
-    std::list<std::string> registered_logger_names;
+    std::vector<std::string> registered_logger_names;
     auto on_registration_callback = [&](const std::shared_ptr<spdlog::logger>& logger)
     {
         registered_logger_names.push_back(logger->name());
@@ -132,7 +132,7 @@ TEST_CASE("add_on_registration_callback", "[registry]") {
     spdlog::register_logger(non_captured_registration_logger2);
 
     // Check that only the automatically registered logged and the manually registered logger were captured
-    REQUIRE(registered_logger_names == std::list<std::string>({"captured_registration_logger1", "captured_registration_logger2"}));
+    REQUIRE(registered_logger_names == std::vector<std::string>({"captured_registration_logger1", "captured_registration_logger2"}));
 
     spdlog::set_level(spdlog::level::info);
     spdlog::set_automatic_registration(true);


### PR DESCRIPTION
Use case:

We have a collection of libraries that use spdlog in a somewhat "bare" fashion (setting up a colored multithreaded stdout log for the most part).

We wish to be able to redirect those logs to a file or a custom sink to view within a UI and whatnot. While we can easily do that for logs that have already been setup through the registry and automatic registration (pretty much all libraries directly linked to, that initialize it in a static variable), using the already existing `apply_all` function, this cannot work for libraries that may be loaded dynamically later as plugins (e.g., in our case, mostly QML plugins in the Qt framework) since they'll be loaded after our "main" routine. Calling `apply_all` late (thus potentially missing out on early log) or doing some hack with a timer that repeatedly calls `apply_all` don't seem like good solutions.

Thus we wish to be able to register functions that are called when a logger is registered, mostly to be able to tweak its sinks vector and redirect the log.

Thank you in advance for your comments in hopes this feature suits you. Have a nice day !
