### PR TITLE
Remove the legacy AnalyzeTemporaryDtors option from .clang-tidy.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,6 @@ clang-analyzer-*,
 
 WarningsAsErrors: ''
 HeaderFilterRegex: '*spdlog/[^f].*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none
 
 CheckOptions:    


### PR DESCRIPTION
Remove the legacy `AnalyzeTemporaryDtors` option from `.clang-tidy`.

This option was deprecated in clang-tidy-16, and removed in clang-tidy-18:
https://releases.llvm.org/18.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#improvements-to-clang-tidy
