### PR TITLE
fmt/*.h: include tweakme.h to set SPDLOG_FMT_EXTERNAL according to system

### DIFF
--- a/include/spdlog/fmt/chrono.h
+++ b/include/spdlog/fmt/chrono.h
@@ -7,6 +7,7 @@
 //
 // include bundled or external copy of fmtlib's chrono support
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)

--- a/include/spdlog/fmt/compile.h
+++ b/include/spdlog/fmt/compile.h
@@ -7,6 +7,7 @@
 //
 // include bundled or external copy of fmtlib's compile-time support
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)

--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -9,6 +9,7 @@
 // Include a bundled header-only copy of fmtlib or an external one.
 // By default spdlog include its own copy.
 //
+#include <spdlog/tweakme.h>
 
 #if defined(SPDLOG_USE_STD_FORMAT)  // SPDLOG_USE_STD_FORMAT is defined - use std::format
     #include <format>

--- a/include/spdlog/fmt/ostr.h
+++ b/include/spdlog/fmt/ostr.h
@@ -7,6 +7,7 @@
 //
 // include bundled or external copy of fmtlib's ostream support
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)

--- a/include/spdlog/fmt/ranges.h
+++ b/include/spdlog/fmt/ranges.h
@@ -7,6 +7,7 @@
 //
 // include bundled or external copy of fmtlib's ranges support
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)

--- a/include/spdlog/fmt/std.h
+++ b/include/spdlog/fmt/std.h
@@ -8,6 +8,7 @@
 // include bundled or external copy of fmtlib's std support (for formatting e.g.
 // std::filesystem::path, std::thread::id, std::monostate, std::variant, ...)
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)

--- a/include/spdlog/fmt/xchar.h
+++ b/include/spdlog/fmt/xchar.h
@@ -7,6 +7,7 @@
 //
 // include bundled or external copy of fmtlib's xchar support
 //
+#include <spdlog/tweakme.h>
 
 #if !defined(SPDLOG_USE_STD_FORMAT)
     #if !defined(SPDLOG_FMT_EXTERNAL)


### PR DESCRIPTION
Fixes #2922

Since people need to include the version of FMT that spdlog uses when they do things like defining custom formatters in headers, it should be possible to `#include <spdlog/fmt/fmt.h>` without previously including other spdlog headers.

Currently that's not possible (#2922), and simply including the tweakme.h solves that.
