### PR TITLE
Ansi colored file sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/
 * [Custom](https://github.com/gabime/spdlog/wiki/3.-Custom-formatting) formatting.
 * Multi/Single threaded loggers.
 * Various log targets:
-  * Rotating log files.
+  * Rotating log files (ANSI colors supported).
   * Daily log files.
   * Console logging (colors supported).
   * syslog.
@@ -126,6 +126,18 @@ void rotating_example()
     auto max_size = 1048576 * 5;
     auto max_files = 3;
     auto logger = spdlog::rotating_logger_mt("some_logger_name", "logs/rotating.txt", max_size, max_files);
+}
+```
+
+---
+#### ANSI-colored rotating files
+```c++
+#include "spdlog/sinks/ansicolor_rotating_file_sink.h"
+void ansicolor_rotating_example() {
+    // Create an ANSI-colored file rotating logger with 10 MB size max and 3 rotated files.
+    auto max_size = 1048576 * 10;
+    auto max_files = 3;
+    auto logger = spdlog::ansicolor_rotating_logger_mt("ansi_logger", "logs/ansicolor_rotating.txt", max_size, max_files);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,23 +61,23 @@ see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/
 ```c++
 #include "spdlog/spdlog.h"
 
-int main() 
+int main()
 {
     spdlog::info("Welcome to spdlog!");
     spdlog::error("Some error message with arg: {}", 1);
-    
+
     spdlog::warn("Easy padding in numbers like {:08d}", 12);
     spdlog::critical("Support for int: {0:d};  hex: {0:x};  oct: {0:o}; bin: {0:b}", 42);
     spdlog::info("Support for floats {:03.2f}", 1.23456);
     spdlog::info("Positional args are {1} {0}..", "too", "supported");
     spdlog::info("{:<30}", "left aligned");
-    
+
     spdlog::set_level(spdlog::level::debug); // Set global log level to debug
-    spdlog::debug("This message should be displayed..");    
-    
+    spdlog::debug("This message should be displayed..");
+
     // change log pattern
     spdlog::set_pattern("[%H:%M:%S %z] [%n] [%^---%L---%$] [thread %t] %v");
-    
+
     // Compile time log levels
     // Note that this does not change the current log level, it will only
     // remove (depending on SPDLOG_ACTIVE_LEVEL) the call on the release code.
@@ -94,8 +94,8 @@ int main()
 void stdout_example()
 {
     // create a color multi-threaded logger
-    auto console = spdlog::stdout_color_mt("console");    
-    auto err_logger = spdlog::stderr_color_mt("stderr");    
+    auto console = spdlog::stdout_color_mt("console");
+    auto err_logger = spdlog::stderr_color_mt("stderr");
     spdlog::get("console")->info("loggers can be retrieved from a global registry using the spdlog::get(logger_name)");
 }
 ```
@@ -106,9 +106,25 @@ void stdout_example()
 #include "spdlog/sinks/basic_file_sink.h"
 void basic_logfile_example()
 {
-    try 
+    try
     {
         auto logger = spdlog::basic_logger_mt("basic_logger", "logs/basic-log.txt");
+    }
+    catch (const spdlog::spdlog_ex &ex)
+    {
+        std::cout << "Log init failed: " << ex.what() << std::endl;
+    }
+}
+```
+---
+#### ANSI-colored file logger
+```c++
+#include "spdlog/sinks/ansicolor_file_sink.h"
+void ansicolor_logfile_example()
+{
+    try
+    {
+        auto logger = spdlog::ansicolor_logger_mt("ansi_logger", "logs/ansicolor-log.txt");
     }
     catch (const spdlog::spdlog_ex &ex)
     {
@@ -161,7 +177,7 @@ void daily_example()
 // This is useful to display debug logs only when needed (e.g. when an error happens).
 // When needed, call dump_backtrace() to dump them to your log.
 
-spdlog::enable_backtrace(32); // Store the latest 32 messages in a buffer. 
+spdlog::enable_backtrace(32); // Store the latest 32 messages in a buffer.
 // or my_logger->enable_backtrace(32)..
 for(int i = 0; i < 100; i++)
 {
@@ -188,9 +204,9 @@ spdlog::flush_every(std::chrono::seconds(3));
 #include "spdlog/stopwatch.h"
 void stopwatch_example()
 {
-    spdlog::stopwatch sw;    
+    spdlog::stopwatch sw;
     spdlog::debug("Elapsed {}", sw);
-    spdlog::debug("Elapsed {:.3}", sw);       
+    spdlog::debug("Elapsed {:.3}", sw);
 }
 
 ```
@@ -277,7 +293,7 @@ void async_example()
     // spdlog::init_thread_pool(8192, 1); // queue with 8k items and 1 backing thread.
     auto async_file = spdlog::basic_logger_mt<spdlog::async_factory>("async_file_logger", "logs/async_log.txt");
     // alternatively:
-    // auto async_file = spdlog::create_async<spdlog::sinks::basic_file_sink_mt>("async_file_logger", "logs/async_log.txt");   
+    // auto async_file = spdlog::create_async<spdlog::sinks::basic_file_sink_mt>("async_file_logger", "logs/async_log.txt");
 }
 
 ```
@@ -299,7 +315,7 @@ void multi_sink_example2()
     spdlog::register_logger(logger);
 }
 ```
- 
+
 ---
 #### User-defined types
 ```c++
@@ -321,7 +337,7 @@ void user_defined_example()
 
 ---
 #### User-defined flags in the log pattern
-```c++ 
+```c++
 // Log patterns can contain custom flags.
 // the following example will add new flag '%*' - which will be bound to a <my_formatter_flag> instance.
 #include "spdlog/pattern_formatter.h"
@@ -341,7 +357,7 @@ public:
 };
 
 void custom_flags_example()
-{    
+{
     auto formatter = std::make_unique<spdlog::pattern_formatter>();
     formatter->add_flag<my_formatter_flag>('*').set_pattern("[%n] [%*] [%^%l%$] %v");
     spdlog::set_formatter(std::move(formatter));
@@ -409,7 +425,7 @@ $ ./example
 ---
 #### Log file open/close event handlers
 ```c++
-// You can get callbacks from spdlog before/after a log file has been opened or closed. 
+// You can get callbacks from spdlog before/after a log file has been opened or closed.
 // This is useful for cleanup procedures or for adding something to the start/end of the log file.
 void file_events_example()
 {
@@ -419,7 +435,7 @@ void file_events_example()
     handlers.after_open = [](spdlog::filename_t filename, std::FILE *fstream) { fputs("After opening\n", fstream); };
     handlers.before_close = [](spdlog::filename_t filename, std::FILE *fstream) { fputs("Before closing\n", fstream); };
     handlers.after_close = [](spdlog::filename_t filename) { spdlog::info("After closing {}", filename); };
-    auto my_logger = spdlog::basic_logger_st("some_logger", "logs/events-sample.txt", true, handlers);        
+    auto my_logger = spdlog::basic_logger_st("some_logger", "logs/events-sample.txt", true, handlers);
 }
 ```
 
@@ -500,16 +516,16 @@ Below are some [benchmarks](https://github.com/gabime/spdlog/blob/v1.x/bench/ben
 [info] Messages     : 1,000,000
 [info] Threads      : 10
 [info] Queue        : 8,192 slots
-[info] Queue memory : 8,192 x 272 = 2,176 KB 
+[info] Queue memory : 8,192 x 272 = 2,176 KB
 [info] -------------------------------------------------
-[info] 
+[info]
 [info] *********************************
 [info] Queue Overflow Policy: block
 [info] *********************************
 [info] Elapsed: 1.70784 secs     585,535/sec
 [info] Elapsed: 1.69805 secs     588,910/sec
 [info] Elapsed: 1.7026 secs      587,337/sec
-[info] 
+[info]
 [info] *********************************
 [info] Queue Overflow Policy: overrun
 [info] *********************************

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -11,6 +11,7 @@ void load_levels_example();
 void stdout_logger_example();
 void basic_example();
 void rotating_example();
+void ansicolor_rotating_example();
 void daily_example();
 void callback_example();
 void async_example();
@@ -71,6 +72,7 @@ int main(int, char *[]) {
         stdout_logger_example();
         basic_example();
         rotating_example();
+        ansicolor_rotating_example();
         daily_example();
         callback_example();
         async_example();
@@ -126,6 +128,13 @@ void rotating_example() {
     // Create a file rotating logger with 5mb size max and 3 rotated files.
     auto rotating_logger =
         spdlog::rotating_logger_mt("some_logger_name", "logs/rotating.txt", 1048576 * 5, 3);
+}
+
+#include "spdlog/sinks/ansicolor_rotating_file_sink.h"
+void ansicolor_rotating_example() {
+    // Create an ANSI-colored file rotating logger with 10mb size max and 3 rotated files.
+    auto ansicolor_rotating_logger = spdlog::ansicolor_rotating_logger_mt(
+        "ansi_logger", "logs/ansicolor_rotating.txt", 1048576 * 10, 3);
 }
 
 #include "spdlog/sinks/daily_file_sink.h"

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -10,6 +10,7 @@
 void load_levels_example();
 void stdout_logger_example();
 void basic_example();
+void ansicolor_example();
 void rotating_example();
 void ansicolor_rotating_example();
 void daily_example();
@@ -71,6 +72,7 @@ int main(int, char *[]) {
     try {
         stdout_logger_example();
         basic_example();
+        ansicolor_example();
         rotating_example();
         ansicolor_rotating_example();
         daily_example();
@@ -121,6 +123,12 @@ void stdout_logger_example() {
 void basic_example() {
     // Create basic file logger (not rotated).
     auto my_logger = spdlog::basic_logger_mt("file_logger", "logs/basic-log.txt", true);
+}
+
+#include "spdlog/sinks/ansicolor_file_sink.h"
+void ansicolor_example() {
+    // Create ANSI-colored file logger (not rotated).
+    auto my_logger = spdlog::ansicolor_logger_mt("ansi_logger", "logs/ansicolor-log.txt", true);
 }
 
 #include "spdlog/sinks/rotating_file_sink.h"

--- a/include/spdlog/details/ansicolors-inl.h
+++ b/include/spdlog/details/ansicolors-inl.h
@@ -10,6 +10,41 @@
 namespace spdlog {
 namespace details {
 
+// Formatting codes
+constexpr const char* ansicolors::reset;
+constexpr const char* ansicolors::bold;
+constexpr const char* ansicolors::dark;
+constexpr const char* ansicolors::underline;
+constexpr const char* ansicolors::blink;
+constexpr const char* ansicolors::reverse;
+constexpr const char* ansicolors::concealed;
+constexpr const char* ansicolors::clear_line;
+
+// Foreground colors
+constexpr const char* ansicolors::black;
+constexpr const char* ansicolors::red;
+constexpr const char* ansicolors::green;
+constexpr const char* ansicolors::yellow;
+constexpr const char* ansicolors::blue;
+constexpr const char* ansicolors::magenta;
+constexpr const char* ansicolors::cyan;
+constexpr const char* ansicolors::white;
+
+/// Background colors
+constexpr const char* ansicolors::on_black;
+constexpr const char* ansicolors::on_red;
+constexpr const char* ansicolors::on_green;
+constexpr const char* ansicolors::on_yellow;
+constexpr const char* ansicolors::on_blue;
+constexpr const char* ansicolors::on_magenta;
+constexpr const char* ansicolors::on_cyan;
+constexpr const char* ansicolors::on_white;
+
+/// Bold colors
+constexpr const char* ansicolors::yellow_bold;
+constexpr const char* ansicolors::red_bold;
+constexpr const char* ansicolors::bold_on_red;
+
 SPDLOG_INLINE ansicolors::ansicolors() {
     colors_.at(level::trace) = to_string_(white);
     colors_.at(level::debug) = to_string_(cyan);
@@ -25,7 +60,7 @@ SPDLOG_INLINE void ansicolors::set_color(level::level_enum color_level, string_v
 }
 
 SPDLOG_INLINE std::vector<string_view_t> ansicolors::ranges(
-    const details::log_msg &msg, const memory_buf_t &formatted_msg) const {
+    const details::log_msg& msg, const memory_buf_t& formatted_msg) const {
     std::vector<string_view_t> result{};
     if (msg.color_range_end > msg.color_range_start) {
         // before color range
@@ -49,7 +84,7 @@ SPDLOG_INLINE std::vector<string_view_t> ansicolors::ranges(
     return result;
 }
 
-SPDLOG_INLINE std::string ansicolors::to_string_(const string_view_t &sv) {
+SPDLOG_INLINE std::string ansicolors::to_string_(const string_view_t& sv) {
     return std::string(sv.data(), sv.size());
 }
 

--- a/include/spdlog/details/ansicolors-inl.h
+++ b/include/spdlog/details/ansicolors-inl.h
@@ -1,0 +1,57 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+    #include <spdlog/details/ansicolors.h>
+#endif
+
+namespace spdlog {
+namespace details {
+
+SPDLOG_INLINE ansicolors::ansicolors() {
+    colors_.at(level::trace) = to_string_(white);
+    colors_.at(level::debug) = to_string_(cyan);
+    colors_.at(level::info) = to_string_(green);
+    colors_.at(level::warn) = to_string_(yellow_bold);
+    colors_.at(level::err) = to_string_(red_bold);
+    colors_.at(level::critical) = to_string_(bold_on_red);
+    colors_.at(level::off) = to_string_(reset);
+}
+
+SPDLOG_INLINE void ansicolors::set_color(level::level_enum color_level, string_view_t color) {
+    colors_.at(static_cast<size_t>(color_level)) = to_string_(color);
+}
+
+SPDLOG_INLINE std::vector<string_view_t> ansicolors::ranges(
+    const details::log_msg &msg, const memory_buf_t &formatted_msg) const {
+    std::vector<string_view_t> result{};
+    if (msg.color_range_end > msg.color_range_start) {
+        // before color range
+        if (msg.color_range_start > 0) {
+            result.push_back(string_view_t{formatted_msg.data(), msg.color_range_start});
+        }
+        // in color range
+        result.push_back(string_view_t{colors_.at(static_cast<size_t>(msg.level))});
+        result.push_back(string_view_t{formatted_msg.data() + msg.color_range_start,
+                                       msg.color_range_end - msg.color_range_start});
+        result.push_back(reset);
+        // after color range
+        if (msg.color_range_end < formatted_msg.size()) {
+            result.push_back(string_view_t{formatted_msg.data() + msg.color_range_end,
+                                           formatted_msg.size() - msg.color_range_end});
+        }
+    } else  // no color
+    {
+        result.push_back(string_view_t{formatted_msg.data(), formatted_msg.size()});
+    }
+    return result;
+}
+
+SPDLOG_INLINE std::string ansicolors::to_string_(const string_view_t &sv) {
+    return std::string(sv.data(), sv.size());
+}
+
+}  // namespace details
+}  // namespace spdlog

--- a/include/spdlog/details/ansicolors.h
+++ b/include/spdlog/details/ansicolors.h
@@ -1,0 +1,72 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/common.h>
+
+#include <spdlog/details/log_msg.h>
+
+#include <array>
+#include <vector>
+
+namespace spdlog {
+namespace details {
+
+class SPDLOG_API ansicolors {
+public:
+    explicit ansicolors();
+    ansicolors(const ansicolors&) = delete;
+    ansicolors& operator=(const ansicolors&) = delete;
+
+    void set_color(level::level_enum color_level, string_view_t color);
+
+    std::vector<string_view_t> ranges(const details::log_msg& msg,
+                                      const memory_buf_t& formatted_msg) const;
+
+    // Formatting codes
+    static constexpr const char* reset = "\033[m";
+    static constexpr const char* bold = "\033[1m";
+    static constexpr const char* dark = "\033[2m";
+    static constexpr const char* underline = "\033[4m";
+    static constexpr const char* blink = "\033[5m";
+    static constexpr const char* reverse = "\033[7m";
+    static constexpr const char* concealed = "\033[8m";
+    static constexpr const char* clear_line = "\033[K";
+
+    // Foreground colors
+    static constexpr const char* black = "\033[30m";
+    static constexpr const char* red = "\033[31m";
+    static constexpr const char* green = "\033[32m";
+    static constexpr const char* yellow = "\033[33m";
+    static constexpr const char* blue = "\033[34m";
+    static constexpr const char* magenta = "\033[35m";
+    static constexpr const char* cyan = "\033[36m";
+    static constexpr const char* white = "\033[37m";
+
+    /// Background colors
+    static constexpr const char* on_black = "\033[40m";
+    static constexpr const char* on_red = "\033[41m";
+    static constexpr const char* on_green = "\033[42m";
+    static constexpr const char* on_yellow = "\033[43m";
+    static constexpr const char* on_blue = "\033[44m";
+    static constexpr const char* on_magenta = "\033[45m";
+    static constexpr const char* on_cyan = "\033[46m";
+    static constexpr const char* on_white = "\033[47m";
+
+    /// Bold colors
+    static constexpr const char* yellow_bold = "\033[33m\033[1m";
+    static constexpr const char* red_bold = "\033[31m\033[1m";
+    static constexpr const char* bold_on_red = "\033[1m\033[41m";
+
+private:
+    std::array<std::string, level::n_levels> colors_;
+    static std::string to_string_(const string_view_t& sv);
+};
+
+}  // namespace details
+}  // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+    #include "ansicolors-inl.h"
+#endif

--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -106,6 +106,15 @@ SPDLOG_INLINE void file_helper::write(const memory_buf_t &buf) {
     }
 }
 
+SPDLOG_INLINE void file_helper::write(string_view_t buf) {
+    if (fd_ == nullptr) return;
+    size_t msg_size = buf.size();
+    auto data = buf.data();
+    if (std::fwrite(data, 1, msg_size, fd_) != msg_size) {
+        throw_spdlog_ex("Failed writing to file " + os::filename_to_str(filename_), errno);
+    }
+}
+
 SPDLOG_INLINE size_t file_helper::size() const {
     if (fd_ == nullptr) {
         throw_spdlog_ex("Cannot use size() on closed file " + os::filename_to_str(filename_));

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -28,6 +28,7 @@ public:
     void sync();
     void close();
     void write(const memory_buf_t &buf);
+    void write(string_view_t buf);
     size_t size() const;
     const filename_t &filename() const;
 

--- a/include/spdlog/details/rotating_file-inl.h
+++ b/include/spdlog/details/rotating_file-inl.h
@@ -1,0 +1,123 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+    #include <spdlog/details/rotating_file.h>
+#endif
+
+#include <spdlog/fmt/fmt.h>
+
+#include <spdlog/details/file_helper.h>
+
+namespace spdlog {
+namespace details {
+
+SPDLOG_INLINE rotating_file::rotating_file(filename_t base_filename,
+                                           std::size_t max_size,
+                                           std::size_t max_files,
+                                           bool rotate_on_open,
+                                           const file_event_handlers &event_handlers)
+    : base_filename_(std::move(base_filename)),
+      max_size_(max_size),
+      max_files_(max_files),
+      file_helper_{event_handlers} {
+    if (max_size == 0) {
+        throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
+    }
+    if (max_files > 200000) {
+        throw_spdlog_ex("rotating sink constructor: max_files arg cannot exceed 200000");
+    }
+    file_helper_.open(calc_filename(base_filename_, 0));
+    current_size_ = file_helper_.size();  // expensive. called only once
+    if (rotate_on_open && current_size_ > 0) {
+        rotate_();
+        current_size_ = 0;
+    }
+}
+
+SPDLOG_INLINE void rotating_file::write(const memory_buf_t &buf) {
+    write(string_view_t{buf.data(), buf.size()});
+}
+
+SPDLOG_INLINE void rotating_file::write(string_view_t buf) {
+    auto new_size = current_size_ + buf.size();
+
+    // rotate if the new estimated file size exceeds max size.
+    // rotate only if the real size > 0 to better deal with full disk (see issue #2261).
+    // we only check the real size when new_size > max_size_ because it is relatively expensive.
+    if (new_size > max_size_) {
+        file_helper_.flush();
+        if (file_helper_.size() > 0) {
+            rotate_();
+            new_size = buf.size();
+        }
+    }
+    file_helper_.write(buf);
+    current_size_ = new_size;
+}
+
+// Rotate files:
+// log.txt -> log.1.txt
+// log.1.txt -> log.2.txt
+// log.2.txt -> log.3.txt
+// log.3.txt -> delete
+SPDLOG_INLINE void rotating_file::rotate_() {
+    using details::os::filename_to_str;
+    using details::os::path_exists;
+
+    file_helper_.close();
+    for (auto i = max_files_; i > 0; --i) {
+        filename_t src = calc_filename(base_filename_, i - 1);
+        if (!path_exists(src)) {
+            continue;
+        }
+        filename_t target = calc_filename(base_filename_, i);
+
+        if (!rename_file_(src, target)) {
+            // if failed try again after a small delay.
+            // this is a workaround to a windows issue, where very high rotation
+            // rates can cause the rename to fail with permission denied (because of antivirus?).
+            details::os::sleep_for_millis(100);
+            if (!rename_file_(src, target)) {
+                file_helper_.reopen(
+                    true);  // truncate the log file anyway to prevent it to grow beyond its limit!
+                current_size_ = 0;
+                throw_spdlog_ex("rotating_file_sink: failed renaming " + filename_to_str(src) +
+                                    " to " + filename_to_str(target),
+                                errno);
+            }
+        }
+    }
+    file_helper_.reopen(true);
+}
+
+SPDLOG_INLINE void rotating_file::flush() { file_helper_.flush(); }
+
+// calc filename according to index and file extension if exists.
+// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
+SPDLOG_INLINE filename_t rotating_file::calc_filename(const filename_t &filename,
+                                                      std::size_t index) {
+    if (index == 0u) {
+        return filename;
+    }
+
+    filename_t basename, ext;
+    std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
+    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
+}
+
+SPDLOG_INLINE filename_t rotating_file::filename() const { return file_helper_.filename(); }
+
+// delete the target if exists, and rename the src file  to target
+// return true on success, false otherwise.
+SPDLOG_INLINE bool rotating_file::rename_file_(const filename_t &src_filename,
+                                               const filename_t &target_filename) {
+    // try to delete the target file in case it already exists.
+    (void)details::os::remove(target_filename);
+    return details::os::rename(src_filename, target_filename) == 0;
+}
+
+}  // namespace details
+}  // namespace spdlog

--- a/include/spdlog/details/rotating_file.h
+++ b/include/spdlog/details/rotating_file.h
@@ -1,0 +1,58 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/common.h>
+
+#include <spdlog/details/file_helper.h>
+
+#include <tuple>
+
+namespace spdlog {
+namespace details {
+
+class SPDLOG_API rotating_file {
+public:
+    explicit rotating_file(filename_t base_filename,
+                           std::size_t max_size,
+                           std::size_t max_files,
+                           bool rotate_on_open,
+                           const file_event_handlers &event_handlers);
+    rotating_file(const rotating_file &) = delete;
+    rotating_file &operator=(const rotating_file &) = delete;
+
+    static filename_t calc_filename(const filename_t &filename, std::size_t index);
+
+    void write(const memory_buf_t &buf);
+    void write(string_view_t buf);
+
+    void flush();
+
+    filename_t filename() const;
+
+private:
+    // Rotate files:
+    // log.txt -> log.1.txt
+    // log.1.txt -> log.2.txt
+    // log.2.txt -> log.3.txt
+    // log.3.txt -> delete
+    void rotate_();
+
+    // delete the target if exists, and rename the src file  to target
+    // return true on success, false otherwise.
+    bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
+
+    filename_t base_filename_;
+    std::size_t max_size_;
+    std::size_t max_files_;
+    std::size_t current_size_;
+    file_helper file_helper_;
+};
+
+}  // namespace details
+}  // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+    #include "rotating_file-inl.h"
+#endif

--- a/include/spdlog/sinks/ansicolor_file_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_file_sink-inl.h
@@ -1,0 +1,52 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+    #include <spdlog/sinks/ansicolor_file_sink.h>
+#endif
+
+#include <spdlog/common.h>
+#include <spdlog/details/os.h>
+
+namespace spdlog {
+namespace sinks {
+
+template <typename Mutex>
+SPDLOG_INLINE ansicolor_file_sink<Mutex>::ansicolor_file_sink(
+    const filename_t &filename, bool truncate, const file_event_handlers &event_handlers)
+    : file_helper_{event_handlers} {
+    file_helper_.open(filename, truncate);
+}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_file_sink<Mutex>::set_color(level::level_enum color_level,
+                                                         string_view_t color) {
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
+    colors_.set_color(color_level, color);
+}
+
+template <typename Mutex>
+SPDLOG_INLINE const filename_t &ansicolor_file_sink<Mutex>::filename() const {
+    return file_helper_.filename();
+}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
+    msg.color_range_start = 0;
+    msg.color_range_end = 0;
+    memory_buf_t formatted;
+    base_sink<Mutex>::formatter_->format(msg, formatted);
+    for (const auto &range : colors_.ranges(msg, formatted)) {
+        file_helper_.write(range);
+    }
+}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_file_sink<Mutex>::flush_() {
+    file_helper_.flush();
+}
+
+}  // namespace sinks
+}  // namespace spdlog

--- a/include/spdlog/sinks/ansicolor_file_sink.h
+++ b/include/spdlog/sinks/ansicolor_file_sink.h
@@ -1,0 +1,68 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/details/ansicolors.h>
+#include <spdlog/details/file_helper.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/base_sink.h>
+
+#include <mutex>
+#include <string>
+
+namespace spdlog {
+namespace sinks {
+/*
+ * ANSI-colored file sink with single file as target
+ */
+template <typename Mutex>
+class ansicolor_file_sink final : public base_sink<Mutex> {
+public:
+    explicit ansicolor_file_sink(const filename_t &filename,
+                                 bool truncate = false,
+                                 const file_event_handlers &event_handlers = {});
+    void set_color(level::level_enum color_level, string_view_t color);
+    const filename_t &filename() const;
+
+protected:
+    void sink_it_(const details::log_msg &msg) override;
+    void flush_() override;
+
+private:
+    details::ansicolors colors_;
+    details::file_helper file_helper_;
+};
+
+using ansicolor_file_sink_mt = ansicolor_file_sink<std::mutex>;
+using ansicolor_file_sink_st = ansicolor_file_sink<details::null_mutex>;
+
+}  // namespace sinks
+
+//
+// factory functions
+//
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> ansicolor_logger_mt(const std::string &logger_name,
+                                                   const filename_t &filename,
+                                                   bool truncate = false,
+                                                   const file_event_handlers &event_handlers = {}) {
+    return Factory::template create<sinks::ansicolor_file_sink_mt>(logger_name, filename, truncate,
+                                                                   event_handlers);
+}
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> ansicolor_logger_st(const std::string &logger_name,
+                                                   const filename_t &filename,
+                                                   bool truncate = false,
+                                                   const file_event_handlers &event_handlers = {}) {
+    return Factory::template create<sinks::ansicolor_file_sink_st>(logger_name, filename, truncate,
+                                                                   event_handlers);
+}
+
+}  // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+    #include "ansicolor_file_sink-inl.h"
+#endif

--- a/include/spdlog/sinks/ansicolor_rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_rotating_file_sink-inl.h
@@ -1,0 +1,67 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#ifndef SPDLOG_HEADER_ONLY
+    #include <spdlog/sinks/ansicolor_rotating_file_sink.h>
+#endif
+
+#include <spdlog/common.h>
+
+#include <spdlog/details/rotating_file.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/fmt/fmt.h>
+
+#include <mutex>
+
+namespace spdlog {
+namespace sinks {
+
+template <typename Mutex>
+SPDLOG_INLINE ansicolor_rotating_file_sink<Mutex>::ansicolor_rotating_file_sink(
+    filename_t base_filename,
+    std::size_t max_size,
+    std::size_t max_files,
+    bool rotate_on_open,
+    const file_event_handlers &event_handlers)
+    : file_{base_filename, max_size, max_files, rotate_on_open, event_handlers} {}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_rotating_file_sink<Mutex>::set_color(level::level_enum color_level,
+                                                                  string_view_t color) {
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
+    colors_.set_color(color_level, color);
+}
+
+// calc filename according to index and file extension if exists.
+// e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
+template <typename Mutex>
+SPDLOG_INLINE filename_t
+ansicolor_rotating_file_sink<Mutex>::calc_filename(const filename_t &filename, std::size_t index) {
+    return details::rotating_file::calc_filename(filename, index);
+}
+
+template <typename Mutex>
+SPDLOG_INLINE filename_t ansicolor_rotating_file_sink<Mutex>::filename() {
+    return file_.filename();
+}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
+    msg.color_range_start = 0;
+    msg.color_range_end = 0;
+    memory_buf_t formatted;
+    base_sink<Mutex>::formatter_->format(msg, formatted);
+    for (const auto &range : colors_.ranges(msg, formatted)) {
+        file_.write(range);
+    }
+}
+
+template <typename Mutex>
+SPDLOG_INLINE void ansicolor_rotating_file_sink<Mutex>::flush_() {
+    file_.flush();
+}
+
+}  // namespace sinks
+}  // namespace spdlog

--- a/include/spdlog/sinks/ansicolor_rotating_file_sink.h
+++ b/include/spdlog/sinks/ansicolor_rotating_file_sink.h
@@ -1,0 +1,81 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/details/ansicolors.h>
+#include <spdlog/details/rotating_file.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/base_sink.h>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+
+namespace spdlog {
+namespace sinks {
+
+//
+// Rotating file sink based on size, with ansi colors.
+//
+template <typename Mutex>
+class ansicolor_rotating_file_sink final : public base_sink<Mutex> {
+public:
+    ansicolor_rotating_file_sink(filename_t base_filename,
+                                 std::size_t max_size,
+                                 std::size_t max_files,
+                                 bool rotate_on_open = false,
+                                 const file_event_handlers &event_handlers = {});
+
+    void set_color(level::level_enum color_level, string_view_t color);
+
+    static filename_t calc_filename(const filename_t &filename, std::size_t index);
+    filename_t filename();
+
+protected:
+    void sink_it_(const details::log_msg &msg) override;
+    void flush_() override;
+
+private:
+    details::ansicolors colors_;
+    details::rotating_file file_;
+};
+
+using ansicolor_rotating_file_sink_mt = ansicolor_rotating_file_sink<std::mutex>;
+using ansicolor_rotating_file_sink_st = ansicolor_rotating_file_sink<details::null_mutex>;
+
+}  // namespace sinks
+
+//
+// factory functions
+//
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> ansicolor_rotating_logger_mt(
+    const std::string &logger_name,
+    const filename_t &filename,
+    size_t max_file_size,
+    size_t max_files,
+    bool rotate_on_open = false,
+    const file_event_handlers &event_handlers = {}) {
+    return Factory::template create<sinks::ansicolor_rotating_file_sink_mt>(
+        logger_name, filename, max_file_size, max_files, rotate_on_open, event_handlers);
+}
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> ansicolor_rotating_logger_st(
+    const std::string &logger_name,
+    const filename_t &filename,
+    size_t max_file_size,
+    size_t max_files,
+    bool rotate_on_open = false,
+    const file_event_handlers &event_handlers = {}) {
+    return Factory::template create<sinks::ansicolor_rotating_file_sink_st>(
+        logger_name, filename, max_file_size, max_files, rotate_on_open, event_handlers);
+}
+}  // namespace spdlog
+
+#ifdef SPDLOG_HEADER_ONLY
+    #include "ansicolor_rotating_file_sink-inl.h"
+#endif

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -17,24 +17,15 @@ template <typename ConsoleMutex>
 SPDLOG_INLINE ansicolor_sink<ConsoleMutex>::ansicolor_sink(FILE *target_file, color_mode mode)
     : target_file_(target_file),
       mutex_(ConsoleMutex::mutex()),
-      formatter_(details::make_unique<spdlog::pattern_formatter>())
-
-{
+      formatter_(details::make_unique<spdlog::pattern_formatter>()) {
     set_color_mode(mode);
-    colors_.at(level::trace) = to_string_(white);
-    colors_.at(level::debug) = to_string_(cyan);
-    colors_.at(level::info) = to_string_(green);
-    colors_.at(level::warn) = to_string_(yellow_bold);
-    colors_.at(level::err) = to_string_(red_bold);
-    colors_.at(level::critical) = to_string_(bold_on_red);
-    colors_.at(level::off) = to_string_(reset);
 }
 
 template <typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color(level::level_enum color_level,
                                                            string_view_t color) {
     std::lock_guard<mutex_t> lock(mutex_);
-    colors_.at(static_cast<size_t>(color_level)) = to_string_(color);
+    colors_.set_color(color_level, color);
 }
 
 template <typename ConsoleMutex>
@@ -46,15 +37,10 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::log(const details::log_msg &msg
     msg.color_range_end = 0;
     memory_buf_t formatted;
     formatter_->format(msg, formatted);
-    if (should_do_colors_ && msg.color_range_end > msg.color_range_start) {
-        // before color range
-        print_range_(formatted, 0, msg.color_range_start);
-        // in color range
-        print_ccode_(colors_.at(static_cast<size_t>(msg.level)));
-        print_range_(formatted, msg.color_range_start, msg.color_range_end);
-        print_ccode_(reset);
-        // after color range
-        print_range_(formatted, msg.color_range_end, formatted.size());
+    if (should_do_colors_) {
+        for (const auto &range : colors_.ranges(msg, formatted)) {
+            print_view_(range);
+        }
     } else  // no color
     {
         print_range_(formatted, 0, formatted.size());
@@ -71,7 +57,7 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::flush() {
 template <typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern) {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = details::make_unique<pattern_formatter>(pattern);
 }
 
 template <typename ConsoleMutex>
@@ -105,8 +91,8 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_color_mode(color_mode mode)
 }
 
 template <typename ConsoleMutex>
-SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::print_ccode_(const string_view_t &color_code) {
-    fwrite(color_code.data(), sizeof(char), color_code.size(), target_file_);
+SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::print_view_(const string_view_t &sv) {
+    fwrite(sv.data(), sizeof(char), sv.size(), target_file_);
 }
 
 template <typename ConsoleMutex>
@@ -114,11 +100,6 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::print_range_(const memory_buf_t
                                                               size_t start,
                                                               size_t end) {
     fwrite(formatted.data() + start, sizeof(char), end - start, target_file_);
-}
-
-template <typename ConsoleMutex>
-SPDLOG_INLINE std::string ansicolor_sink<ConsoleMutex>::to_string_(const string_view_t &sv) {
-    return std::string(sv.data(), sv.size());
 }
 
 // ansicolor_stdout_sink

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <memory>
 #include <mutex>
+#include <spdlog/details/ansicolors.h>
 #include <spdlog/details/console_globals.h>
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/sinks/sink.h>
@@ -44,49 +45,48 @@ public:
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
 
     // Formatting codes
-    const string_view_t reset = "\033[m";
-    const string_view_t bold = "\033[1m";
-    const string_view_t dark = "\033[2m";
-    const string_view_t underline = "\033[4m";
-    const string_view_t blink = "\033[5m";
-    const string_view_t reverse = "\033[7m";
-    const string_view_t concealed = "\033[8m";
-    const string_view_t clear_line = "\033[K";
+    const string_view_t reset = details::ansicolors::reset;
+    const string_view_t bold = details::ansicolors::bold;
+    const string_view_t dark = details::ansicolors::dark;
+    const string_view_t underline = details::ansicolors::underline;
+    const string_view_t blink = details::ansicolors::blink;
+    const string_view_t reverse = details::ansicolors::reverse;
+    const string_view_t concealed = details::ansicolors::concealed;
+    const string_view_t clear_line = details::ansicolors::clear_line;
 
     // Foreground colors
-    const string_view_t black = "\033[30m";
-    const string_view_t red = "\033[31m";
-    const string_view_t green = "\033[32m";
-    const string_view_t yellow = "\033[33m";
-    const string_view_t blue = "\033[34m";
-    const string_view_t magenta = "\033[35m";
-    const string_view_t cyan = "\033[36m";
-    const string_view_t white = "\033[37m";
+    const string_view_t black = details::ansicolors::black;
+    const string_view_t red = details::ansicolors::red;
+    const string_view_t green = details::ansicolors::green;
+    const string_view_t yellow = details::ansicolors::yellow;
+    const string_view_t blue = details::ansicolors::blue;
+    const string_view_t magenta = details::ansicolors::magenta;
+    const string_view_t cyan = details::ansicolors::cyan;
+    const string_view_t white = details::ansicolors::white;
 
     /// Background colors
-    const string_view_t on_black = "\033[40m";
-    const string_view_t on_red = "\033[41m";
-    const string_view_t on_green = "\033[42m";
-    const string_view_t on_yellow = "\033[43m";
-    const string_view_t on_blue = "\033[44m";
-    const string_view_t on_magenta = "\033[45m";
-    const string_view_t on_cyan = "\033[46m";
-    const string_view_t on_white = "\033[47m";
+    const string_view_t on_black = details::ansicolors::on_black;
+    const string_view_t on_red = details::ansicolors::on_red;
+    const string_view_t on_green = details::ansicolors::on_green;
+    const string_view_t on_yellow = details::ansicolors::on_yellow;
+    const string_view_t on_blue = details::ansicolors::on_blue;
+    const string_view_t on_magenta = details::ansicolors::on_magenta;
+    const string_view_t on_cyan = details::ansicolors::on_cyan;
+    const string_view_t on_white = details::ansicolors::on_white;
 
     /// Bold colors
-    const string_view_t yellow_bold = "\033[33m\033[1m";
-    const string_view_t red_bold = "\033[31m\033[1m";
-    const string_view_t bold_on_red = "\033[1m\033[41m";
+    const string_view_t yellow_bold = details::ansicolors::yellow_bold;
+    const string_view_t red_bold = details::ansicolors::red_bold;
+    const string_view_t bold_on_red = details::ansicolors::bold_on_red;
 
 private:
     FILE *target_file_;
     mutex_t &mutex_;
+    details::ansicolors colors_;
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;
-    std::array<std::string, level::n_levels> colors_;
-    void print_ccode_(const string_view_t &color_code);
+    void print_view_(const string_view_t &sv);
     void print_range_(const memory_buf_t &formatted, size_t start, size_t end);
-    static std::string to_string_(const string_view_t &sv);
 };
 
 template <typename ConsoleMutex>

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -9,16 +9,11 @@
 
 #include <spdlog/common.h>
 
-#include <spdlog/details/file_helper.h>
+#include <spdlog/details/rotating_file.h>
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/fmt/fmt.h>
 
-#include <cerrno>
-#include <chrono>
-#include <ctime>
 #include <mutex>
-#include <string>
-#include <tuple>
 
 namespace spdlog {
 namespace sinks {
@@ -30,114 +25,31 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
     std::size_t max_files,
     bool rotate_on_open,
     const file_event_handlers &event_handlers)
-    : base_filename_(std::move(base_filename)),
-      max_size_(max_size),
-      max_files_(max_files),
-      file_helper_{event_handlers} {
-    if (max_size == 0) {
-        throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
-    }
-
-    if (max_files > 200000) {
-        throw_spdlog_ex("rotating sink constructor: max_files arg cannot exceed 200000");
-    }
-    file_helper_.open(calc_filename(base_filename_, 0));
-    current_size_ = file_helper_.size();  // expensive. called only once
-    if (rotate_on_open && current_size_ > 0) {
-        rotate_();
-        current_size_ = 0;
-    }
-}
+    : file_{base_filename, max_size, max_files, rotate_on_open, event_handlers} {}
 
 // calc filename according to index and file extension if exists.
 // e.g. calc_filename("logs/mylog.txt, 3) => "logs/mylog.3.txt".
 template <typename Mutex>
 SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::calc_filename(const filename_t &filename,
                                                                   std::size_t index) {
-    if (index == 0u) {
-        return filename;
-    }
-
-    filename_t basename, ext;
-    std::tie(basename, ext) = details::file_helper::split_by_extension(filename);
-    return fmt_lib::format(SPDLOG_FILENAME_T("{}.{}{}"), basename, index, ext);
+    return details::rotating_file::calc_filename(filename, index);
 }
 
 template <typename Mutex>
 SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename() {
-    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
-    return file_helper_.filename();
+    return file_.filename();
 }
 
 template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);
-    auto new_size = current_size_ + formatted.size();
-
-    // rotate if the new estimated file size exceeds max size.
-    // rotate only if the real size > 0 to better deal with full disk (see issue #2261).
-    // we only check the real size when new_size > max_size_ because it is relatively expensive.
-    if (new_size > max_size_) {
-        file_helper_.flush();
-        if (file_helper_.size() > 0) {
-            rotate_();
-            new_size = formatted.size();
-        }
-    }
-    file_helper_.write(formatted);
-    current_size_ = new_size;
+    file_.write(formatted);
 }
 
 template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::flush_() {
-    file_helper_.flush();
-}
-
-// Rotate files:
-// log.txt -> log.1.txt
-// log.1.txt -> log.2.txt
-// log.2.txt -> log.3.txt
-// log.3.txt -> delete
-template <typename Mutex>
-SPDLOG_INLINE void rotating_file_sink<Mutex>::rotate_() {
-    using details::os::filename_to_str;
-    using details::os::path_exists;
-
-    file_helper_.close();
-    for (auto i = max_files_; i > 0; --i) {
-        filename_t src = calc_filename(base_filename_, i - 1);
-        if (!path_exists(src)) {
-            continue;
-        }
-        filename_t target = calc_filename(base_filename_, i);
-
-        if (!rename_file_(src, target)) {
-            // if failed try again after a small delay.
-            // this is a workaround to a windows issue, where very high rotation
-            // rates can cause the rename to fail with permission denied (because of antivirus?).
-            details::os::sleep_for_millis(100);
-            if (!rename_file_(src, target)) {
-                file_helper_.reopen(
-                    true);  // truncate the log file anyway to prevent it to grow beyond its limit!
-                current_size_ = 0;
-                throw_spdlog_ex("rotating_file_sink: failed renaming " + filename_to_str(src) +
-                                    " to " + filename_to_str(target),
-                                errno);
-            }
-        }
-    }
-    file_helper_.reopen(true);
-}
-
-// delete the target if exists, and rename the src file  to target
-// return true on success, false otherwise.
-template <typename Mutex>
-SPDLOG_INLINE bool rotating_file_sink<Mutex>::rename_file_(const filename_t &src_filename,
-                                                           const filename_t &target_filename) {
-    // try to delete the target file in case it already exists.
-    (void)details::os::remove(target_filename);
-    return details::os::rename(src_filename, target_filename) == 0;
+    file_.flush();
 }
 
 }  // namespace sinks

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <spdlog/details/file_helper.h>
+#include <spdlog/details/rotating_file.h>
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/synchronous_factory.h>
 #include <spdlog/sinks/base_sink.h>
@@ -34,22 +34,7 @@ protected:
     void flush_() override;
 
 private:
-    // Rotate files:
-    // log.txt -> log.1.txt
-    // log.1.txt -> log.2.txt
-    // log.2.txt -> log.3.txt
-    // log.3.txt -> delete
-    void rotate_();
-
-    // delete the target if exists, and rename the src file  to target
-    // return true on success, false otherwise.
-    bool rename_file_(const filename_t &src_filename, const filename_t &target_filename);
-
-    filename_t base_filename_;
-    std::size_t max_size_;
-    std::size_t max_files_;
-    std::size_t current_size_;
-    details::file_helper file_helper_;
+    details::rotating_file file_;
 };
 
 using rotating_file_sink_mt = rotating_file_sink<std::mutex>;

--- a/src/file_sinks.cpp
+++ b/src/file_sinks.cpp
@@ -15,6 +15,10 @@
 template class SPDLOG_API spdlog::sinks::basic_file_sink<std::mutex>;
 template class SPDLOG_API spdlog::sinks::basic_file_sink<spdlog::details::null_mutex>;
 
+#include <spdlog/sinks/ansicolor_file_sink-inl.h>
+template class SPDLOG_API spdlog::sinks::ansicolor_file_sink<std::mutex>;
+template class SPDLOG_API spdlog::sinks::ansicolor_file_sink<spdlog::details::null_mutex>;
+
 #include <spdlog/sinks/rotating_file_sink-inl.h>
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<std::mutex>;
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;

--- a/src/file_sinks.cpp
+++ b/src/file_sinks.cpp
@@ -18,3 +18,7 @@ template class SPDLOG_API spdlog::sinks::basic_file_sink<spdlog::details::null_m
 #include <spdlog/sinks/rotating_file_sink-inl.h>
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<std::mutex>;
 template class SPDLOG_API spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;
+
+#include <spdlog/sinks/ansicolor_rotating_file_sink-inl.h>
+template class SPDLOG_API spdlog::sinks::ansicolor_rotating_file_sink<std::mutex>;
+template class SPDLOG_API spdlog::sinks::ansicolor_rotating_file_sink<spdlog::details::null_mutex>;

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -13,6 +13,7 @@
 #include <spdlog/details/os-inl.h>
 #include <spdlog/details/registry-inl.h>
 #include <spdlog/details/rotating_file-inl.h>
+#include <spdlog/details/ansicolors-inl.h>
 #include <spdlog/logger-inl.h>
 #include <spdlog/pattern_formatter-inl.h>
 #include <spdlog/sinks/base_sink-inl.h>

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -12,6 +12,7 @@
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/details/os-inl.h>
 #include <spdlog/details/registry-inl.h>
+#include <spdlog/details/rotating_file-inl.h>
 #include <spdlog/logger-inl.h>
 #include <spdlog/pattern_formatter-inl.h>
 #include <spdlog/sinks/base_sink-inl.h>

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -28,6 +28,7 @@
 #include "spdlog/details/fmt_helper.h"
 #include "spdlog/mdc.h"
 #include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/ansicolor_file_sink.h"
 #include "spdlog/sinks/daily_file_sink.h"
 #include "spdlog/sinks/null_sink.h"
 #include "spdlog/sinks/ostream_sink.h"

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -32,6 +32,7 @@
 #include "spdlog/sinks/null_sink.h"
 #include "spdlog/sinks/ostream_sink.h"
 #include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/ansicolor_rotating_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/msvc_sink.h"
 #include "spdlog/pattern_formatter.h"

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -63,13 +63,11 @@ TEST_CASE("ansicolor_file_logger", "[ansicolor_logger]") {
     logger->flush();
     require_message_count(SIMPLE_LOG, 2);
     using spdlog::details::os::default_eol;
-    REQUIRE(file_contents(SIMPLE_LOG) ==
-            spdlog::fmt_lib::format(
-                "[{ansi_blue}+++{ansi_reset}] Test message 1{eol}"
-                "[{ansi_blue}+++{ansi_reset}] Test message 2{eol}",
-                spdlog::fmt_lib::arg("ansi_blue", spdlog::details::ansicolors::blue),
-                spdlog::fmt_lib::arg("ansi_reset", spdlog::details::ansicolors::reset),
-                spdlog::fmt_lib::arg("eol", default_eol)));
+    REQUIRE(file_contents(SIMPLE_LOG) == spdlog::fmt_lib::format("[{0}+++{1}] Test message 1{2}"
+                                                                 "[{0}+++{1}] Test message 2{2}",
+                                                                 spdlog::details::ansicolors::blue,
+                                                                 spdlog::details::ansicolors::reset,
+                                                                 default_eol));
 }
 
 TEST_CASE("rotating_file_logger1", "[rotating_logger]") {

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -101,3 +101,60 @@ TEST_CASE("rotating_file_logger3", "[rotating_logger]") {
     REQUIRE_THROWS_AS(spdlog::rotating_logger_mt("logger", basename, max_size, 0),
                       spdlog::spdlog_ex);
 }
+
+TEST_CASE("ansicolor_rotating_file_logger1", "[ansicolor_rotating_logger]") {
+    prepare_logdir();
+    size_t max_size = 1024 * 10;
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+    auto logger = spdlog::ansicolor_rotating_logger_mt("logger", basename, max_size, 0);
+
+    for (int i = 0; i < 10; ++i) {
+        logger->info("Test message {}", i);
+    }
+
+    logger->flush();
+    require_message_count(ROTATING_LOG, 10);
+}
+
+TEST_CASE("ansicolor_rotating_file_logger2", "[ansicolor_rotating_logger]") {
+    prepare_logdir();
+    size_t max_size = 1024 * 10;
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+
+    {
+        // make an initial logger to create the first output file
+        auto logger = spdlog::ansicolor_rotating_logger_mt("logger", basename, max_size, 2, true);
+        for (int i = 0; i < 10; ++i) {
+            logger->info("Test message {}", i);
+        }
+        // drop causes the logger destructor to be called, which is required so the
+        // next logger can rename the first output file.
+        spdlog::drop(logger->name());
+    }
+
+    auto logger = spdlog::ansicolor_rotating_logger_mt("logger", basename, max_size, 2, true);
+    for (int i = 0; i < 10; ++i) {
+        logger->info("Test message {}", i);
+    }
+
+    logger->flush();
+
+    require_message_count(ROTATING_LOG, 10);
+
+    for (int i = 0; i < 1000; i++) {
+        logger->info("Test message {}", i);
+    }
+
+    logger->flush();
+    REQUIRE(get_filesize(ROTATING_LOG) <= max_size);
+    REQUIRE(get_filesize(ROTATING_LOG ".1") <= max_size);
+}
+
+// test that passing max_size=0 throws
+TEST_CASE("ansicolor_rotating_file_logger3", "[ansicolor_rotating_logger]") {
+    prepare_logdir();
+    size_t max_size = 0;
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+    REQUIRE_THROWS_AS(spdlog::ansicolor_rotating_logger_mt("logger", basename, max_size, 0),
+                      spdlog::spdlog_ex);
+}

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -45,6 +45,33 @@ TEST_CASE("flush_on", "[flush_on]") {
                                     default_eol, default_eol, default_eol));
 }
 
+TEST_CASE("ansicolor_file_logger", "[ansicolor_logger]") {
+    prepare_logdir();
+    spdlog::filename_t filename = SPDLOG_FILENAME_T(SIMPLE_LOG);
+
+    // auto logger = spdlog::details::make_unique<spdlog::sinks::ansicolor_file_sink_mt>(filename);
+    auto logger = spdlog::create<spdlog::sinks::ansicolor_file_sink_mt>("logger", filename);
+    logger->set_pattern("[%^+++%$] %v");
+
+    auto sink =
+        std::dynamic_pointer_cast<spdlog::sinks::ansicolor_file_sink_mt>(logger->sinks().front());
+    sink->set_color(spdlog::level::info, spdlog::details::ansicolors::blue);
+
+    logger->info("Test message {}", 1);
+    logger->info("Test message {}", 2);
+
+    logger->flush();
+    require_message_count(SIMPLE_LOG, 2);
+    using spdlog::details::os::default_eol;
+    REQUIRE(file_contents(SIMPLE_LOG) ==
+            spdlog::fmt_lib::format(
+                "[{ansi_blue}+++{ansi_reset}] Test message 1{eol}"
+                "[{ansi_blue}+++{ansi_reset}] Test message 2{eol}",
+                spdlog::fmt_lib::arg("ansi_blue", spdlog::details::ansicolors::blue),
+                spdlog::fmt_lib::arg("ansi_reset", spdlog::details::ansicolors::reset),
+                spdlog::fmt_lib::arg("eol", default_eol)));
+}
+
 TEST_CASE("rotating_file_logger1", "[rotating_logger]") {
     prepare_logdir();
     size_t max_size = 1024 * 10;


### PR DESCRIPTION
This PR addresses #1838.

I could not make it work with the [suggested](https://github.com/gabime/spdlog/issues/1838#issuecomment-1177245221) approach. The `details::log_msg` members `color_range_start` and `color_range_end` are ignored in the methods `basic_file_sink::sink_it_` and `rotating_file_sink::sink_it_`.
Only the class `ansicolor_sink` uses the color range.

My first idea was to subclass `ansicolor_sink` and pass a stream to the opened file as the `FILE *target_file` argument to the base class constructor. However this had two problems:
1. The `ansicolor_sink::mutex_` member is a reference to `ConsoleMutex::mutex()` which is a singleton. This is not suitable for file sinks.
2. File rotation is not easily added.

To address this, I factored out the ANSI coloring and file rotation into separate classes, to be reused in the new sink classes `ansicolor_file_sink` and `ansicolor_rotating_file_sink`.

My apologies for the whitespace differences, my code editor is configured to remove trailing spaces.