### PR TITLE
Make async_logger::flush() synchronous and wait for the flush to comp…

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -43,13 +43,15 @@ SPDLOG_LOGGER_CATCH(msg.source)
 }
 
 // send flush request to the thread pool
-SPDLOG_INLINE void spdlog::async_logger::flush_(){
-    SPDLOG_TRY{if (auto pool_ptr = thread_pool_.lock()){
-        pool_ptr->post_flush(shared_from_this(), overflow_policy_);
-}
-else {
+SPDLOG_INLINE void spdlog::async_logger::flush_(){SPDLOG_TRY{auto pool_ptr = thread_pool_.lock();
+if (!pool_ptr) {
     throw_spdlog_ex("async flush: thread pool doesn't exist anymore");
 }
+
+std::future<void> future = pool_ptr->post_flush(shared_from_this(), overflow_policy_);
+// Wait for the flush operation to complete.
+// This might throw exception if the flush message get dropped because of overflow.
+future.get();
 }
 SPDLOG_LOGGER_CATCH(source_loc())
 }

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <functional>
+#include <future>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -27,6 +28,7 @@ enum class async_msg_type { log, flush, terminate };
 struct async_msg : log_msg_buffer {
     async_msg_type msg_type{async_msg_type::log};
     async_logger_ptr worker_ptr;
+    std::promise<void> flush_promise;
 
     async_msg() = default;
     ~async_msg() = default;
@@ -56,12 +58,22 @@ struct async_msg : log_msg_buffer {
     async_msg(async_logger_ptr &&worker, async_msg_type the_type, const details::log_msg &m)
         : log_msg_buffer{m},
           msg_type{the_type},
-          worker_ptr{std::move(worker)} {}
+          worker_ptr{std::move(worker)},
+          flush_promise{} {}
 
     async_msg(async_logger_ptr &&worker, async_msg_type the_type)
         : log_msg_buffer{},
           msg_type{the_type},
-          worker_ptr{std::move(worker)} {}
+          worker_ptr{std::move(worker)},
+          flush_promise{} {}
+
+    async_msg(async_logger_ptr &&worker,
+              async_msg_type the_type,
+              std::promise<void> &&promise)
+        : log_msg_buffer{},
+          msg_type{the_type},
+          worker_ptr{std::move(worker)},
+          flush_promise{std::move(promise)} {}
 
     explicit async_msg(async_msg_type the_type)
         : async_msg{nullptr, the_type} {}
@@ -88,7 +100,8 @@ public:
     void post_log(async_logger_ptr &&worker_ptr,
                   const details::log_msg &msg,
                   async_overflow_policy overflow_policy);
-    void post_flush(async_logger_ptr &&worker_ptr, async_overflow_policy overflow_policy);
+    std::future<void> post_flush(async_logger_ptr &&worker_ptr,
+                                 async_overflow_policy overflow_policy);
     size_t overrun_counter();
     void reset_overrun_counter();
     size_t discard_counter();


### PR DESCRIPTION
This patch make the async_logger::flush() interface a synchronous operation, similar to that of normal logger::flush(). The flush operation return only after it succeeds or fail. If failed, the error handler would be invoked with a exception message.

This patch also modify the minimum c++ stdandard to be c++14, to be able to use functions like std::make_unique().