### PR TITLE
`async_msg`: take ownership of filename/funcname

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - { compiler: gcc, version: 12, build_type: Release, cppstd: 20 }
           - { compiler: clang, version: 12, build_type: Debug, cppstd: 17, asan: OFF }
           - { compiler: clang, version: 15, build_type: Release, cppstd: 20, asan: OFF }
+        async_owning_sourceloc_strings:
+          - ON
+          - OFF
     container:
       image: ${{ matrix.config.compiler == 'clang' && 'teeks99/clang-ubuntu' || matrix.config.compiler }}:${{ matrix.config.version }}
     name: "${{ matrix.config.compiler}} ${{ matrix.config.version }} (C++${{ matrix.config.cppstd }}, ${{ matrix.config.build_type }})"
@@ -51,6 +54,7 @@ jobs:
             -DSPDLOG_BUILD_BENCH=OFF \
             -DSPDLOG_BUILD_TESTS=ON \
             -DSPDLOG_BUILD_TESTS_HO=OFF \
+            -DSPDLOG_ASYNC_OWNING_SOURCELOC_STRINGS=${{ matrix.async_owning_sourceloc_strings }} \
             -DSPDLOG_SANITIZE_ADDRESS=${{ matrix.config.asan || 'ON' }}
           make -j2
           ctest -j2 --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ option(SPDLOG_SANITIZE_ADDRESS "Enable address sanitizer in tests" OFF)
 # warning options
 option(SPDLOG_BUILD_WARNINGS "Enable compiler warnings" OFF)
 
+# owning sourceloc strings options
+option(SPDLOG_ASYNC_OWNING_SOURCELOC_STRINGS "Async loggers take owership of source_loc strings" OFF)
+
+
 # install options
 option(SPDLOG_SYSTEM_INCLUDES "Include as system headers (skip for clang-tidy)." OFF)
 option(SPDLOG_INSTALL "Generate the install target" ${SPDLOG_MASTER_PROJECT})
@@ -248,6 +252,7 @@ foreach(
     SPDLOG_NO_TLS
     SPDLOG_NO_ATOMIC_LEVELS
     SPDLOG_DISABLE_DEFAULT_LOGGER
+    SPDLOG_ASYNC_OWNING_SOURCELOC_STRINGS
     SPDLOG_USE_STD_FORMAT)
     if(${SPDLOG_OPTION})
         target_compile_definitions(spdlog PUBLIC ${SPDLOG_OPTION})


### PR DESCRIPTION
the async logger cannot ensure that filename/funcname pointers are still valid at the time when the async worker is executed:
* filename/funcname may be provided by a VM
* filename/funcname may point to a readonly text field, in a shared object that had been `dlclose`d

we add an api that can be enabled via `SPDLOG_ASYNC_OWNING_SOURCELOC_STRINGS` to take ownership of the strings

fixes #2867