### PR TITLE
Match SPDLOG_CONSTEXPR_FUNC to FMT_CONSTEXPR

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -70,13 +70,19 @@
     #define SPDLOG_CONSTEXPR constexpr
 #endif
 
-// If building with fmt SPDLOG_CONSTEXPR_FUNC needs to be set the same as FMT_CONSTEXPR
-// to avoid situations where a constexpr function in spdlog could end up calling
-// a non-constexpr function in fmt depending on the compiler
-#ifdef FMT_CONSTEXPR
-    #define SPDLOG_CONSTEXPR_FUNC FMT_CONSTEXPR
-#else
+// If building with std::format, can just use constexpr, otherwise if building with fmt
+// SPDLOG_CONSTEXPR_FUNC needs to be set the same as FMT_CONSTEXPR to avoid situations where
+// a constexpr function in spdlog could end up calling a non-constexpr function in fmt
+// depending on the compiler
+// If fmt determines it can't use constexpr, we should inline the function instead
+#ifdef SPDLOG_USE_STD_FORMAT
     #define SPDLOG_CONSTEXPR_FUNC constexpr
+#else  // Being built with fmt
+    #if FMT_USE_CONSTEXPR
+        #define SPDLOG_CONSTEXPR_FUNC FMT_CONSTEXPR
+    #else
+	#define SPDLOG_CONSTEXPR_FUNC inline
+    #endif
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -70,11 +70,19 @@
     #define SPDLOG_CONSTEXPR constexpr
 #endif
 
-#ifndef __has_feature
-#    define __has_feature(x) 0
+#ifdef __has_feature
+#    define SPDLOG_HAS_FEATURE(x) __has_feature(x)
+#else
+#    define SPDLOG_HAS_FEATURE(x) 0
 #endif
 
-#if (__has_feature(cxx_relaxed_constexpr) || (defined(_MSC_VER) && (_MSC_VER >= 1912)) ||                                                  \
+// Check if relaxed C++14 constexpr is supported
+// GCC doesn't allow throw in constexpr until version 6 (bug 67371)
+// This needs to stay synchronized with FMT_CONSTEXPR otherwise we can run into
+// situations where spdlog constexpr functions can try to call non-constexpr
+// fmt functions
+// See https://github.com/gabime/spdlog/issues/2856 where this happens with nvcc
+#if (SPDLOG_HAS_FEATURE(cxx_relaxed_constexpr) || (defined(_MSC_VER) && (_MSC_VER >= 1912)) ||                                                  \
      (defined(__GNUC__) && __GNUC__ >= 6 && defined(__cplusplus) && __cplusplus >= 201402L)) &&                                            \
     !defined(__ICL) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
     #define SPDLOG_CONSTEXPR_FUNC constexpr

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -70,19 +70,13 @@
     #define SPDLOG_CONSTEXPR constexpr
 #endif
 
-// If building with std::format, can just use constexpr, otherwise if building with fmt
-// SPDLOG_CONSTEXPR_FUNC needs to be set the same as FMT_CONSTEXPR to avoid situations where
-// a constexpr function in spdlog could end up calling a non-constexpr function in fmt
-// depending on the compiler
-// If fmt determines it can't use constexpr, we should inline the function instead
-#ifdef SPDLOG_USE_STD_FORMAT
+// If building with fmt SPDLOG_CONSTEXPR_FUNC needs to be set the same as FMT_CONSTEXPR
+// to avoid situations where a constexpr function in spdlog could end up calling
+// a non-constexpr function in fmt depending on the compiler
+#ifdef FMT_CONSTEXPR
+    #define SPDLOG_CONSTEXPR_FUNC FMT_CONSTEXPR
+#else
     #define SPDLOG_CONSTEXPR_FUNC constexpr
-#else  // Being built with fmt
-    #if FMT_USE_CONSTEXPR
-        #define SPDLOG_CONSTEXPR_FUNC FMT_CONSTEXPR
-    #else
-	#define SPDLOG_CONSTEXPR_FUNC inline
-    #endif
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -65,15 +65,21 @@
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
     #define SPDLOG_NOEXCEPT _NOEXCEPT
     #define SPDLOG_CONSTEXPR
-    #define SPDLOG_CONSTEXPR_FUNC inline
 #else
     #define SPDLOG_NOEXCEPT noexcept
     #define SPDLOG_CONSTEXPR constexpr
-    #if __cplusplus >= 201402L
-        #define SPDLOG_CONSTEXPR_FUNC constexpr
-    #else
-        #define SPDLOG_CONSTEXPR_FUNC inline
-    #endif
+#endif
+
+#ifndef __has_feature
+#    define __has_feature(x) 0
+#endif
+
+#if (__has_feature(cxx_relaxed_constexpr) || (defined(_MSC_VER) && (_MSC_VER >= 1912)) ||                                                  \
+     (defined(__GNUC__) && __GNUC__ >= 6 && defined(__cplusplus) && __cplusplus >= 201402L)) &&                                            \
+    !defined(__ICL) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
+    #define SPDLOG_CONSTEXPR_FUNC constexpr
+#else
+    #define SPDLOG_CONSTEXPR_FUNC inline
 #endif
 
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
Fixes #2856.

PR based on #2858 and #2859.

Fixes the issue where a constexpr function in spdlog may call a non-constexpr function in fmt because `FMT_CONSTEXPR` is not defined or is defined differently for a given compiler.

Ideally, a test could be added of building a `.cu` file using nvcc and add that to CI to prevent nvcc breakages moving forward.
