### PR TITLE
Improve Cross-Platform Build Instructions in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,8 @@ Copy the include [folder](https://github.com/gabime/spdlog/tree/v1.x/include/spd
 #### Compiled version (recommended - much faster compile times)
 ```console
 git clone https://github.com/gabime/spdlog.git
-cd spdlog
-mkdir build
-cd build
-cmake ..
-cmake --build . --parallel
+cd spdlog ; mkdir build ; cd build
+cmake .. ; cmake --build . --parallel
 cmake --install .
 ```
 see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/CMakeLists.txt) on how to use.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ Copy the include [folder](https://github.com/gabime/spdlog/tree/v1.x/include/spd
 
 #### Compiled version (recommended - much faster compile times)
 ```console
-git clone https://github.com/gabime/spdlog.git
-cd spdlog ; mkdir build ; cd build
-cmake .. ; cmake --build . --parallel
-cmake --install .
+$ git clone https://github.com/gabime/spdlog.git
+$ cd spdlog && mkdir build && cd build
+$ cmake .. && cmake --build .
 ```
 see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/CMakeLists.txt) on how to use.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ Copy the include [folder](https://github.com/gabime/spdlog/tree/v1.x/include/spd
 
 #### Compiled version (recommended - much faster compile times)
 ```console
-$ git clone https://github.com/gabime/spdlog.git
-$ cd spdlog && mkdir build && cd build
-$ cmake .. && make -j
+git clone https://github.com/gabime/spdlog.git
+cd spdlog
+mkdir build
+cd build
+cmake ..
+cmake --build . --parallel
+cmake --install .
 ```
 see example [CMakeLists.txt](https://github.com/gabime/spdlog/blob/v1.x/example/CMakeLists.txt) on how to use.
 


### PR DESCRIPTION
### Description:
This PR updates the build instructions in the documentation to make them more cross-platform and compatible with different development environments, such as Windows with MSVC.

### Details:
Previously, the documentation included commands specific to GNU-based toolchains, notably `make`. However, this can be problematic for users on non-GNU systems (such as Windows with MSVC), where `make` is not available by default. This update replaces `make -j` with the more universally supported `cmake --build . --parallel` and adds a clear `cmake --install .` command for the installation step.

### Reasoning:
- **Cross-Platform Compatibility**: The updated commands are compatible across platforms, as CMake will automatically choose the appropriate build system (e.g., `MSBuild` on Windows, `make` on Unix-like systems).
- **Improved Readability**: By breaking down the commands into separate lines, the process becomes easier to follow, especially for users who are not familiar with the default GNU environment assumptions.
- **Consistent CMake Usage**: Using `cmake --build` and `cmake --install` promotes consistency with CMake’s intended workflows and is less reliant on external toolchains.

---

Thank you for considering this contribution to enhance the usability of the build instructions for a broader range of developers.