### PR TITLE
Add missing include in circular_q.h

### DIFF
--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -7,6 +7,8 @@
 #include <cassert>
 #include <vector>
 
+#include "spdlog/common.h"
+
 namespace spdlog {
 namespace details {
 template <typename T>


### PR DESCRIPTION
`circular_q` uses the SPDLOG_NOEXCEPT macro, which is defined in `spdlog/common.h`. Due to some recent reorganization of includes in `ringbuffer_sink.h`, `common.h` was no longer included before `circular_q.h`, causing my build to break when updating to v1.13.0