### PR TITLE
Disable MDC if `SPDLOG_NO_TLS` is defined

### DIFF
--- a/include/spdlog/mdc.h
+++ b/include/spdlog/mdc.h
@@ -8,6 +8,10 @@
 
 #include <spdlog/common.h>
 
+#ifdef SPDLOG_NO_TLS
+    #error MDC is not supported with SPDLOG_NO_TLS.
+#endif
+
 // MDC is a simple map of key->string values stored in thread local storage whose content will be printed by the loggers.
 // Note: Not supported in async mode (thread local storage - so the async thread pool have different copy).
 //


### PR DESCRIPTION
This resolves the issue I mentioned in #3101.
I added an error to `mdc.h` for anyone trying to include mdc if `SPDLOG_NO_TLS` is defined, if you prefer making the `mdc::` functions no-ops or putting the class itself behind a ifndef let me know.
If `SPDLOG_NO_TLS` is defined the `&` flag is treated as an unknown flag, if you prefer just ignoring it or something similar, let me know.
I successfully tested these changes on a platform without TLS support with `SPDLOG_NO_TLS` defined.