### PR TITLE
Fix source group for msvc compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,8 +301,8 @@ set_target_properties(spdlog PROPERTIES DEBUG_POSTFIX d)
 
 # set source groups for visual studio
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
-    source_group(TREE ${CMAKE_SOURCE_DIR}/include PREFIX include FILES ${SPDLOG_HEADERS})
-    source_group(TREE ${CMAKE_SOURCE_DIR}/src PREFIX sources FILES ${SPDLOG_SRCS})    
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/include PREFIX include FILES ${SPDLOG_HEADERS})
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX sources FILES ${SPDLOG_SRCS})    
     source_group(sources FILES ${VERSION_RC})
 endif()
 


### PR DESCRIPTION
If use spdlog as dependency for cmake project that builds with msvc, 
`
CPMAddPackage(
        NAME spdlog
        GITHUB_REPOSITORY gabime/spdlog
        GIT_TAG 69d412b5260ffdb67b2f18a60f4eb1043035d1cf
        OPTIONS
                "SPDLOG_USE_STD_FORMAT ON"
                "CMAKE_CXX_STANDARD 23"
)
target_link_libraries(${PROJECT_NAME} spdlog)
`
project configuraion failed with error
`
[cmake] -- Generating C:/DEV/Gooscience/build/_deps/spdlog-src/include/spdlog/spdlog_config.h
[cmake] CMake Error at build/_deps/spdlog-src/CMakeLists.txt:304 (source_group):
[cmake]   source_group ROOT: C:/DEV/Gooscience/include is not a prefix of file:
[cmake]   C:/DEV/Gooscience/build/_deps/spdlog-src/include/spdlog/async.h
[cmake] 
[cmake] 
[cmake] CMake Error at build/_deps/spdlog-src/CMakeLists.txt:305 (source_group):
[cmake]   source_group ROOT: C:/DEV/Gooscience/src is not a prefix of file:
[cmake]   C:/DEV/Gooscience/build/_deps/spdlog-src/src/async_logger.cpp
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
`

error occur because incorrect path defined in CMakeLists.txt in lines 304, 305. Instead of ${CMAKE_SOURCE_DIR} should be ${CMAKE_CURRENT_SOURCE_DIR}