### PR TITLE
Add missing xchar.h header for fmt > 11.0.2 (v2)

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -53,9 +53,7 @@
     FMT_VERSION >= 80000  // backward compatibility with fmt versions older than 8
     #define SPDLOG_FMT_RUNTIME(format_string) fmt::runtime(format_string)
     #define SPDLOG_FMT_STRING(format_string) FMT_STRING(format_string)
-    #if defined(SPDLOG_WCHAR_FILENAMES) || defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
-        #include <spdlog/fmt/xchar.h>
-    #endif
+    #include <spdlog/fmt/xchar.h>
 #else
     #define SPDLOG_FMT_RUNTIME(format_string) format_string
     #define SPDLOG_FMT_STRING(format_string) format_string


### PR DESCRIPTION
Better version than https://github.com/gabime/spdlog/pull/3274
Fixes https://github.com/gabime/spdlog/issues/3202

NOTE: I cannot conditionally add the header based on the FMT version, as it's stuck to `#define FMT_VERSION 110002`, even though we're passed that version.

Tested fine on `Ubuntu` + `clang` & `gcc`, on both release and debug.  