### PR TITLE
Allow customization of syslog_sink

### DIFF
--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -64,13 +64,14 @@ protected:
     //
     // Simply maps spdlog's log level to syslog priority level.
     //
-    int syslog_prio_from_level(const details::log_msg &msg) const {
+    virtual int syslog_prio_from_level(const details::log_msg &msg) const {
         return syslog_levels_.at(static_cast<levels_array::size_type>(msg.level));
     }
 
-private:
     using levels_array = std::array<int, 7>;
     levels_array syslog_levels_;
+
+private:
     // must store the ident because the man says openlog might use the pointer as
     // is and not a string copy
     const std::string ident_;


### PR DESCRIPTION
I also took the liberty of allowing access to `syslog_levels_`, this would simplify my implementation. Feel free to disagree.