### PR TITLE
[docs] Removed duplicate line in daily_file_sink document

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -62,7 +62,6 @@ struct daily_filename_format_calculator {
  * Rotating file sink based on date.
  * If truncate != false , the created file will be truncated.
  * If max_files > 0, retain only the last max_files and delete previous.
- * If max_files > 0, retain only the last max_files and delete previous.
  * Note that old log files from previous executions will not be deleted by this class,
  * rotation and deletion is only applied while the program is running.
  */


### PR DESCRIPTION
I removed a duplicate line in the daily_file_sink comment documentation.

Because I noticed that there were two identical comments in the daily_file_sink documentation in [v1.5.0](https://github.com/gabime/spdlog/blob/8e5613379f5140fefb0b60412fbf1f5406e7c7f8/include/spdlog/sinks/daily_file_sink.h#L64). 

There were none in [v1.4.0](https://github.com/gabime/spdlog/blob/0a53eafe18d983c7c8ba4cadd02d0cc7f7308f28/include/spdlog/sinks/daily_file_sink.h#L64).