### PR TITLE
Fix MSVC compile flag for no exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ if(SPDLOG_NO_EXCEPTIONS)
     if(NOT MSVC)
         target_compile_options(spdlog PRIVATE -fno-exceptions)
     else()
-        target_compile_options(spdlog PRIVATE /EHsc)
+        target_compile_options(spdlog PRIVATE /EHs-c-)
     endif()
 endif()
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Looks like there was a small oversite when the disable exceptions flag was implemented for msvc. As per [msdn](https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170), the correct flag for disabling exceptions has the hyphens.

This issue also exists on the 2.x branch, however I do not know enough about github if its possible to make this pull request apply to both branches