### PR TITLE
Add explicit `fmt::` and `std::` to avoid ambiguous call

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ struct fmt::formatter<my_type> : fmt::formatter<std::string>
 {
     auto format(my_type my, format_context &ctx) const -> decltype(ctx.out())
     {
-        return format_to(ctx.out(), "[my_type i={}]", my.i);
+        return fmt::format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -281,7 +281,7 @@ struct fmt::formatter<my_type> : fmt::formatter<std::string> {
 template <>
 struct std::formatter<my_type> : std::formatter<std::string> {
     auto format(my_type my, format_context &ctx) const -> decltype(ctx.out()) {
-        return format_to(ctx.out(), "[my_type i={}]", my.i);
+        return std::format_to(ctx.out(), "[my_type i={}]", my.i);
     }
 };
 #endif


### PR DESCRIPTION
Use three major compilers (clang++ 19, msvc 2022, g++ 14) when `std::format_to` and `fmt::format_to` are both present, the call in
```c++
       return format_to(ctx.out(), "[my_type i={}]", my.i);
```
would be ambiguous. The reason is unknown(even if it's in `fmt::formatter` or `std::formatter`), but it's really easy to fix this. specify `std::` or `fmt::` before `format_to` will solve the problem.