### PR TITLE
Adding lock to rotate_now()

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -71,6 +71,7 @@ SPDLOG_INLINE filename_t rotating_file_sink<Mutex>::filename() {
 
 template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::rotate_now() {
+    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
     rotate_();
 }
 


### PR DESCRIPTION
This change fixes a missing lock in the recently introduced rotate_now() of rotating file sinks.