### PR TITLE
V2.x - Attribute support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,8 @@ set(SPDLOG_HEADERS
         "include/spdlog/sinks/systemd_sink.h"
         "include/spdlog/sinks/tcp_sink.h"
         "include/spdlog/sinks/udp_sink.h"
-        "include/spdlog/sinks/async_sink.h")
+        "include/spdlog/sinks/async_sink.h"
+        "include/spdlog/attributes.h")
 set(SPDLOG_SRCS
         "src/common.cpp"
         "src/logger.cpp"

--- a/include/spdlog/attributes.h
+++ b/include/spdlog/attributes.h
@@ -2,14 +2,15 @@
 
 #include <spdlog/common.h>
 
+#include <map>
 #include <mutex>
-#include <unordered_map>
+
 
 namespace spdlog {
 
 class SPDLOG_API log_attributes {
 public:
-    using attr_map_t = std::unordered_map<std::string, std::string>;
+    using attr_map_t = std::map<std::string, std::string>;
     using key_t = attr_map_t::key_type;
     using value_t = attr_map_t::mapped_type;
     using const_iter = attr_map_t::const_iterator;

--- a/include/spdlog/attributes.h
+++ b/include/spdlog/attributes.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <spdlog/common.h>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace spdlog {
+
+class SPDLOG_API log_attributes {
+public:
+    using attr_map_t = std::unordered_map<std::string, std::string>;
+    using key_t = attr_map_t::key_type;
+    using value_t = attr_map_t::mapped_type;
+    using const_iter = attr_map_t::const_iterator;
+
+    log_attributes() = default;
+    log_attributes(const log_attributes& other) {
+        const auto& o_map = other.get_map();
+        attr_ctx(o_map.begin(), o_map.end());
+    }
+    log_attributes& operator=(const log_attributes& other) {
+        if (this != &other) {
+            clear();
+            const auto& o_map = other.get_map();
+            attr_ctx(o_map.begin(), o_map.end());
+        }
+        return *this;
+    }
+
+    void put(const key_t& key, const value_t& value) {
+        auto lck = lock();
+        attrs[key] = value;
+    }
+
+    void remove(const key_t& key) {
+        auto lck = lock();
+        auto value_it = attrs.find(key);
+        if (value_it != attrs.end()) {
+            attrs.erase(key);
+        }
+    }
+
+    void clear() {
+        auto lck = lock();
+        attrs.clear();
+    }
+
+    bool empty() const {
+        auto lck = lock();
+        return attrs.empty();
+    }
+
+    std::pair<bool, const_iter> const get(key_t const& key) const {
+        auto lck = lock();
+        auto value_it = attrs.find(key);
+
+        return std::make_pair(value_it == attrs.end(), value_it);
+    }
+
+    // provide a local copy of the attributes to be free of race issues
+    // alternative is to lock the attr_map while the formatter iterates over it
+    attr_map_t get_map() const {
+        auto lck = lock();
+        return attrs;
+    }
+
+    template <typename Attribute_Iter>
+    void attr_ctx(Attribute_Iter begin, Attribute_Iter end) {
+        auto lck = lock();
+        attrs.insert(begin, end);
+    }
+
+    void attr_ctx(std::initializer_list<attr_map_t::value_type> attributes) { attr_ctx(attributes.begin(), attributes.end()); }
+
+    bool empty() {
+        auto lck = lock();
+        return attrs.empty();
+    }
+
+private:
+    std::lock_guard<std::mutex> lock() const { return std::lock_guard(attrs_mtx); }
+
+    mutable std::mutex attrs_mtx;
+    attr_map_t attrs;
+};
+
+}  // namespace spdlog

--- a/include/spdlog/attributes.h
+++ b/include/spdlog/attributes.h
@@ -52,11 +52,12 @@ public:
         return attrs.empty();
     }
 
+    // return {true, iter} if found, {false, end} otherwise
     std::pair<bool, const_iter> const get(key_t const& key) const {
         auto lck = lock();
         auto value_it = attrs.find(key);
 
-        return std::make_pair(value_it == attrs.end(), value_it);
+        return std::make_pair(value_it != attrs.end(), value_it);
     }
 
     // provide a local copy of the attributes to be free of race issues

--- a/include/spdlog/attributes.h
+++ b/include/spdlog/attributes.h
@@ -16,23 +16,20 @@ public:
     using const_iter = attr_map_t::const_iterator;
 
     log_attributes() = default;
-    log_attributes(const log_attributes& other) {
-        const auto& o_map = other.get_map();
-        attr_ctx(o_map.begin(), o_map.end());
-    }
+    log_attributes(const log_attributes& other) { put(other.get_map()); }
     log_attributes& operator=(const log_attributes& other) {
         if (this != &other) {
             clear();
-            const auto& o_map = other.get_map();
-            attr_ctx(o_map.begin(), o_map.end());
+            put(other.get_map());
         }
         return *this;
     }
 
-    void put(const key_t& key, const value_t& value) {
+    void put(attr_map_t const& attributes) {
         auto lck = lock();
-        attrs[key] = value;
+        attrs.insert(attributes.begin(), attributes.end());
     }
+    void put(const key_t& key, const value_t& value) { put({{key, value}}); }
 
     void remove(const key_t& key) {
         auto lck = lock();

--- a/include/spdlog/attributes.h
+++ b/include/spdlog/attributes.h
@@ -46,7 +46,7 @@ public:
 
     void put(attr_map_t const& attributes) {
         auto lck = lock();
-        attrs.insert(attributes.begin(), attributes.end());
+        for (auto const& attribute : attributes) attrs.insert_or_assign(attribute.first, attribute.second);
     }
     void put(const key_t& key, const value_t& value) { put({{key, value}}); }
 

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -13,14 +13,14 @@ namespace details {
 struct SPDLOG_API log_msg {
     log_msg() = default;
     log_msg(log_clock::time_point log_time,
-            source_loc loc,
+            const source_loc &loc,
             string_view_t logger_name,
             level lvl,
             string_view_t msg,
             log_attributes attributes);
     log_msg(log_clock::time_point log_time, const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg);
     log_msg(const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg);
-    log_msg(source_loc loc, string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes);
+    log_msg(const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes);
     log_msg(string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes);
     log_msg(string_view_t logger_name, level lvl, string_view_t msg);
     log_msg(const log_msg &other) = default;

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -5,14 +5,23 @@
 
 #include <string>
 
+#include "../attributes.h"
 #include "../common.h"
 
 namespace spdlog {
 namespace details {
 struct SPDLOG_API log_msg {
     log_msg() = default;
+    log_msg(log_clock::time_point log_time,
+            source_loc loc,
+            string_view_t logger_name,
+            level lvl,
+            string_view_t msg,
+            log_attributes attributes);
     log_msg(log_clock::time_point log_time, const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg);
     log_msg(const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg);
+    log_msg(source_loc loc, string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes);
+    log_msg(string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes);
     log_msg(string_view_t logger_name, level lvl, string_view_t msg);
     log_msg(const log_msg &other) = default;
     log_msg &operator=(const log_msg &other) = default;
@@ -28,6 +37,7 @@ struct SPDLOG_API log_msg {
 
     source_loc source;
     string_view_t payload;
+    log_attributes attributes;
 };
 }  // namespace details
 }  // namespace spdlog

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -161,11 +161,7 @@ public:
     // create new logger with same sinks and configuration.
     std::shared_ptr<logger> clone(std::string logger_name);
 
-    void push_attribute(log_attributes::attr_map_t const &attributes);
-    void push_attribute(log_attributes::key_t const &key, log_attributes::value_t const &value);
-    void push_attribute(log_attributes const &attributes);
-    void remove_attribute(const log_attributes::key_t &key);
-    void clear_attribute();
+    log_attributes &attrs();
 
 private:
     std::string name_;

--- a/src/details/log_msg.cpp
+++ b/src/details/log_msg.cpp
@@ -8,32 +8,13 @@
 namespace spdlog {
 namespace details {
 
-log_msg::log_msg(spdlog::log_clock::time_point log_time,
-                 spdlog::source_loc loc,
-                 string_view_t a_logger_name,
-                 spdlog::level lvl,
-                 spdlog::string_view_t msg,
-                 spdlog::log_attributes attributes)
-    : logger_name(a_logger_name),
-      log_level(lvl),
-      time(log_time)
-#ifndef SPDLOG_NO_THREAD_ID
-      ,
-      thread_id(os::thread_id())
-#endif
-      ,
-      source(loc),
-      payload(msg),
-      attributes(attributes) {
-}
-
 log_msg::log_msg(const log_clock::time_point log_time,
-                 const source_loc loc,
-                 const string_view_t a_logger_name,
+                 const source_loc &loc,
+                 const string_view_t logger_name,
                  const level lvl,
                  const string_view_t msg,
                  const log_attributes attributes)
-    : logger_name(a_logger_name),
+    : logger_name(logger_name),
       log_level(lvl),
       time(log_time),
 #ifdef SPDLOG_NO_THREAD_ID
@@ -64,20 +45,16 @@ log_msg::log_msg(const log_clock::time_point log_time,
 }
 
 log_msg::log_msg(const source_loc &loc, const string_view_t logger_name, const level lvl, const string_view_t msg)
-    : log_msg(os::now(), loc, logger_name, lvl, msg) {}
+    : log_msg(os::now(), loc, logger_name, lvl, msg, {}) {}
 
-log_msg::log_msg(spdlog::source_loc loc,
-                 string_view_t a_logger_name,
-                 spdlog::level lvl,
-                 spdlog::string_view_t msg,
-                 spdlog::log_attributes attributes)
-    : log_msg(os::now(), loc, a_logger_name, lvl, msg, attributes) {}
+log_msg::log_msg(const source_loc &loc, string_view_t logger_name, level lvl, string_view_t msg, log_attributes attributes)
+    : log_msg(os::now(), loc, logger_name, lvl, msg, attributes) {}
 
 log_msg::log_msg(const string_view_t logger_name, const level lvl, const string_view_t msg)
     : log_msg(os::now(), source_loc{}, logger_name, lvl, msg) {}
 
-log_msg::log_msg(string_view_t a_logger_name, spdlog::level lvl, spdlog::string_view_t msg, spdlog::log_attributes attributes)
-    : log_msg(os::now(), source_loc{}, a_logger_name, lvl, msg, attributes) {}
+log_msg::log_msg(const string_view_t logger_name, const level lvl, const string_view_t msg, const log_attributes attributes)
+    : log_msg(os::now(), source_loc{}, logger_name, lvl, msg, attributes) {}
 
 }  // namespace details
 }  // namespace spdlog

--- a/src/details/log_msg.cpp
+++ b/src/details/log_msg.cpp
@@ -8,6 +8,44 @@
 namespace spdlog {
 namespace details {
 
+log_msg::log_msg(spdlog::log_clock::time_point log_time,
+                 spdlog::source_loc loc,
+                 string_view_t a_logger_name,
+                 spdlog::level lvl,
+                 spdlog::string_view_t msg,
+                 spdlog::log_attributes attributes)
+    : logger_name(a_logger_name),
+      log_level(lvl),
+      time(log_time)
+#ifndef SPDLOG_NO_THREAD_ID
+      ,
+      thread_id(os::thread_id())
+#endif
+      ,
+      source(loc),
+      payload(msg),
+      attributes(attributes) {
+}
+
+log_msg::log_msg(const log_clock::time_point log_time,
+                 const source_loc loc,
+                 const string_view_t a_logger_name,
+                 const level lvl,
+                 const string_view_t msg,
+                 const log_attributes attributes)
+    : logger_name(a_logger_name),
+      log_level(lvl),
+      time(log_time),
+#ifdef SPDLOG_NO_THREAD_ID
+      thread_id(0),
+#else
+      thread_id(os::thread_id()),
+#endif
+      source(loc),
+      payload(msg),
+      attributes(attributes) {
+}
+
 log_msg::log_msg(const log_clock::time_point log_time,
                  const source_loc &loc,
                  const string_view_t logger_name,
@@ -28,8 +66,18 @@ log_msg::log_msg(const log_clock::time_point log_time,
 log_msg::log_msg(const source_loc &loc, const string_view_t logger_name, const level lvl, const string_view_t msg)
     : log_msg(os::now(), loc, logger_name, lvl, msg) {}
 
+log_msg::log_msg(spdlog::source_loc loc,
+                 string_view_t a_logger_name,
+                 spdlog::level lvl,
+                 spdlog::string_view_t msg,
+                 spdlog::log_attributes attributes)
+    : log_msg(os::now(), loc, a_logger_name, lvl, msg, attributes) {}
+
 log_msg::log_msg(const string_view_t logger_name, const level lvl, const string_view_t msg)
     : log_msg(os::now(), source_loc{}, logger_name, lvl, msg) {}
+
+log_msg::log_msg(string_view_t a_logger_name, spdlog::level lvl, spdlog::string_view_t msg, spdlog::log_attributes attributes)
+    : log_msg(os::now(), source_loc{}, a_logger_name, lvl, msg, attributes) {}
 
 }  // namespace details
 }  // namespace spdlog

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -81,4 +81,20 @@ void logger::flush_() noexcept {
         }
     }
 }
+
+void logger::push_attribute(const log_attributes::attr_map_t &attributes) {
+    this->attributes.attr_ctx(attributes.begin(), attributes.end());
+}
+void logger::push_attribute(const log_attributes::key_t &key, const log_attributes::value_t &value) {
+    attributes.put(key, value);
+}
+void logger::push_attribute(const log_attributes &attributes) {
+    const auto &map = attributes.get_map();
+    this->attributes.attr_ctx(map.begin(), map.end());
+}
+
+void logger::remove_attribute(const log_attributes::key_t &key) { attributes.remove(key); }
+
+void logger::clear_attribute() { attributes.clear(); }
+
 }  // namespace spdlog

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -82,19 +82,6 @@ void logger::flush_() noexcept {
     }
 }
 
-void logger::push_attribute(const log_attributes::attr_map_t &attributes) {
-    this->attributes.attr_ctx(attributes.begin(), attributes.end());
-}
-void logger::push_attribute(const log_attributes::key_t &key, const log_attributes::value_t &value) {
-    attributes.put(key, value);
-}
-void logger::push_attribute(const log_attributes &attributes) {
-    const auto &map = attributes.get_map();
-    this->attributes.attr_ctx(map.begin(), map.end());
-}
-
-void logger::remove_attribute(const log_attributes::key_t &key) { attributes.remove(key); }
-
-void logger::clear_attribute() { attributes.clear(); }
+log_attributes &logger::attrs() { return attributes; }
 
 }  // namespace spdlog

--- a/src/pattern_formatter.cpp
+++ b/src/pattern_formatter.cpp
@@ -742,6 +742,41 @@ private:
     log_clock::time_point last_message_time_;
 };
 
+template <typename ScopedPadder>
+class attribute_formatter final : public flag_formatter {
+public:
+    explicit attribute_formatter(padding_info padinfo)
+        : flag_formatter(padinfo) {}
+
+    void format(const details::log_msg &msg, const std::tm &, memory_buf_t &dest) override {
+        if (msg.attributes.empty()) {
+            ScopedPadder p(0, padinfo_, dest);
+            return;
+        } else {
+            const auto &attributes = msg.attributes.get_map();
+            format_attributes(attributes, dest);
+        }
+    }
+
+    void format_attributes(const spdlog::log_attributes::attr_map_t &attributes, memory_buf_t &dest) {
+        for (auto it = attributes.begin(); it != attributes.end(); ++it) {
+            bool last_item = std::next(it) == attributes.end();
+            auto &attribute = *it;
+            const auto &key = attribute.first;
+            const auto &value = attribute.second;
+            size_t content_size = key.size() + value.size() + 1;  // 1 for ':'
+
+            if (!last_item) content_size++;  // 1 for ' '
+
+            ScopedPadder p(content_size, padinfo_, dest);
+            fmt_helper::append_string_view(key, dest);
+            fmt_helper::append_string_view(":", dest);
+            fmt_helper::append_string_view(value, dest);
+            if (!last_item) fmt_helper::append_string_view(" ", dest);
+        }
+    }
+};
+
 // Full info formatter
 // pattern: [%Y-%m-%d %H:%M:%S.%e] [%n] [%l] [%s:%#] %v
 class default_format_formatter final : public flag_formatter {
@@ -824,12 +859,23 @@ public:
             dest.push_back(']');
             dest.push_back(' ');
         }
+
+        // add attributes if present
+        if (!msg.attributes.empty()) {
+            dest.push_back('[');
+            const auto &attributes = msg.attributes.get_map();
+            attribute_formatter_.format_attributes(attributes, dest);
+            dest.push_back(']');
+            dest.push_back(' ');
+        }
+
         fmt_helper::append_string_view(msg.payload, dest);
     }
 
 private:
     std::chrono::seconds cache_timestamp_{0};
     memory_buf_t cached_datetime_;
+    attribute_formatter<null_scoped_padder> attribute_formatter_{padding_info{}};
 };
 }  // namespace details
 
