### PR TITLE
Also use _stat() on Windows to be more UTF8 friendly

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -177,11 +177,11 @@ SPDLOG_INLINE int rename(const filename_t &filename1, const filename_t &filename
 // Return true if path exists (file or directory)
 SPDLOG_INLINE bool path_exists(const filename_t &filename) SPDLOG_NOEXCEPT {
 #ifdef _WIN32
-    struct _stat64i32 buffer;
+    struct _stat buffer;
     #ifdef SPDLOG_WCHAR_FILENAMES
-    return (::_wstat64i32(filename.c_str(), &buffer) == 0);
+    return (::_wstat(filename.c_str(), &buffer) == 0);
     #else
-    return (::_stat64i32(filename.c_str(), &buffer) == 0);
+    return (::_stat(filename.c_str(), &buffer) == 0);
     #endif
 #else  // common linux/unix all have the stat system call
     struct stat buffer;

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -177,12 +177,12 @@ SPDLOG_INLINE int rename(const filename_t &filename1, const filename_t &filename
 // Return true if path exists (file or directory)
 SPDLOG_INLINE bool path_exists(const filename_t &filename) SPDLOG_NOEXCEPT {
 #ifdef _WIN32
+    struct _stat64i32 buffer;
     #ifdef SPDLOG_WCHAR_FILENAMES
-    auto attribs = ::GetFileAttributesW(filename.c_str());
+    return (::_wstat64i32(filename.c_str(), &buffer) == 0);
     #else
-    auto attribs = ::GetFileAttributesA(filename.c_str());
+    return (::_stat64i32(filename.c_str(), &buffer) == 0);
     #endif
-    return attribs != INVALID_FILE_ATTRIBUTES;
 #else  // common linux/unix all have the stat system call
     struct stat buffer;
     return (::stat(filename.c_str(), &buffer) == 0);


### PR DESCRIPTION
This PR tries to fix #2977.

The advantage of using ```_stat()``` function over ```GetFileAttributesA()``` API is that:

- When ```SPDLOG_WCHAR_FILENAMES``` is not defined:
-- If ```setlocale(LC_ALL, ".UTF8")``` is called before, then filename will be treated as UTF8 string, and this is the main use case for supporting UTF8 filenames with std::string under Windows.
-- If ```setlocale(LC_ALL, ".UTF8")``` is not called before, then filename will be treated with the current code page (CP_ACP), just like the old behavior.
- When ```SPDLOG_WCHAR_FILENAMES``` is defined, the behavior is the same as if ```GetFileAttributesW()``` was used. 