### PR TITLE
Initialize function-local static variables using "T& t = *new T"

### DIFF
--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -12,7 +12,7 @@ namespace details {
 struct console_mutex {
     using mutex_t = std::mutex;
     static mutex_t &mutex() {
-        static mutex_t s_mutex;
+        static mutex_t& s_mutex = *new mutex_t;
         return s_mutex;
     }
 };
@@ -20,7 +20,7 @@ struct console_mutex {
 struct console_nullmutex {
     using mutex_t = null_mutex;
     static mutex_t &mutex() {
-        static mutex_t s_mutex;
+        static mutex_t& s_mutex = *new mutex_t;
         return s_mutex;
     }
 };

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -234,7 +234,7 @@ SPDLOG_INLINE void registry::set_levels(log_levels levels, level::level_enum *gl
 }
 
 SPDLOG_INLINE registry &registry::instance() {
-    static registry s_instance;
+    static registry& s_instance = *new registry;
     return s_instance;
 }
 

--- a/include/spdlog/mdc.h
+++ b/include/spdlog/mdc.h
@@ -38,7 +38,7 @@ public:
     static void clear() { get_context().clear(); }
 
     static mdc_map_t &get_context() {
-        static thread_local mdc_map_t context;
+        static thread_local mdc_map_t& context = *new mdc_map_t;
         return context;
     }
 };

--- a/include/spdlog/mdc.h
+++ b/include/spdlog/mdc.h
@@ -38,7 +38,7 @@ public:
     static void clear() { get_context().clear(); }
 
     static mdc_map_t &get_context() {
-        static thread_local mdc_map_t& context = *new mdc_map_t;
+        static thread_local mdc_map_t context;
         return context;
     }
 };


### PR DESCRIPTION
It would be safer if init the static object with reference according to [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Static_and_Global_Variables).

I compile the static lib, link to my program, then get segmentation fault on calling  `mdc::get_context()`. After applying these patches the bug was gone.  :100: 