### PR TITLE
Memory leak fix on shutdown

### DIFF
--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -90,7 +90,10 @@ public:
 
     static registry &instance();
 
-    void apply_logger_env_levels(std::shared_ptr<logger> new_logger);
+    // explicitely free the singleton instance.
+    static void free();
+
+    void apply_logger_env_levels(std::shared_ptr<logger> new_logger);   
 
 private:
     registry();
@@ -112,6 +115,9 @@ private:
     std::shared_ptr<logger> default_logger_;
     bool automatic_registration_ = true;
     size_t backtrace_n_messages_ = 0;
+
+    static registry* s_instance;
+    static std::mutex s_instanceMutex;
 };
 
 }  // namespace details

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -116,7 +116,7 @@ private:
     bool automatic_registration_ = true;
     size_t backtrace_n_messages_ = 0;
 
-    static registry* s_instance;
+    static std::atomic<registry*> s_instance;
     static std::mutex s_instanceMutex;
 };
 

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -67,7 +67,10 @@ SPDLOG_INLINE void drop(const std::string &name) { details::registry::instance()
 
 SPDLOG_INLINE void drop_all() { details::registry::instance().drop_all(); }
 
-SPDLOG_INLINE void shutdown() { details::registry::instance().shutdown(); }
+SPDLOG_INLINE void shutdown() {
+    details::registry::instance().shutdown();
+    details::registry::free();
+}
 
 SPDLOG_INLINE void set_automatic_registration(bool automatic_registration) {
     details::registry::instance().set_automatic_registration(automatic_registration);


### PR DESCRIPTION
Fix for false-positive memory leak when using leak detection methods (such as CRT dump memory leaks).

Since we cannot rely on static de-initialisation for freeing the registry::s_instance, this is now lazily allocated instead and freed during spdlog::shutdown() function. In my test case, saves ~15 reported memory leaks.