### PR TITLE
Allow manual rotation of rotating_file_sink

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -71,8 +71,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename() {
 
 template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::rotate_now() {
-    SPDLOG_TRY { rotate_(); }
-    SPDLOG_CATCH_STD
+    rotate_();
 }
 
 template <typename Mutex>

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -70,7 +70,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename() {
 }
 
 template <typename Mutex>
-SPDLOG_INLINE void rotating_file_sink<Mutex>::force_rotation() {
+SPDLOG_INLINE void rotating_file_sink<Mutex>::rotate_now() {
     SPDLOG_TRY { rotate_(); }
     SPDLOG_CATCH_STD
 }

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -70,6 +70,12 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename() {
 }
 
 template <typename Mutex>
+SPDLOG_INLINE void rotating_file_sink<Mutex>::force_rotation() {
+    SPDLOG_TRY { rotate_(); }
+    SPDLOG_CATCH_STD
+}
+
+template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -28,7 +28,7 @@ public:
                        const file_event_handlers &event_handlers = {});
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
-    void force_rotation();
+    void rotate_now();
 
 protected:
     void sink_it_(const details::log_msg &msg) override;

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -28,6 +28,7 @@ public:
                        const file_event_handlers &event_handlers = {});
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
+    void force_rotation();
 
 protected:
     void sink_it_(const details::log_msg &msg) override;

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -101,3 +101,22 @@ TEST_CASE("rotating_file_logger3", "[rotating_logger]") {
     REQUIRE_THROWS_AS(spdlog::rotating_logger_mt("logger", basename, max_size, 0),
                       spdlog::spdlog_ex);
 }
+
+// test forced rotation of logs
+TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
+    prepare_logdir();
+    size_t max_size = 1024 * 10;
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(ROTATING_LOG, max_size, 2);
+    auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
+
+    logger->info("Test message - pre-rotation");
+    logger->flush();
+
+    sink->force_rotation();
+
+    logger->info("Test message - post-rotation");
+    logger->flush();
+
+    REQUIRE(get_filesize(ROTATING_LOG) > 0);
+    REQUIRE(get_filesize(ROTATING_LOG ".1") > 0);
+}

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -102,7 +102,7 @@ TEST_CASE("rotating_file_logger3", "[rotating_logger]") {
                       spdlog::spdlog_ex);
 }
 
-// test forced rotation of logs
+// test on-demand rotation of logs
 TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
     prepare_logdir();
     size_t max_size = 1024 * 10;
@@ -112,7 +112,7 @@ TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
     logger->info("Test message - pre-rotation");
     logger->flush();
 
-    sink->force_rotation();
+    sink->rotate_now();
 
     logger->info("Test message - post-rotation");
     logger->flush();

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -106,7 +106,8 @@ TEST_CASE("rotating_file_logger3", "[rotating_logger]") {
 TEST_CASE("rotating_file_logger4", "[rotating_logger]") {
     prepare_logdir();
     size_t max_size = 1024 * 10;
-    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(ROTATING_LOG, max_size, 2);
+    spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2);
     auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
 
     logger->info("Test message - pre-rotation");


### PR DESCRIPTION
This PR adds the ability to force a `rotating_file_sink` to rotate its log files on-demand, in addition to the normal size-based rotation.

This is a feature that I implemented as a custom sink for a project where we needed to be able to manually trigger rotation of logs.  That implementation effectively required that the entire `rotating_file_sink` be copy/pasted (as `rotating_file_sink` is marked as `final`, and `rotate_()` is marked as `private`).

This feels like a generally-useful extension to the standard `rotating_file_sink`, that I thought it worth offering upstream.