@@ -1105,6 +1151,10 @@ void pattern_formatter::handle_flag_(char flag, details::padding_info padding) {
 
         case ('O'):  // elapsed time since last log message in seconds
             formatters_.push_back(std::make_unique<details::elapsed_formatter<Padder, std::chrono::seconds>>(padding));
+            break;
+
+        case ('*'):
+            formatters_.push_back(std::make_unique<details::attribute_formatter<Padder>>(padding));
             break;
 
         default:  // Unknown flag appears as is

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SPDLOG_UTESTS_SOURCES
     test_no_source_location.cpp
     test_log_level.cpp
     test_include_sinks.cpp
+    test_attributes.cpp
     test_bin_to_hex.cpp
     test_errors.cpp)
 

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -1,7 +1,6 @@
 #include <future>
 
 #include "includes.h"
-#include "spdlog/mdc.h"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/spdlog.h"
 #include "test_sink.h"
@@ -182,7 +181,7 @@ TEST_CASE("attribute test - multi threaded") {
     // put attributes with multiple threads simultaneously
     std::vector<std::future<void>> tasks;
     for (unsigned int i = 0; i < n_tasks; ++i) {
-        auto task = std::async([&logger, i] {
+        auto task = std::async([&logger, i, n_values] {
             for (auto j = 0; j < n_values; ++j)
                 logger.attrs().put(fmt_lib::format("log_{}_key_{}", i, j), fmt_lib::format("log_{}_value_{}", i, j));
         });

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -9,9 +9,11 @@
 using namespace spdlog;
 
 std::string format_attrs(std::string_view const log_name, log_attributes::attr_map_t const& attrs = {}) {
-    std::vector<std::string> fmt_attrs;
-    for (auto&& attr : attrs) fmt_attrs.push_back(fmt::format("{}:{}", attr.first, attr.second));
-    return fmt::format("[{}] [{}]", log_name, fmt::join(fmt_attrs, " "));
+    std::string fmt_attrs;
+    for (auto&& attr : attrs) fmt_attrs += fmt_lib::format("{}:{} ", attr.first, attr.second);
+    if (!fmt_attrs.empty()) fmt_attrs.pop_back();
+
+    return fmt_lib::format("[{}] [{}]", log_name, fmt_attrs);
 }
 
 std::pair<logger, std::shared_ptr<sinks::test_sink_st>> make_logger() {
@@ -182,7 +184,7 @@ TEST_CASE("attribute test - multi threaded") {
     for (auto i = 0; i < n_tasks; ++i) {
         auto task = std::async([&logger, i, n_values] {
             for (auto j = 0; j < n_values; ++j)
-                logger.attrs().put(fmt::format("log_{}_key_{}", i, j), fmt::format("log_{}_value_{}", i, j));
+                logger.attrs().put(fmt_lib::format("log_{}_key_{}", i, j), fmt_lib::format("log_{}_value_{}", i, j));
         });
         tasks.emplace_back(std::move(task));
     }
@@ -194,7 +196,7 @@ TEST_CASE("attribute test - multi threaded") {
     auto log_line = mt_sink->lines().back();
     for (auto i = 0; i < n_tasks; ++i) {
         for (auto j = 0; j < n_values; ++j) {
-            auto search_term = fmt::format("log_{0}_key_{1}:log_{0}_value_{1}", i, j);
+            auto search_term = fmt_lib::format("log_{0}_key_{1}:log_{0}_value_{1}", i, j);
             REQUIRE(log_line.find(search_term) != std::string::npos);
         }
     }

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -182,7 +182,7 @@ TEST_CASE("attribute test - multi threaded") {
     // put attributes with multiple threads simultaneously
     std::vector<std::future<void>> tasks;
     for (unsigned int i = 0; i < n_tasks; ++i) {
-        auto task = std::async([&logger, i, n_values] {
+        auto task = std::async([&logger, i] {
             for (auto j = 0; j < n_values; ++j)
                 logger.attrs().put(fmt_lib::format("log_{}_key_{}", i, j), fmt_lib::format("log_{}_value_{}", i, j));
         });

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Attribute test") {
     log_a.set_pattern("[%n] [%*]");
     log_b.set_pattern("[%n] [%*]");
 
-    log_a.push_attribute("my_key", "my_value");
+    log_a.attrs().put("my_key", "my_value");
 
     log_a.info("Hello");
     log_b.info("Hello");

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -173,7 +173,7 @@ TEST_CASE("attribute test - nested scoped") {
 }
 
 TEST_CASE("attribute test - multi threaded") {
-    const int n_tasks = std::thread::hardware_concurrency();
+    const unsigned int n_tasks = std::thread::hardware_concurrency();
     constexpr auto n_values = 30;
     auto mt_sink = std::make_shared<spdlog::sinks::test_sink_mt>();
     auto logger = spdlog::logger("logger", mt_sink);
@@ -181,7 +181,7 @@ TEST_CASE("attribute test - multi threaded") {
 
     // put attributes with multiple threads simultaneously
     std::vector<std::future<void>> tasks;
-    for (auto i = 0; i < n_tasks; ++i) {
+    for (unsigned int i = 0; i < n_tasks; ++i) {
         auto task = std::async([&logger, i, n_values] {
             for (auto j = 0; j < n_values; ++j)
                 logger.attrs().put(fmt_lib::format("log_{}_key_{}", i, j), fmt_lib::format("log_{}_value_{}", i, j));
@@ -194,7 +194,7 @@ TEST_CASE("attribute test - multi threaded") {
     logger.info("");
     REQUIRE(!mt_sink->lines().empty());
     auto log_line = mt_sink->lines().back();
-    for (auto i = 0; i < n_tasks; ++i) {
+    for (unsigned int i = 0; i < n_tasks; ++i) {
         for (auto j = 0; j < n_values; ++j) {
             auto search_term = fmt_lib::format("log_{0}_key_{1}:log_{0}_value_{1}", i, j);
             REQUIRE(log_line.find(search_term) != std::string::npos);

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -1,13 +1,30 @@
+#include <future>
+
 #include "includes.h"
 #include "spdlog/mdc.h"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/spdlog.h"
 #include "test_sink.h"
 
-TEST_CASE("Attribute test") {
-    auto test_sink = std::make_shared<spdlog::sinks::test_sink_st>();
-    spdlog::logger log_a("log_a", test_sink);
-    spdlog::logger log_b("log_b", test_sink);
+using namespace spdlog;
+
+std::string format_attrs(std::string_view const log_name, log_attributes::attr_map_t const& attrs = {}) {
+    std::vector<std::string> fmt_attrs;
+    for (auto&& attr : attrs) fmt_attrs.push_back(fmt::format("{}:{}", attr.first, attr.second));
+    return fmt::format("[{}] [{}]", log_name, fmt::join(fmt_attrs, " "));
+}
+
+std::pair<logger, std::shared_ptr<sinks::test_sink_st>> make_logger() {
+    auto test_sink = std::make_shared<sinks::test_sink_st>();
+    auto log = logger("logger", test_sink);
+    log.set_pattern("[%n] [%*]");
+    return std::make_pair(log, test_sink);
+}
+
+TEST_CASE("attribute test - multiple (single thread)") {
+    auto test_sink = std::make_shared<sinks::test_sink_st>();
+    logger log_a("log_a", test_sink);
+    logger log_b("log_b", test_sink);
     log_a.set_pattern("[%n] [%*]");
     log_b.set_pattern("[%n] [%*]");
 
@@ -16,11 +33,169 @@ TEST_CASE("Attribute test") {
     log_a.info("Hello");
     log_b.info("Hello");
 
-    auto expected_log_a = spdlog::fmt_lib::format("[log_a] [my_key:my_value]");
-    auto expected_log_b = spdlog::fmt_lib::format("[log_b] []");
+    auto expected_log_a = format_attrs("log_a", {{"my_key", "my_value"}});
+    auto expected_log_b = format_attrs("log_b");
+
+    auto [found, value] = log_a.attrs().get("my_key");
+    REQUIRE(found);
+    REQUIRE(value->first == "my_key");
+    REQUIRE(value->second == "my_value");
+
+    auto [not_found, _] = log_a.attrs().get("my_non_existent_key");
+    REQUIRE(!not_found);
 
     auto lines = test_sink->lines();
     REQUIRE(lines.size() == 2);
     REQUIRE(lines[0] == expected_log_a);
     REQUIRE(lines[1] == expected_log_b);
+}
+
+TEST_CASE("attribute test - remove") {
+    std::vector<log_attributes::attr_map_t::value_type> attrs{
+        {"my_key", "my_value"},
+        {"my_key2", "my_value2"},
+    };
+
+    auto [log, test_sink] = make_logger();
+
+    log.attrs().put(attrs[0].first, attrs[0].second);
+    log.attrs().put(attrs[1].first, attrs[1].second);
+
+    log.info("");
+    auto expected_log = format_attrs("logger", {attrs.begin(), attrs.end()});
+
+    REQUIRE(!test_sink->lines().empty());
+    REQUIRE(test_sink->lines().back() == expected_log);
+
+    log.attrs().remove(attrs.front().first);
+    log.info("");
+    expected_log = format_attrs("logger", {attrs.begin() + 1, attrs.end()});
+    REQUIRE(test_sink->lines().back() == expected_log);
+
+    log.attrs().remove(attrs.back().first);
+    log.info("");
+    expected_log = format_attrs("logger");
+    REQUIRE(test_sink->lines().back() == expected_log);
+}
+
+TEST_CASE("attribute test - from range") {
+    std::vector<log_attributes::attr_map_t::value_type> attrs{
+        {"my_key", "my_value"},
+        {"my_key2", "my_value2"},
+    };
+
+    auto [log, test_sink] = make_logger();
+
+    log.attrs().put({attrs.begin(), attrs.end()});
+    log.info("");
+    auto expected_log = format_attrs("logger", {attrs.begin(), attrs.end()});
+
+    REQUIRE(!test_sink->lines().empty());
+    REQUIRE(test_sink->lines().back() == expected_log);
+}
+
+TEST_CASE("attribute test - scoped") {
+    std::vector<log_attributes::attr_map_t::value_type> attrs{
+        {"my_key", "my_value"},
+        {"my_key2", "my_value2"},
+    };
+
+    auto [log, test_sink] = make_logger();
+
+    auto key_value = std::make_pair("additional_key", "additional_value");
+    {
+        // add the attributes in scope
+        auto ctx = log.attrs().scoped_ctx({attrs.begin(), attrs.end()});
+        log.info("");
+        auto expected_log = format_attrs("logger", {attrs.begin(), attrs.end()});
+
+        REQUIRE(!test_sink->lines().empty());
+        REQUIRE(test_sink->lines().back() == expected_log);
+
+        // remove one of the scoped attributes
+        log.attrs().remove(attrs.front().first);
+        log.info("");
+        expected_log = format_attrs("logger", {attrs.begin() + 1, attrs.end()});
+        REQUIRE(test_sink->lines().back() == expected_log);
+
+        // add another non-scoped attribute
+        log.attrs().put(key_value.first, key_value.second);
+        log.info("");
+        expected_log = format_attrs("logger", {attrs[1], key_value});
+        REQUIRE(test_sink->lines().back() == expected_log);
+    }
+
+    log.info("");
+    auto expected_log = format_attrs("logger", {key_value});
+}
+
+TEST_CASE("attribute test - nested scoped") {
+    std::vector<log_attributes::attr_map_t::value_type> attrs{
+        {"my_key", "my_value"},
+        {"my_key2", "my_value2"},
+    };
+    std::vector<log_attributes::attr_map_t::value_type> nested_attrs{
+        {"nested_key", "nested_value"},
+        {"nested_key2", "nested_value2"},
+    };
+
+    auto [log, test_sink] = make_logger();
+
+    {
+        // add the attributes in scope
+        auto ctx = log.attrs().scoped_ctx({attrs.begin(), attrs.end()});
+        log.info("");
+        auto expected_log = format_attrs("logger", {attrs.begin(), attrs.end()});
+
+        REQUIRE(!test_sink->lines().empty());
+        REQUIRE(test_sink->lines().back() == expected_log);
+
+        // add another scoped context
+        {
+            auto ctx_nested = log.attrs().scoped_ctx({nested_attrs.begin(), nested_attrs.end()});
+            log.info("");
+            log_attributes::attr_map_t all_attrs{attrs.begin(), attrs.end()};
+            all_attrs.insert(nested_attrs.begin(), nested_attrs.end());
+            expected_log = format_attrs("logger", {all_attrs.begin(), all_attrs.end()});
+            REQUIRE(test_sink->lines().back() == expected_log);
+        }
+
+        // delete nested scope
+        log.info("");
+        expected_log = format_attrs("logger", {attrs.begin(), attrs.end()});
+        REQUIRE(test_sink->lines().back() == expected_log);
+    }
+
+    log.info("");
+    auto expected_log = format_attrs("logger");
+}
+
+TEST_CASE("attribute test - multi threaded") {
+    const int n_tasks = std::thread::hardware_concurrency();
+    constexpr auto n_values = 30;
+    auto mt_sink = std::make_shared<spdlog::sinks::test_sink_mt>();
+    auto logger = spdlog::logger("logger", mt_sink);
+    logger.set_pattern("[%n] [%*]");
+
+    // put attributes with multiple threads simultaneously
+    std::vector<std::future<void>> tasks;
+    for (auto i = 0; i < n_tasks; ++i) {
+        auto task = std::async([&logger, i, n_values] {
+            for (auto j = 0; j < n_values; ++j)
+                logger.attrs().put(fmt::format("log_{}_key_{}", i, j), fmt::format("log_{}_value_{}", i, j));
+        });
+        tasks.emplace_back(std::move(task));
+    }
+
+    for (auto&& task : tasks) task.wait();
+
+    logger.info("");
+    REQUIRE(!mt_sink->lines().empty());
+    auto log_line = mt_sink->lines().back();
+    for (auto i = 0; i < n_tasks; ++i) {
+        for (auto j = 0; j < n_values; ++j) {
+            auto search_term = fmt::format("log_{0}_key_{1}:log_{0}_value_{1}", i, j);
+            REQUIRE(log_line.find(search_term) != std::string::npos);
+        }
+    }
 }

--- a/tests/test_attributes.cpp
+++ b/tests/test_attributes.cpp
@@ -1,0 +1,26 @@
+#include "includes.h"
+#include "spdlog/mdc.h"
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+#include "test_sink.h"
+
+TEST_CASE("Attribute test") {
+    auto test_sink = std::make_shared<spdlog::sinks::test_sink_st>();
+    spdlog::logger log_a("log_a", test_sink);
+    spdlog::logger log_b("log_b", test_sink);
+    log_a.set_pattern("[%n] [%*]");
+    log_b.set_pattern("[%n] [%*]");
+
+    log_a.push_attribute("my_key", "my_value");
+
+    log_a.info("Hello");
+    log_b.info("Hello");
+
+    auto expected_log_a = spdlog::fmt_lib::format("[log_a] [my_key:my_value]");
+    auto expected_log_b = spdlog::fmt_lib::format("[log_b] []");
+
+    auto lines = test_sink->lines();
+    REQUIRE(lines.size() == 2);
+    REQUIRE(lines[0] == expected_log_a);
+    REQUIRE(lines[1] == expected_log_b);
+}

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -481,3 +481,80 @@ TEST_CASE("override need_localtime", "[pattern_formatter]") {
         REQUIRE(to_string_view(formatted) == oss.str());
     }
 }
+
+TEST_CASE("attribute formatter test-1", "[pattern_formatter]") {
+    spdlog::log_attributes attributes;
+    attributes.put("attribute_key_1", "attribute_value_1");
+    attributes.put("attribute_key_2", "attribute_value_2");
+
+    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    formatter->set_pattern("[%n] [%l] [%*] %v");
+
+    memory_buf_t formatted;
+    spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message", attributes);
+    formatter->format(msg, formatted);
+
+    auto expected = spdlog::fmt_lib::format(
+        "[logger-name] [info] [attribute_key_1:attribute_value_1 attribute_key_2:attribute_value_2] some message{}",
+        spdlog::details::os::default_eol);
+    REQUIRE(to_string_view(formatted) == expected);
+}
+
+TEST_CASE("attribute formatter value update", "[pattern_formatter]") {
+    spdlog::log_attributes attributes;
+    attributes.put("attribute_key_1", "attribute_value_1");
+    attributes.put("attribute_key_2", "attribute_value_2");
+
+    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    formatter->set_pattern("[%n] [%l] [%*] %v");
+
+    memory_buf_t formatted_1;
+    spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message", attributes);
+    formatter->format(msg, formatted_1);
+
+    auto expected = spdlog::fmt_lib::format(
+        "[logger-name] [info] [attribute_key_1:attribute_value_1 attribute_key_2:attribute_value_2] some message{}",
+        spdlog::details::os::default_eol);
+
+    REQUIRE(to_string_view(formatted_1) == expected);
+
+    msg.attributes.put("attribute_key_1", "new_attribute_value_1");
+    memory_buf_t formatted_2;
+    formatter->format(msg, formatted_2);
+    expected = spdlog::fmt_lib::format(
+        "[logger-name] [info] [attribute_key_1:new_attribute_value_1 attribute_key_2:attribute_value_2] some message{}",
+        spdlog::details::os::default_eol);
+
+    REQUIRE(to_string_view(formatted_2) == expected);
+}
+
+TEST_CASE("attribute remove key", "[pattern_formatter]") {
+    spdlog::log_attributes attributes;
+    attributes.put("attribute_key_1", "attribute_value_1");
+    attributes.put("attribute_key_2", "attribute_value_2");
+    attributes.remove("attribute_key_1");
+
+    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    formatter->set_pattern("[%n] [%l] [%*] %v");
+
+    memory_buf_t formatted;
+    spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message", attributes);
+    formatter->format(msg, formatted);
+
+    auto expected = spdlog::fmt_lib::format("[logger-name] [info] [attribute_key_2:attribute_value_2] some message{}",
+                                            spdlog::details::os::default_eol);
+    REQUIRE(to_string_view(formatted) == expected);
+}
+
+TEST_CASE("attribute empty", "[pattern_formatter]") {
+    spdlog::log_attributes attributes;
+    auto formatter = std::make_shared<spdlog::pattern_formatter>();
+    formatter->set_pattern("[%n] [%l] [%*] %v");
+
+    memory_buf_t formatted;
+    spdlog::details::log_msg msg(spdlog::source_loc{}, "logger-name", spdlog::level::info, "some message", attributes);
+    formatter->format(msg, formatted);
+
+    auto expected = spdlog::fmt_lib::format("[logger-name] [info] [] some message{}", spdlog::details::os::default_eol);
+    REQUIRE(to_string_view(formatted) == expected);
+}


### PR DESCRIPTION
This is quite similar to the MDC support by #2907 except for one major difference: MDC is stored in global thread local storage vs. attributes are stored per logger.

Each logger has an `attributes_` map which is a `std::string/std::string` map. During logging, these attributes are passed with the log message to the formatter. An `attributes_formatter` (`%*`) will format these the same way that the `mdc_formatter` does.

I could use inheritance or a common function to reduce the code duplication.

## What's the use case?

We are using spdlog on a webserver and have multiple threads handling requests. They share a common logger instance. Since there are multiple threads writing to the same logger, we cannot use MDC to associate additional context to the log messages. The thread writing to the sink will always be a different one than the one executing the web-handler.

This approach will provide the ability to have context associated with a logger instance rather than with a thread. I can have multiple threads writing to the same logger and providing context.

## Considerations

### 1. It's thread safe but is it useful?

After the implementation, I noticed a flaw in my train of thoughts. If I have multiple threads that can safely put context on a logger and write them together with the log messages, I still get a form of race condition.

Logger `A` wants to do some file operation and calls `logger.attrs().put("file-path", "my/path.txt")` to have the file path be logged with any subsequent logs.

Logger `B` may fail parsing an incoming JSON and calls `logger.attrs().put("error", exception.what())`.

If these two then log "at the same time", the logging message will contain both context attributes.

Maybe I shouldn't reuse the same logger for entirely different operations. But even if they are similar, they are not the same and logs from one task don't matter for the other. I am now quite confident, this is what @tt4g tried to explain to me in https://github.com/gabime/spdlog/issues/3083#issuecomment-2092550414 that I am just grasping now.

### 2. using a different map
Currently every attribute has to be formatted as a string before inserting it into the API. Maybe this can be worked around by providing a `formattable` type or similar in the attributes API rather than a string. I haven't dug into fmtlib/std::format enough to see whether that's possible somehow without going down the template rabbit hole.

