### PR TITLE
V1.x : fixed "suggest override" errors for gcc 8.5 and gcc 9.1 

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -40,7 +40,7 @@ public:
 
     void log(const details::log_msg &msg) override;
     void flush() override;
-    void set_pattern(const std::string &pattern) final;
+    void set_pattern(const std::string &pattern) final override;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
 
     // Formatting codes

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -28,10 +28,10 @@ public:
     base_sink &operator=(const base_sink &) = delete;
     base_sink &operator=(base_sink &&) = delete;
 
-    void log(const details::log_msg &msg) final;
-    void flush() final;
-    void set_pattern(const std::string &pattern) final;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final;
+    void log(const details::log_msg &msg) final override;
+    void flush() final override;
+    void set_pattern(const std::string &pattern) final override;
+    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final override;
 
 protected:
     // sink formatter


### PR DESCRIPTION
fixed errors for gcc 8.5 and gcc 9.1 compilers, which seems reporting an error if no override presented with final. 
I saw FMT_OVERRIDE option used to be present in the repo but then gone, I hope due to it is not an error on newer compiler to have both specifiers.

checked here:
https://godbolt.org/z/33csE9W1P