### PR TITLE
Ensure flush callback gets called in move-assign operator

### DIFF
--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -49,12 +49,12 @@ struct async_msg : log_msg_buffer {
           flush_callback(std::move(other.flush_callback)) {
         other.flush_callback = nullptr;
     }
+
     async_msg &operator=(async_msg &&other) SPDLOG_NOEXCEPT {
         *static_cast<log_msg_buffer *>(this) = static_cast<log_msg_buffer&&>(other);
         msg_type = other.msg_type;
         worker_ptr = std::move(other.worker_ptr);
-        flush_callback = std::move(other.flush_callback);
-        other.flush_callback = nullptr;
+        std::swap(flush_callback, other.flush_callback);
         return *this;
     }
 


### PR DESCRIPTION
While this change makes the condition_variable more reliable, without the 100 ms loop results in spdlog-utests getting stuck sometimes. With the `wait_for` loop, the [multithreaded flush test](https://github.com/gabime/spdlog/blob/22b0f4fc06980d82fb06d82a249215b98e3142fe/tests/test_async.cpp#L96), which inserts 10240 messages of which most get overridden, continues to work.  