### PR TITLE
fix/issue-3101: fix the issue where mdc ignores SPDLOG_NO_TLS

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -382,7 +382,9 @@ void replace_default_logger_example() {
 // Mapped Diagnostic Context (MDC) is a map that stores key-value pairs (string values) in thread local storage.
 // Each thread maintains its own MDC, which loggers use to append diagnostic information to log outputs.
 // Note: it is not supported in asynchronous mode due to its reliance on thread-local storage.
-#include "spdlog/mdc.h"
+
+#ifndef SPDLOG_NO_TLS
+    #include "spdlog/mdc.h"
 void mdc_example()
 {
     spdlog::mdc::put("key1", "value1");
@@ -391,3 +393,8 @@ void mdc_example()
     spdlog::set_pattern("[%H:%M:%S %z] [%^%L%$] [%&] %v");
     spdlog::info("Some log message with context");
 }
+#else
+void mdc_example() {
+    // if TLS feature is disabled
+}
+#endif

--- a/include/spdlog/mdc.h
+++ b/include/spdlog/mdc.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#if defined(SPDLOG_NO_TLS)
+    #error "This header requires thread local storage support. Please do not define SPDLOG_NO_TLS."
+#endif
+
 #include <map>
 #include <string>
 

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -10,7 +10,11 @@
 #include <spdlog/details/fmt_helper.h>
 #include <spdlog/details/log_msg.h>
 #include <spdlog/details/os.h>
-#include <spdlog/mdc.h>
+
+#ifndef SPDLOG_NO_TLS
+    #include <spdlog/mdc.h>
+#endif
+
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/formatter.h>
 
@@ -786,6 +790,7 @@ private:
 
 // Class for formatting Mapped Diagnostic Context (MDC) in log messages.
 // Example: [logger-name] [info] [mdc_key_1:mdc_value_1 mdc_key_2:mdc_value_2] some message
+#ifndef SPDLOG_NO_TLS
 template <typename ScopedPadder>
 class mdc_formatter : public flag_formatter {
 public:
@@ -824,6 +829,7 @@ public:
         }
     }
 };
+#endif
 
 // Full info formatter
 // pattern: [%Y-%m-%d %H:%M:%S.%e] [%n] [%l] [%s:%#] %v
@@ -901,6 +907,7 @@ public:
             dest.push_back(' ');
         }
 
+#ifndef SPDLOG_NO_TLS
         // add mdc if present
         auto &mdc_map = mdc::get_context();
         if (!mdc_map.empty()) {
@@ -909,6 +916,7 @@ public:
             dest.push_back(']');
             dest.push_back(' ');
         }
+#endif
         // fmt_helper::append_string_view(msg.msg(), dest);
         fmt_helper::append_string_view(msg.payload, dest);
     }
@@ -916,7 +924,11 @@ public:
 private:
     std::chrono::seconds cache_timestamp_{0};
     memory_buf_t cached_datetime_;
+
+#ifndef SPDLOG_NO_TLS
     mdc_formatter<null_scoped_padder> mdc_formatter_{padding_info{}};
+#endif
+
 };
 
 }  // namespace details
@@ -1211,9 +1223,11 @@ SPDLOG_INLINE void pattern_formatter::handle_flag_(char flag, details::padding_i
                     padding));
             break;
 
+#ifndef SPDLOG_NO_TLS  // mdc formatter requires TLS support
         case ('&'):
             formatters_.push_back(details::make_unique<details::mdc_formatter<Padder>>(padding));
             break;
+#endif
 
         default:  // Unknown flag appears as is
             auto unknown_flag = details::make_unique<details::aggregate_formatter>();

--- a/tests/includes.h
+++ b/tests/includes.h
@@ -26,7 +26,11 @@
 #include "spdlog/spdlog.h"
 #include "spdlog/async.h"
 #include "spdlog/details/fmt_helper.h"
-#include "spdlog/mdc.h"
+
+#ifndef SPDLOG_NO_TLS
+    #include "spdlog/mdc.h"
+#endif
+
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/daily_file_sink.h"
 #include "spdlog/sinks/null_sink.h"

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -501,6 +501,7 @@ TEST_CASE("override need_localtime", "[pattern_formatter]") {
     }
 }
 
