### PR TITLE
Exchange promise for condition_variable when flushing (fixes #3221)

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -32,28 +32,30 @@ SPDLOG_INLINE spdlog::async_logger::async_logger(std::string logger_name,
 
 // send the log message to the thread pool
 SPDLOG_INLINE void spdlog::async_logger::sink_it_(const details::log_msg &msg){
-    SPDLOG_TRY{if (auto pool_ptr = thread_pool_.lock()){
-        pool_ptr->post_log(shared_from_this(), msg, overflow_policy_);
-}
-else {
-    throw_spdlog_ex("async log: thread pool doesn't exist anymore");
-}
-}
-SPDLOG_LOGGER_CATCH(msg.source)
+    SPDLOG_TRY {
+        if (auto pool_ptr = thread_pool_.lock()){
+            pool_ptr->post_log(shared_from_this(), msg, overflow_policy_);
+        }
+        else {
+            throw_spdlog_ex("async log: thread pool doesn't exist anymore");
+        }
+    }
+    SPDLOG_LOGGER_CATCH(msg.source)
 }
 
 // send flush request to the thread pool
-SPDLOG_INLINE void spdlog::async_logger::flush_(){SPDLOG_TRY{auto pool_ptr = thread_pool_.lock();
-if (!pool_ptr) {
-    throw_spdlog_ex("async flush: thread pool doesn't exist anymore");
-}
+SPDLOG_INLINE void spdlog::async_logger::flush_() {
+    SPDLOG_TRY {
+        auto pool_ptr = thread_pool_.lock();
+        if (!pool_ptr) {
+            throw_spdlog_ex("async flush: thread pool doesn't exist anymore");
+        }
 
-std::future<void> future = pool_ptr->post_flush(shared_from_this(), overflow_policy_);
-// Wait for the flush operation to complete.
-// This might throw exception if the flush message get dropped because of overflow.
-future.get();
-}
-SPDLOG_LOGGER_CATCH(source_loc())
+        // Wait for the flush operation to complete.
+        // This might throw exception if the flush message get dropped because of overflow.
+        pool_ptr->post_and_wait_for_flush(shared_from_this(), overflow_policy_);
+    }
+    SPDLOG_LOGGER_CATCH(source_loc())
 }
 
 //

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -62,13 +62,25 @@ void SPDLOG_INLINE thread_pool::post_log(async_logger_ptr &&worker_ptr,
     post_async_msg_(std::move(async_m), overflow_policy);
 }
 
-std::future<void> SPDLOG_INLINE thread_pool::post_flush(async_logger_ptr &&worker_ptr,
+void SPDLOG_INLINE thread_pool::post_and_wait_for_flush(async_logger_ptr &&worker_ptr,
                                                         async_overflow_policy overflow_policy) {
-    std::promise<void> promise;
-    std::future<void> future = promise.get_future();
-    post_async_msg_(async_msg(std::move(worker_ptr), async_msg_type::flush, std::move(promise)),
-                    overflow_policy);
-    return future;
+    std::mutex m;
+    std::unique_lock<std::mutex> l(m);
+    std::condition_variable cv;
+    std::atomic<async_msg_flush> cv_flag{async_msg_flush::not_synced};
+    post_async_msg_(async_msg(std::move(worker_ptr), async_msg_type::flush, [&cv, &cv_flag](async_msg_flush flushed) {
+        cv_flag.store(flushed, std::memory_order_relaxed);
+        cv.notify_all();
+    }), overflow_policy);
+    while(cv_flag.load(std::memory_order_relaxed) == async_msg_flush::not_synced) {
+        cv.wait_for(l, std::chrono::milliseconds(100), [&cv_flag]() {
+            return cv_flag.load(std::memory_order_relaxed) != async_msg_flush::not_synced;
+        });
+    }
+
+    if(cv_flag.load(std::memory_order_relaxed) == async_msg_flush::synced_not_flushed) {
+        throw spdlog_ex("Request for flushing got dropped.");
+    }
 }
 
 size_t SPDLOG_INLINE thread_pool::overrun_counter() { return q_.overrun_counter(); }
@@ -112,7 +124,10 @@ bool SPDLOG_INLINE thread_pool::process_next_msg_() {
         }
         case async_msg_type::flush: {
             incoming_async_msg.worker_ptr->backend_flush_();
-            incoming_async_msg.flush_promise.set_value();
+            if(incoming_async_msg.flush_callback) {
+                incoming_async_msg.flush_callback(async_msg_flush::synced_flushed);
+                incoming_async_msg.flush_callback = nullptr;
+            }
             return true;
         }
 


### PR DESCRIPTION
### Description

std::promise and std::future use std::call_once under the hood, which requires the tls-model to be at least initial_exec, excluding local_exec.

Furthermore, gcc has a bug regarding exceptions in std::call_once that is best avoided. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66146 for more info.

Coincidentally, this change also fixes the flush functionality when compiling with vs2013, as the move constructor/operator for vs2013 didn't move the `flush_promise` member. I also initially missed this, as I don't test on windows.

### Considerations

* Each flush request now uses a `std::condition_variable` that checks every 100 ms for a flag change or until a `cv.notify_all()` happens. The latter might race for some reason, so there may be a delay of up to 100 ms until the change is detected in rare cases.
* The `std::future` solution threw exceptions if the `async_msg` got dropped. This behaviour is still there, though it is technically possible to return a boolean now and call the `err_handler_` without an exception, saving the cost of throwing one at the expense of an if statement on the non-error case. I don't have any benchmarks on if that would be a worthy tradeoff.

### Tested on

Tested on linux x64, with and without sanitizers, with `-ftls-model=local-exec` and `-ftls-model=initial-exec`.


Please let me know if you want to see any changes.