### PR TITLE
[docs] Update conan install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/
 * Arch Linux: `pacman -S spdlog`
 * openSUSE: `sudo zypper in spdlog-devel`
 * vcpkg: `vcpkg install spdlog`
-* conan: `spdlog/[>=1.4.1]`
+* conan: `conan install --requires=spdlog/[*]`
 * conda: `conda install -c conda-forge spdlog`
 * build2: ```depends: spdlog ^1.8.2```
 


### PR DESCRIPTION
Hello!

I observed that the Conan "instruction" in the readme file is only pointing the spdlog version to be installed, but not the command itself. I updated it with the entire command.

The latest spdlog available in Conan Center can be found on the web page: https://conan.io/center/recipes/spdlog?version=1.14.1

About Conan 2.x install command: https://docs.conan.io/2/reference/commands/install.html

The `[*]` indicates to install the latest version available. 