### PR TITLE
Fix OS availability check of pthread_threadid_np for iOS

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -332,15 +332,21 @@ SPDLOG_INLINE size_t _thread_id() SPDLOG_NOEXCEPT {
     return static_cast<size_t>(::thr_self());
 #elif __APPLE__
     uint64_t tid;
-    // There is no pthread_threadid_np prior to 10.6, and it is not supported on any PPC,
+    // There is no pthread_threadid_np prior to Mac OS X 10.6, and it is not supported on any PPC,
     // including 10.6.8 Rosetta. __POWERPC__ is Apple-specific define encompassing ppc and ppc64.
-    #if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
-    tid = pthread_mach_thread_np(pthread_self());
-    #elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
-    if (&pthread_threadid_np) {
-        pthread_threadid_np(nullptr, &tid);
-    } else {
+    #ifdef MAC_OS_X_VERSION_MAX_ALLOWED
+    {
+        #if (MAC_OS_X_VERSION_MAX_ALLOWED < 1060) || defined(__POWERPC__)
         tid = pthread_mach_thread_np(pthread_self());
+        #elif MAC_OS_X_VERSION_MIN_REQUIRED < 1060
+        if (&pthread_threadid_np) {
+            pthread_threadid_np(nullptr, &tid);
+        } else {
+            tid = pthread_mach_thread_np(pthread_self());
+        }
+        #else
+        pthread_threadid_np(nullptr, &tid);
+        #endif
     }
     #else
     pthread_threadid_np(nullptr, &tid);


### PR DESCRIPTION
The OS availability check of `pthread_threadid_np` (introduced in https://github.com/gabime/spdlog/pull/2715) is not considering other Apple OSes, where the macOS specific macros are not defined as such these C preprocessor undefined values evaluate to zero causing the #if expression to evaluate in an unexpected way (e.g. unnecessary weak linking check on iOS).