### PR TITLE
SPDLOG_LEVEL_NAMES, comment use string_view_literals

### DIFF
--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -104,6 +104,13 @@
 //
 // #define SPDLOG_LEVEL_NAMES { "MY TRACE", "MY DEBUG", "MY INFO", "MY WARNING", "MY ERROR", "MY
 // CRITICAL", "OFF" }
+//
+// Starting with C++17 use string_view_literals:
+//
+// #include <string_view>
+// using namespace std::string_view_literals;
+// #define SPDLOG_LEVEL_NAMES { "MY TRACE"sv, "MY DEBUG"sv, "MY INFO"sv, "MY WARNING"sv, "MY ERROR"sv, "MY
+// CRITICAL"sv, "OFF"sv }
 ///////////////////////////////////////////////////////////////////////////////
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/spdlog/tweakme.h
+++ b/include/spdlog/tweakme.h
@@ -105,7 +105,7 @@
 // #define SPDLOG_LEVEL_NAMES { "MY TRACE", "MY DEBUG", "MY INFO", "MY WARNING", "MY ERROR", "MY
 // CRITICAL", "OFF" }
 //
-// Starting with C++17 use string_view_literals:
+// For C++17 use string_view_literals:
 //
 // #include <string_view>
 // using namespace std::string_view_literals;


### PR DESCRIPTION
fixes #3287 
fixes #3233