### PR TITLE
Adds details about how compile time macros work

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ int main()
     spdlog::set_pattern("[%H:%M:%S %z] [%n] [%^---%L---%$] [thread %t] %v");
     
     // Compile time log levels
-    // define SPDLOG_ACTIVE_LEVEL to desired level
+    // Note that this does not change the current log level, it will only
+    // remove (depending on SPDLOG_ACTIVE_LEVEL) the call on the release code.
     SPDLOG_TRACE("Some trace message with param {}", 42);
     SPDLOG_DEBUG("Some debug message");
 }


### PR DESCRIPTION
Makes it more clear about how compile time macros work. Currently, it may induce the user to think that the macros will override the current log level, and they won't. This is related to issue #2975.