### PR TITLE
use std::lock_guard instead of std::unique_lock

### DIFF
--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -148,19 +148,19 @@ public:
 #endif
 
     size_t overrun_counter() {
-        std::unique_lock<std::mutex> lock(queue_mutex_);
+        std::lock_guard<std::mutex> lock(queue_mutex_);
         return q_.overrun_counter();
     }
 
     size_t discard_counter() { return discard_counter_.load(std::memory_order_relaxed); }
 
     size_t size() {
-        std::unique_lock<std::mutex> lock(queue_mutex_);
+        std::lock_guard<std::mutex> lock(queue_mutex_);
         return q_.size();
     }
 
     void reset_overrun_counter() {
-        std::unique_lock<std::mutex> lock(queue_mutex_);
+        std::lock_guard<std::mutex> lock(queue_mutex_);
         q_.reset_overrun_counter();
     }
 


### PR DESCRIPTION
I think `overrun_counter`, `size`, and `reset_overrun_counter` func don't need the flexibility of `std::unique_lock`, it's better to use `std::lock_guard` with minimal overhead;