### PR TITLE
fixing vs analyser's "here could be constexpr" warning

### DIFF
--- a/include/spdlog/fmt/bundled/format-inl.h
+++ b/include/spdlog/fmt/bundled/format-inl.h
@@ -1248,7 +1248,7 @@ template <typename T> auto to_decimal(T x) noexcept -> decimal_fp<T> {
   auto br = bit_cast<carrier_uint>(x);
 
   // Extract significand bits and exponent bits.
-  const carrier_uint significand_mask =
+  constexpr carrier_uint significand_mask =
       (static_cast<carrier_uint>(1) << num_significand_bits<T>()) - 1;
   carrier_uint significand = (br & significand_mask);
   int exponent =

--- a/include/spdlog/fmt/bundled/format.h
+++ b/include/spdlog/fmt/bundled/format.h
@@ -1633,7 +1633,7 @@ template <typename F> struct basic_fp {
     static_assert(std::numeric_limits<Float>::digits <= 113, "unsupported FP");
     // Assume Float is in the format [sign][exponent][significand].
     using carrier_uint = typename dragonbox::float_info<Float>::carrier_uint;
-    const auto num_float_significand_bits =
+    constexpr auto num_float_significand_bits =
         detail::num_significand_bits<Float>();
     const auto implicit_bit = carrier_uint(1) << num_float_significand_bits;
     const auto significand_mask = implicit_bit - 1;
@@ -2839,7 +2839,7 @@ class bigint {
   FMT_CONSTEXPR20 void multiply(UInt value) {
     using half_uint =
         conditional_t<std::is_same<UInt, uint128_t>::value, uint64_t, uint32_t>;
-    const int shift = num_bits<half_uint>() - bigit_bits;
+    constexpr int shift = num_bits<half_uint>() - bigit_bits;
     const UInt lower = static_cast<half_uint>(value);
     const UInt upper = value >> num_bits<half_uint>();
     UInt carry = 0;
@@ -3323,7 +3323,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
     using info = dragonbox::float_info<double>;
     auto br = bit_cast<uint64_t>(static_cast<double>(value));
 
-    const uint64_t significand_mask =
+	constexpr uint64_t significand_mask =
         (static_cast<uint64_t>(1) << num_significand_bits<double>()) - 1;
     uint64_t significand = (br & significand_mask);
     int exponent = static_cast<int>((br & exponent_mask<double>()) >>
@@ -3657,7 +3657,7 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
   constexpr auto specs = format_specs<Char>();
   using floaty = conditional_t<std::is_same<T, long double>::value, double, T>;
   using floaty_uint = typename dragonbox::float_info<floaty>::carrier_uint;
-  floaty_uint mask = exponent_mask<floaty>();
+  constexpr floaty_uint mask = exponent_mask<floaty>();
   if ((bit_cast<floaty_uint>(value) & mask) == mask)
     return write_nonfinite(out, std::isnan(value), specs, fspecs);
 

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1308,7 +1308,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
         if (*it == '%') {
             if (user_chars)  // append user chars found so far
             {
-                formatters_.emplace_back(user_chars.release());
+                formatters_.push_back(std::move(user_chars));
             }
 
             auto padding = handle_padspec_(++it, end);
@@ -1332,7 +1332,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
     }
     if (user_chars)  // append raw chars found so far
     {
-		formatters_.emplace_back(user_chars.release());
-	}
+        formatters_.push_back(std::move(user_chars));
+    }
 }
 }  // namespace spdlog

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1308,7 +1308,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
         if (*it == '%') {
             if (user_chars)  // append user chars found so far
             {
-                formatters_.push_back(std::move(user_chars));
+                formatters_.emplace_back(user_chars.release());
             }
 
             auto padding = handle_padspec_(++it, end);
@@ -1332,7 +1332,7 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
     }
     if (user_chars)  // append raw chars found so far
     {
-        formatters_.push_back(std::move(user_chars));
-    }
+		formatters_.emplace_back(user_chars.release());
+	}
 }
 }  // namespace spdlog


### PR DESCRIPTION
Please consider replacing const with constexpr which an analyser marked with
"warning C26498: The function '...' is constexpr, mark variable '...' constexpr if compile-time evaluation is desired (con.5)."