### PR TITLE
Better integrate with std::source_location

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <initializer_list>
@@ -319,14 +320,14 @@ private:
 
 struct source_loc {
     SPDLOG_CONSTEXPR source_loc() = default;
-    SPDLOG_CONSTEXPR source_loc(const char *filename_in, int line_in, const char *funcname_in)
+    SPDLOG_CONSTEXPR source_loc(const char *filename_in, std::uint_least32_t line_in, const char *funcname_in)
         : filename{filename_in},
           line{line_in},
           funcname{funcname_in} {}
 
     SPDLOG_CONSTEXPR bool empty() const SPDLOG_NOEXCEPT { return line == 0; }
     const char *filename{nullptr};
-    int line{0};
+    std::uint_least32_t line{0};
     const char *funcname{nullptr};
 };
 

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -16,8 +16,13 @@
 #include <string>
 #include <type_traits>
 
+#ifdef __has_include
+    #if __has_include(<version>)
+        #include <version>
+    #endif
+#endif
+
 #ifdef SPDLOG_USE_STD_FORMAT
-    #include <version>
     #if __cpp_lib_format >= 202207L
         #include <format>
     #else

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -107,7 +107,13 @@
 #endif
 
 #ifndef SPDLOG_FUNCTION
-    #define SPDLOG_FUNCTION static_cast<const char *>(__FUNCTION__)
+    // use std::source_location instead of macros if available
+    #ifdef __cpp_lib_source_location
+        #define SPDLOG_STD_SOURCE_LOCATION
+        #include <source_location>
+    #else
+        #define SPDLOG_FUNCTION static_cast<const char *>(__FUNCTION__)
+    #endif
 #endif
 
 #ifdef SPDLOG_NO_EXCEPTIONS
@@ -324,6 +330,13 @@ struct source_loc {
         : filename{filename_in},
           line{line_in},
           funcname{funcname_in} {}
+
+    #ifdef SPDLOG_STD_SOURCE_LOCATION
+    SPDLOG_CONSTEXPR source_loc(const std::source_location& loc)
+        : filename{loc.file_name()},
+          line{loc.line()},
+          funcname{loc.function_name()} {}
+    #endif
 
     SPDLOG_CONSTEXPR bool empty() const SPDLOG_NOEXCEPT { return line == 0; }
     const char *filename{nullptr};

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -284,8 +284,13 @@ inline void critical(const T &msg) {
 //
 
 #ifndef SPDLOG_NO_SOURCE_LOC
-    #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-        (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+    #ifdef SPDLOG_STD_SOURCE_LOCATION
+        #define SPDLOG_LOGGER_CALL(logger, level, ...) \
+            (logger)->log(spdlog::source_loc{std::source_location::current()}, level, __VA_ARGS__)
+    #else
+        #define SPDLOG_LOGGER_CALL(logger, level, ...) \
+            (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+    #endif
 #else
     #define SPDLOG_LOGGER_CALL(logger, level, ...) \
         (logger)->log(spdlog::source_loc{}, level, __VA_ARGS__)

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -131,7 +131,8 @@
 // Uncomment (and change if desired) macro to use for function names.
 // This is compiler dependent.
 // __PRETTY_FUNCTION__ might be nicer in clang/gcc, and __FUNCTION__ in msvc.
-// Defaults to __FUNCTION__ (should work on all compilers) if not defined.
+// Defaults to __FUNCTION__ (should work on all compilers) if not defined and
+// std::source_location (introduced in C++20) is not available..
 //
 // #ifdef __PRETTY_FUNCTION__
 // # define SPDLOG_FUNCTION __PRETTY_FUNCTION__


### PR DESCRIPTION
This PR aims to better integrate spdlog v1.x with [`std::source_location`](https://en.cppreference.com/w/cpp/utility/source_location). Effectively closes https://github.com/gabime/spdlog/issues/1959.

The main idea is to allow constructing `spdlog::source_loc` from `std::source_location`. This approach is significantly simpler compared to https://github.com/gabime/spdlog/pull/2667 and still works as one would expect:
```cpp
spdlog::log(std::source_location::current(), spdlog::level::info, "test");
```

The neat part is that thanks to `std::source_location` being `constexpr`, it has the same runtime performance as the macro solution. The only caveat is that `std::source_location` uses `std::uint_least32_t` instead of `int` for the line number - I adapted `spdlog::source_loc` to use this as well, which might result in some compiler/linter warnings when upgrading (though they are trivial to fix by changing the cast type).