### PR TITLE
Adding on demand truncation for basic file sinks

### DIFF
--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -28,6 +28,7 @@ SPDLOG_INLINE const filename_t &basic_file_sink<Mutex>::filename() const {
 
 template <typename Mutex>
 SPDLOG_INLINE void basic_file_sink<Mutex>::truncate() {
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
     file_helper_.reopen(true);
 }
 

--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -28,7 +28,6 @@ SPDLOG_INLINE const filename_t &basic_file_sink<Mutex>::filename() const {
 
 template <typename Mutex>
 SPDLOG_INLINE void basic_file_sink<Mutex>::truncate() {
-    file_helper_.close();
     file_helper_.reopen(true);
 }
 

--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -27,6 +27,12 @@ SPDLOG_INLINE const filename_t &basic_file_sink<Mutex>::filename() const {
 }
 
 template <typename Mutex>
+SPDLOG_INLINE void basic_file_sink<Mutex>::truncate() {
+    file_helper_.close();
+    file_helper_.reopen(true);
+}
+
+template <typename Mutex>
 SPDLOG_INLINE void basic_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -23,6 +23,7 @@ public:
                              bool truncate = false,
                              const file_event_handlers &event_handlers = {});
     const filename_t &filename() const;
+    void truncate();
 
 protected:
     void sink_it_(const details::log_msg &msg) override;

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -45,6 +45,26 @@ TEST_CASE("flush_on", "[flush_on]") {
                                     default_eol, default_eol, default_eol));
 }
 
+TEST_CASE("simple_file_logger", "[truncate]") {
+    prepare_logdir();
+    const spdlog::filename_t filename = SPDLOG_FILENAME_T(SIMPLE_LOG);
+    const bool truncate = true;
+    const auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>(filename, truncate);
+    const auto logger = std::make_shared<spdlog::logger>("simple_file_logger", sink);
+
+    logger->info("Test message {}", 3.14);
+    logger->info("Test message {}", 2.71);
+    logger->flush();
+    REQUIRE(count_lines(SIMPLE_LOG) == 2);
+    
+    sink->truncate();
+    REQUIRE(count_lines(SIMPLE_LOG) == 0);
+
+    logger->info("Test message {}", 6.28);
+    logger->flush();
+    REQUIRE(count_lines(SIMPLE_LOG) == 1);
+}
+
 TEST_CASE("rotating_file_logger1", "[rotating_logger]") {
     prepare_logdir();
     size_t max_size = 1024 * 10;


### PR DESCRIPTION
Sometimes log rotation can be overkill. There are use cases where it is sufficient to simply truncate without the need for managing rotated logs or archiving. To address this, I have introduced a feature that allows a basic file sink to truncate its log file on demand.