### PR TITLE
Feature | Adds `std::string_view` overloads for logger accessor

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -84,6 +84,22 @@ SPDLOG_INLINE std::shared_ptr<logger> registry::get(const std::string &logger_na
     return found == loggers_.end() ? nullptr : found->second;
 }
 
+#if __cplusplus >= 201703L  // C++17
+SPDLOG_INLINE std::shared_ptr<logger> registry::get(std::string_view logger_name) {
+    std::lock_guard<std::mutex> lock(logger_map_mutex_);
+    for (const auto &[key, val] : loggers_) {
+        if (key == logger_name) {
+            return val;
+        }
+    }
+    return nullptr;
+}
+
+SPDLOG_INLINE std::shared_ptr<logger> registry::get(const char *logger_name) {
+    return get(std::string_view(logger_name));
+}
+#endif
+
 SPDLOG_INLINE std::shared_ptr<logger> registry::default_logger() {
     std::lock_guard<std::mutex> lock(logger_map_mutex_);
     return default_logger_;

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -18,6 +18,10 @@
 #include <string>
 #include <unordered_map>
 
+#if __cplusplus >= 201703L  // C++17
+    #include <string_view>
+#endif
+
 namespace spdlog {
 class logger;
 
@@ -33,6 +37,10 @@ public:
     void register_logger(std::shared_ptr<logger> new_logger);
     void initialize_logger(std::shared_ptr<logger> new_logger);
     std::shared_ptr<logger> get(const std::string &logger_name);
+#if __cplusplus >= 201703L  // C++17
+    std::shared_ptr<logger> get(std::string_view logger_name);
+    std::shared_ptr<logger> get(const char *logger_name);
+#endif
     std::shared_ptr<logger> default_logger();
 
     // Return raw ptr to the default logger.

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -20,6 +20,16 @@ SPDLOG_INLINE std::shared_ptr<logger> get(const std::string &name) {
     return details::registry::instance().get(name);
 }
 
+#if __cplusplus >= 201703L  // C++17
+SPDLOG_INLINE std::shared_ptr<logger> get(std::string_view name) {
+    return details::registry::instance().get(name);
+}
+
+SPDLOG_INLINE std::shared_ptr<logger> get(const char *name) {
+    return details::registry::instance().get(name);
+}
+#endif
+
 SPDLOG_INLINE void set_formatter(std::unique_ptr<spdlog::formatter> formatter) {
     details::registry::instance().set_formatter(std::move(formatter));
 }

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -20,6 +20,10 @@
 #include <memory>
 #include <string>
 
+#if __cplusplus >= 201703L  // C++17
+    #include <string_view>
+#endif
+
 namespace spdlog {
 
 using default_factory = synchronous_factory;
@@ -50,6 +54,10 @@ SPDLOG_API void initialize_logger(std::shared_ptr<logger> logger);
 // exist.
 // example: spdlog::get("my_logger")->info("hello {}", "world");
 SPDLOG_API std::shared_ptr<logger> get(const std::string &name);
+#if __cplusplus >= 201703L  // C++17
+SPDLOG_API std::shared_ptr<logger> get(std::string_view name);
+SPDLOG_API std::shared_ptr<logger> get(const char *name);
+#endif
 
 // Set global formatter. Each sink in each logger will get a clone of this object
 SPDLOG_API void set_formatter(std::unique_ptr<spdlog::formatter> formatter);


### PR DESCRIPTION
# Adds `std::string_view` overloads for logger accessor

## Motivation 

For clients who store logger ids as string literals, or other non-`std::string` data types, it would be very useful to add a `std::string_view` overload for the `spdlog::get` function. This would save such clients needing to make a temporary, dynamically allocated copy of their logger name data in order to access a specific logger.

## Details

### Only enabled in C++17

`std::string_view` is a C++17 feature, so the additional overloads are only included if the project is compiled against C++17 or greater.

### Additional `const char*` overload

With the addition of the `spdlog::get(std::string_view)` overload, calls to this function with a `const char*` become ambiguous.

```cpp
const char *const name = "my_logger";
spdlog::get(name); // error: call to spdlog::get is ambiguous.
```

To disambiguate we also add a `spdlog::get(const char*)` overload which forwards calls on to the `spdlog::get(std::string_view)` overload.