### PR TITLE
Add constructor to `spdlog::source_loc` using `std::source_location`

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -105,6 +105,12 @@
     #endif
 #endif
 
+// Add constructor to spdlog::source_loc using std::source_location
+#if __cpp_lib_source_location >= 201907L
+    #define SPDLOG_STD_SOURCE_LOCATION
+    #include <source_location>
+#endif
+
 #ifndef SPDLOG_FUNCTION
     #define SPDLOG_FUNCTION static_cast<const char *>(__FUNCTION__)
 #endif
@@ -323,6 +329,13 @@ struct source_loc {
         : filename{filename_in},
           line{line_in},
           funcname{funcname_in} {}
+
+    #ifdef SPDLOG_STD_SOURCE_LOCATION
+    SPDLOG_CONSTEXPR source_loc(const std::source_location& loc)
+        : filename{loc.file_name()},
+          line{static_cast<int>(loc.line())},
+          funcname{loc.function_name()} {}
+    #endif
 
     SPDLOG_CONSTEXPR bool empty() const SPDLOG_NOEXCEPT { return line == 0; }
     const char *filename{nullptr};

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -16,8 +16,13 @@
 #include <string>
 #include <type_traits>
 
+#ifdef __has_include
+    #if __has_include(<version>)
+        #include <version>
+    #endif
+#endif
+
 #ifdef SPDLOG_USE_STD_FORMAT
-    #include <version>
     #if __cpp_lib_format >= 202207L
         #include <format>
     #else


### PR DESCRIPTION
Alternative to #2973, closes #1959.

Compared to #1959, this now only adds a constructor to `spdlog::source_loc` using `std::source_location` (if available), but does not change the type of `line` in the struct or use `std::source_location::current()` in the `SPDLOG_LOGGER_CALL` macro.

Motivation for this change is given in https://github.com/gabime/spdlog/pull/2973#issuecomment-1887390376.