### PR TITLE
fix: set `/Zc:__cplusplus` and `/MP` to MSVC only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ elseif(NOT CMAKE_CXX_STANDARD)
 endif()
 
 # make sure __cplusplus is defined when using msvc and enable parallel build
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus /MP")
 endif()
 
@@ -161,7 +161,7 @@ if(SPDLOG_BUILD_SHARED OR BUILD_SHARED_LIBS)
     endif()
     add_library(spdlog SHARED ${SPDLOG_SRCS} ${SPDLOG_ALL_HEADERS})
     target_compile_definitions(spdlog PUBLIC SPDLOG_SHARED_LIB)
-    if(MSVC)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         target_compile_options(spdlog PUBLIC $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:/wd4251
                                              /wd4275>)
     endif()


### PR DESCRIPTION
1. macro `__cplusplus` is enabled by clang-cl
2. `/MP` is not supported by clang-cl (warning `-Wunused-command-line-argument` will be generated)

see also: https://clang.llvm.org/docs/UsersManual.html#id11