### PR TITLE
Added info to the CMakeLists.txt 

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Copyright(c) 2019 spdlog authors Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
+# Make sure to also have the development files for your respective OS!
+# For example, Debian based distributions should install libspdlog-dev.
+
 cmake_minimum_required(VERSION 3.11)
 project(spdlog_examples CXX)
 


### PR DESCRIPTION
I opened an issue regarding adding documentation to the CMakeLists.txt file. #3272 

To recap here, you need to install the proper devel package on your OS in order for the example CMakeLists.txt to work properly. 
I added a comment to the top of the CMakeLists.txt file as an example of what I'm suggesting. 