### PR TITLE
Add missing xchar.h header for fmt > 11.0.2

### DIFF
--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -27,4 +27,5 @@
 #else  // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
     #include <fmt/core.h>
     #include <fmt/format.h>
+    #include <fmt/xchar.h>
 #endif


### PR DESCRIPTION
Using fmt main branch, after the 11.0.2 release, `fmt::basic_format_string` is defined in `xchar.h`. 

Otherwise compile error:
```
spdlog/common.h:369:49: error: no template named 'basic_format_string' in namespace 'fmt'; did you mean 'std::basic_format_string'?
[build]   369 | inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
[build]       |                                                 ^~~~~
[build] /usr/lib/gcc/x86_64-linux-gnu/14/../../../../include/c++/14/format:128:12: note: 'std::basic_format_string' declared here
[build]   128 |     struct basic_format_string
[build]       |            ^
[build] 1 error generated.
```