+#ifndef SPDLOG_NO_TLS
 TEST_CASE("mdc formatter test-1", "[pattern_formatter]") {
     spdlog::mdc::put("mdc_key_1", "mdc_value_1");
     spdlog::mdc::put("mdc_key_2", "mdc_value_2");
@@ -628,3 +629,4 @@ TEST_CASE("mdc empty", "[pattern_formatter]") {
 
     SECTION("Tear down") { spdlog::mdc::clear(); }
 }
+#endif


### PR DESCRIPTION
## Compared to the previous PR, additional testing details have been added.

### Test results of the original v1.x branch code:

compilation steps:
```bash
$ git clone git@github.com:Allen-20180115/spdlog.git
$ cd spdlog && mkdir build && cd build
$ cmake .. -DSPDLOG_BUILD_EXAMPLE=ON -DSPDLOG_NO_TLS=ON
$ make
$ cd example
$ ./example
```

test result:
```bash
allen@allen:~/mytest/spdlog/build/example$ ./example 
[2024-09-11 16:49:41.804] [info] Welcome to spdlog version 1.14.1  !
[2024-09-11 16:49:41.804] [warning] Easy padding in numbers like 00000012
[2024-09-11 16:49:41.804] [critical] Support for int: 42;  hex: 2a;  oct: 52; bin: 101010
[2024-09-11 16:49:41.804] [info] Support for floats 1.23
[2024-09-11 16:49:41.804] [info] Positional args are supported too..
[2024-09-11 16:49:41.804] [info]    right aligned, left     aligned
[2024-09-11 16:49:41.804] [debug] This message should be displayed..
[16:49:41 +08:00] [I] [thread 25864] This an info message with custom format
[2024-09-11 16:49:41.805] [info] ****************** Backtrace Start ******************
[2024-09-11 16:49:41.805] [debug] Backtrace message 90
[2024-09-11 16:49:41.805] [debug] Backtrace message 91
[2024-09-11 16:49:41.805] [debug] Backtrace message 92
[2024-09-11 16:49:41.805] [debug] Backtrace message 93
[2024-09-11 16:49:41.805] [debug] Backtrace message 94
[2024-09-11 16:49:41.805] [debug] Backtrace message 95
[2024-09-11 16:49:41.805] [debug] Backtrace message 96
[2024-09-11 16:49:41.805] [debug] Backtrace message 97
[2024-09-11 16:49:41.805] [debug] Backtrace message 98
[2024-09-11 16:49:41.805] [debug] Backtrace message 99
[2024-09-11 16:49:41.805] [info] ****************** Backtrace End ********************
[2024-09-11 16:49:41.808] [info] Binary example: 
0000: 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
0020: 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
0040: 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f
[2024-09-11 16:49:41.808] [info] Another binary example:00 01 02 03 04 05 06 07 08 09
[2024-09-11 16:49:41.808] [info] Vector example: [1, 2, 3]
[multi_sink_example] [warning] this should appear in both console and file
[2024-09-11 16:49:41.808] [info] user defined type: [my_type i=14]
[2024-09-11 16:49:41.931] [info] Stopwatch: 0.123096335 seconds
[2024-09-11 16:49:41.931] [info] Before opening logs/events-sample.txt
[2024-09-11 16:49:41.931] [info] After opening logs/events-sample.txt
[2024-09-11 16:49:41.931] [info] Before closing logs/events-sample.txt
[2024-09-11 16:49:41.931] [info] After closing logs/events-sample.txt
[16:49:41 +08:00] [I] [key1:value1 key2:value2] Some log message with context
[16:49:41 +08:00] [I] [key1:value1 key2:value2] End of example.
[16:49:41 +08:00] [I] [key1:value1 key2:value2] End of example.
```

### PR branch code test results:

compilation steps:
```bash
$ git clone git@github.com:Allen-20180115/spdlog.git
$ cd spdlog && mkdir build2 && cd build2
$ cmake .. -DSPDLOG_BUILD_EXAMPLE=ON -DSPDLOG_NO_TLS=ON
$ make
$ cd example
$ ./example
```

test result:
```bash
allen@allen:~/mytest/spdlog/build2/example$ ./example 
[2024-09-12 19:26:54.801] [info] Welcome to spdlog version 1.14.1  !
[2024-09-12 19:26:54.801] [warning] Easy padding in numbers like 00000012
[2024-09-12 19:26:54.802] [critical] Support for int: 42;  hex: 2a;  oct: 52; bin: 101010
[2024-09-12 19:26:54.802] [info] Support for floats 1.23
[2024-09-12 19:26:54.802] [info] Positional args are supported too..
[2024-09-12 19:26:54.802] [info]    right aligned, left     aligned
[2024-09-12 19:26:54.802] [debug] This message should be displayed..
[19:26:54 +08:00] [I] [thread 26706] This an info message with custom format
[2024-09-12 19:26:54.802] [info] ****************** Backtrace Start ******************
[2024-09-12 19:26:54.802] [debug] Backtrace message 90
[2024-09-12 19:26:54.802] [debug] Backtrace message 91
[2024-09-12 19:26:54.802] [debug] Backtrace message 92
[2024-09-12 19:26:54.802] [debug] Backtrace message 93
[2024-09-12 19:26:54.802] [debug] Backtrace message 94
[2024-09-12 19:26:54.802] [debug] Backtrace message 95
[2024-09-12 19:26:54.802] [debug] Backtrace message 96
[2024-09-12 19:26:54.802] [debug] Backtrace message 97
[2024-09-12 19:26:54.802] [debug] Backtrace message 98
[2024-09-12 19:26:54.802] [debug] Backtrace message 99
[2024-09-12 19:26:54.802] [info] ****************** Backtrace End ********************
[2024-09-12 19:26:54.803] [info] Binary example: 
0000: 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
0020: 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f
0040: 40 41 42 43 44 45 46 47 48 49 4a 4b 4c 4d 4e 4f
[2024-09-12 19:26:54.803] [info] Another binary example:00 01 02 03 04 05 06 07 08 09
[2024-09-12 19:26:54.803] [info] Vector example: [1, 2, 3]
[multi_sink_example] [warning] this should appear in both console and file
[2024-09-12 19:26:54.803] [info] user defined type: [my_type i=14]
[2024-09-12 19:26:54.927] [info] Stopwatch: 0.123242379 seconds
[2024-09-12 19:26:54.927] [info] Before opening logs/events-sample.txt
[2024-09-12 19:26:54.927] [info] After opening logs/events-sample.txt
[2024-09-12 19:26:54.927] [info] Before closing logs/events-sample.txt
[2024-09-12 19:26:54.927] [info] After closing logs/events-sample.txt
[2024-09-12 19:26:54.927] [info] End of example.
[2024-09-12 19:26:54.927] [console] [info] End of example.
```

**Please note the output results on the end of line. At this point, calling mdc_example() does not ignore the compiler option SPDLOG_NO_TLS**