### PR TITLE
fixing pattern_formatter-inl.h(1319): warning C26800: Use of a moved from object: ''user_chars''

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1308,7 +1308,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
         if (*it == '%') {
             if (user_chars)  // append user chars found so far
             {
-                formatters_.push_back(std::move(user_chars));
+                formatters_.emplace_back(user_chars.release());
             }
 
             auto padding = handle_padspec_(++it, end);
@@ -1332,7 +1332,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
     }
     if (user_chars)  // append raw chars found so far
     {
-        formatters_.push_back(std::move(user_chars));
-    }
+		formatters_.emplace_back(user_chars.release());
+	}
 }
 }  // namespace spdlog


### PR DESCRIPTION
following https://github.com/gabime/spdlog/issues/3214#issue-2583804031