### PR TITLE
Support custom asynchronous logger and reuse thread pool

### DIFF
--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -19,14 +19,6 @@
 
 namespace spdlog {
 
-// Async overflow policy - block by default.
-enum class async_overflow_policy {
-    block,           // Block until message can be enqueued
-    overrun_oldest,  // Discard oldest message in the queue if full when trying to
-                     // add new item.
-    discard_new      // Discard new message if the queue is full when trying to add new item.
-};
-
 namespace details {
 class thread_pool;
 }

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -15,6 +15,7 @@
 // destructing..
 
 #include <spdlog/logger.h>
+#include <spdlog/details/backend_worker.h>
 
 namespace spdlog {
 
@@ -30,10 +31,8 @@ namespace details {
 class thread_pool;
 }
 
-class SPDLOG_API async_logger final : public std::enable_shared_from_this<async_logger>,
-                                      public logger {
-    friend class details::thread_pool;
-
+class SPDLOG_API async_logger final : public logger,
+                                      public details::backend_worker {
 public:
     template <typename It>
     async_logger(std::string logger_name,
@@ -60,8 +59,8 @@ public:
 protected:
     void sink_it_(const details::log_msg &msg) override;
     void flush_() override;
-    void backend_sink_it_(const details::log_msg &incoming_log_msg);
-    void backend_flush_();
+    void backend_sink_it_(const details::log_msg &incoming_log_msg) override;
+    void backend_flush_() override;
 
 private:
     std::weak_ptr<details::thread_pool> thread_pool_;

--- a/include/spdlog/details/backend_worker.h
+++ b/include/spdlog/details/backend_worker.h
@@ -1,0 +1,22 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+
+namespace spdlog {
+
+namespace details {
+
+class thread_pool;
+
+class backend_worker : public std::enable_shared_from_this<backend_worker> {
+    friend class thread_pool;
+
+protected:
+    virtual void backend_sink_it_(const details::log_msg &msg) = 0;
+    virtual void backend_flush_() = 0;
+};
+
+}  // namespace details
+}  // namespace spdlog

--- a/include/spdlog/details/backend_worker.h
+++ b/include/spdlog/details/backend_worker.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
-
 namespace spdlog {
+// Async overflow policy - block by default.
+enum class async_overflow_policy {
+    block,           // Block until message can be enqueued
+    overrun_oldest,  // Discard oldest message in the queue if full when trying to
+                     // add new item.
+    discard_new      // Discard new message if the queue is full when trying to add new item.
+};
 
 namespace details {
-
 class thread_pool;
 
 class backend_worker : public std::enable_shared_from_this<backend_worker> {

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -55,14 +55,14 @@ SPDLOG_INLINE thread_pool::~thread_pool() {
     SPDLOG_CATCH_STD
 }
 
-void SPDLOG_INLINE thread_pool::post_log(async_logger_ptr &&worker_ptr,
+void SPDLOG_INLINE thread_pool::post_log(backend_worker_ptr &&worker_ptr,
                                          const details::log_msg &msg,
                                          async_overflow_policy overflow_policy) {
     async_msg async_m(std::move(worker_ptr), async_msg_type::log, msg);
     post_async_msg_(std::move(async_m), overflow_policy);
 }
 
-void SPDLOG_INLINE thread_pool::post_flush(async_logger_ptr &&worker_ptr,
+void SPDLOG_INLINE thread_pool::post_flush(backend_worker_ptr &&worker_ptr,
                                            async_overflow_policy overflow_policy) {
     post_async_msg_(async_msg(std::move(worker_ptr), async_msg_type::flush), overflow_policy);
 }

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -14,11 +14,12 @@
 #include <vector>
 
 namespace spdlog {
-class async_logger;
 
 namespace details {
 
-using async_logger_ptr = std::shared_ptr<spdlog::async_logger>;
+class backend_worker;
+
+using backend_worker_ptr = std::shared_ptr<backend_worker>;
 
 enum class async_msg_type { log, flush, terminate };
 
@@ -26,7 +27,7 @@ enum class async_msg_type { log, flush, terminate };
 // Movable only. should never be copied
 struct async_msg : log_msg_buffer {
     async_msg_type msg_type{async_msg_type::log};
-    async_logger_ptr worker_ptr;
+    backend_worker_ptr worker_ptr;
 
     async_msg() = default;
     ~async_msg() = default;
@@ -53,12 +54,12 @@ struct async_msg : log_msg_buffer {
 #endif
 
     // construct from log_msg with given type
-    async_msg(async_logger_ptr &&worker, async_msg_type the_type, const details::log_msg &m)
+    async_msg(backend_worker_ptr &&worker, async_msg_type the_type, const details::log_msg &m)
         : log_msg_buffer{m},
           msg_type{the_type},
           worker_ptr{std::move(worker)} {}
 
-    async_msg(async_logger_ptr &&worker, async_msg_type the_type)
+    async_msg(backend_worker_ptr &&worker, async_msg_type the_type)
         : log_msg_buffer{},
           msg_type{the_type},
           worker_ptr{std::move(worker)} {}
@@ -85,10 +86,10 @@ public:
     thread_pool(const thread_pool &) = delete;
     thread_pool &operator=(thread_pool &&) = delete;
 
-    void post_log(async_logger_ptr &&worker_ptr,
+    void post_log(backend_worker_ptr &&worker_ptr,
                   const details::log_msg &msg,
                   async_overflow_policy overflow_policy);
-    void post_flush(async_logger_ptr &&worker_ptr, async_overflow_policy overflow_policy);
+    void post_flush(backend_worker_ptr &&worker_ptr, async_overflow_policy overflow_policy);
     size_t overrun_counter();
     void reset_overrun_counter();
     size_t discard_counter();


### PR DESCRIPTION
In the current version of spdlog, customizing async_logger and reusing spdlog::thread_pool becomes difficult due to the following limitations:

1. The `post_log` and `post_flush` parameters of the `spdlog::thread_pool` class are limited to the `spdlog::async_logger` type, which lacks flexibility.

2. `spdlog::async_logger` is a `final` class and cannot be inherited or customized. This further limits the extensibility and reuse capabilities of the logger.


**Changes**

- Abstract backend worker interface

    1. Abstract the `backend_sink_it_` and `backend_flush__` interfaces into a new class `backend_worker`.

    2. The `spdlog::async_logger` class inherits and implements `backend_worker`, and is no longer directly bound to the backend worker interface.

- Improve the versatility of `spdlog::thread_pool`

    1. Modify the parameter types of `post_log` and `post_flush` from `spdlog::async_logger` to the general `backend_worker` type.

    2. Allow collaboration with other `backend_worker` implementations to improve the reusability of `thread_pool`.

**Advantages**

1. Support custom asynchronous logger

    Users can easily create custom asynchronous logger by inheriting the `spdlog::logger` class and the `backend_worker` class, without being restricted by the fixed implementation of `spdlog::async_logger`.

2. Enhance the reusability of spdlog::thread_pool

    `spdlog::thread_pool` is no longer limited to collaboration with `spdlog::async_logger`, but can cooperate with more implementation classes of the `backend_worker` class, significantly enhancing versatility and extensibility.

3. This shouldn't be too disruptive to the original code structure, spdlog::async_logger is still the final class and can still be passed as a backend worker to spdlog::thread_pool .
