### PR TITLE
Redundant message when using multi-config generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,9 @@ if(SPDLOG_BUILD_PIC)
 endif()
 
 find_package(Threads REQUIRED)
-message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+if(DEFINED CMAKE_BUILD_TYPE)
+    message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+endif()
 # ---------------------------------------------------------------------------------------
 # Static/Shared library
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Multi-config generators such as "Ninja Multi-Config" will not define CMAKE_BUILD_TYPE, therefore the "Build type" message should not be called.