### PR TITLE
Fix warning - extra ';' for -Wextra-semi

### DIFF
--- a/bench/async_bench.cpp
+++ b/bench/async_bench.cpp
@@ -160,7 +160,7 @@ void bench_mt(int howmany, std::shared_ptr<spdlog::logger> logger, int thread_co
 
     for (auto &t : threads) {
         t.join();
-    };
+    }
 
     auto delta = high_resolution_clock::now() - start;
     auto delta_d = duration_cast<duration<double>>(delta).count();

--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -181,7 +181,7 @@ void bench_mt(int howmany, std::shared_ptr<spdlog::logger> log, size_t thread_co
 
     for (auto &t : threads) {
         t.join();
-    };
+    }
 
     auto delta = high_resolution_clock::now() - start;
     auto delta_d = duration_cast<duration<double>>(delta).count();

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -266,7 +266,7 @@ void multi_sink_example() {
 struct my_type {
     int i = 0;
     explicit my_type(int i)
-        : i(i){};
+        : i(i){}
 };
 
 #ifndef SPDLOG_USE_STD_FORMAT  // when using fmtlib

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -27,7 +27,7 @@ public:
 
 protected:
     void sink_it_(const details::log_msg &msg) override { callback_(msg); }
-    void flush_() override{};
+    void flush_() override{}
 
 private:
     custom_log_callback callback_;

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -32,7 +32,7 @@ class msvc_sink : public base_sink<Mutex> {
 public:
     msvc_sink() = default;
     msvc_sink(bool check_debugger_present)
-        : check_debugger_present_{check_debugger_present} {};
+        : check_debugger_present_{check_debugger_present} {}
 
 protected:
     void sink_it_(const details::log_msg &msg) override {


### PR DESCRIPTION
This PR will fix the following warning.

```
D:\a\WasmEdge\WasmEdge\build\_deps\spdlog-src\include\spdlog/sinks/callback_sink.h(30,29): error: extra ';' after member function definition [-Werror,-Wextra-semi]
   30 |     void flush_() override{};
      |                             ^
1 error generated.
```