### PR TITLE
make example compatible with fmt 11

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -272,7 +272,7 @@ struct my_type {
 #ifndef SPDLOG_USE_STD_FORMAT  // when using fmtlib
 template <>
 struct fmt::formatter<my_type> : fmt::formatter<std::string> {
-    auto format(my_type my, format_context &ctx) -> decltype(ctx.out()) {
+    auto format(my_type my, format_context &ctx) const -> decltype(ctx.out()) {
         return fmt::format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };


### PR DESCRIPTION
Since fmt 11.0.0, formatter::format() is required to be const. Mark format() method in example as const to stay compatible with fmt 11.

closes #3129 #3115 