### PR TITLE
Expose the flusher thread object to user in order to allow setting of thread name and thread affinity when needed

### DIFF
--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -38,6 +38,7 @@ public:
             }
         });
     }
+    std::thread *get_thread() { return &worker_thread_; }
     periodic_worker(const periodic_worker &) = delete;
     periodic_worker &operator=(const periodic_worker &) = delete;
     // stop the worker thread and join it

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -38,7 +38,7 @@ public:
             }
         });
     }
-    std::thread *get_thread() { return &worker_thread_; }
+    std::thread &get_thread() { return worker_thread_; }
     periodic_worker(const periodic_worker &) = delete;
     periodic_worker &operator=(const periodic_worker &) = delete;
     // stop the worker thread and join it

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -68,6 +68,8 @@ public:
         periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
     }
 
+    std::unique_ptr<periodic_worker> &get_flusher() { return periodic_flusher_; }
+
     void set_error_handler(err_handler handler);
 
     void apply_all(const std::function<void(const std::shared_ptr<logger>)> &fun);

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -68,7 +68,7 @@ public:
         periodic_flusher_ = details::make_unique<periodic_worker>(clbk, interval);
     }
 
-    std::unique_ptr<periodic_worker> &get_flusher() { return periodic_flusher_; }
+    std::unique_ptr<periodic_worker> &get_flusher() { std::lock_guard<std::mutex> lock(flusher_mutex_); return periodic_flusher_; }
 
     void set_error_handler(err_handler handler);
 

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -89,9 +89,4 @@ SPDLOG_INLINE void apply_logger_env_levels(std::shared_ptr<logger> logger) {
     details::registry::instance().apply_logger_env_levels(std::move(logger));
 }
 
-SPDLOG_INLINE std::unique_ptr<spdlog::details::periodic_worker> &get_flusher()
-{
-    return details::registry::instance().get_flusher();
-}
-
 }  // namespace spdlog

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -89,4 +89,9 @@ SPDLOG_INLINE void apply_logger_env_levels(std::shared_ptr<logger> logger) {
     details::registry::instance().apply_logger_env_levels(std::move(logger));
 }
 
+SPDLOG_INLINE std::unique_ptr<spdlog::details::periodic_worker> &get_flusher()
+{
+    return details::registry::instance().get_flusher();
+}
+
 }  // namespace spdlog


### PR DESCRIPTION
In our app there is a need to set the thread name and thread affinity for all spawned thread. In order to do so with the spdlog flusher thread, I had to expose the thread from the internal data structure  (periodic_worker) via the registery. I thought this might be worthy of a merge back into the main stream.