### PR TITLE
Implement customized rotation filename

### DIFF
--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -30,11 +30,13 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
     std::size_t max_size,
     std::size_t max_files,
     bool rotate_on_open,
-    const file_event_handlers &event_handlers)
+    const file_event_handlers &event_handlers,
+    std::function<filename_t(const filename_t &filename, std::size_t index)> rotation_file_format)
     : base_filename_(std::move(base_filename)),
       max_size_(max_size),
       max_files_(max_files),
-      file_helper_{event_handlers} {
+      file_helper_{event_handlers},
+      rotation_file_format_(std::move(rotation_file_format)) {
     if (max_size == 0) {
         throw_spdlog_ex("rotating sink constructor: max_size arg cannot be zero");
     }
@@ -48,12 +50,6 @@ SPDLOG_INLINE rotating_file_sink<Mutex>::rotating_file_sink(
         rotate_();
         current_size_ = 0;
     }
-}
-
-template <typename Mutex>
-SPDLOG_INLINE void rotating_file_sink<Mutex>::set_rotate_filename_format(std::function<filename_t(const filename_t &filename, std::size_t index)> rotation_file_format) {
-    assert(!rotation_file_format_);
-    rotation_file_format_ = std::move(rotation_file_format);
 }
 
 template <typename Mutex>

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -22,21 +22,18 @@ namespace sinks {
 template <typename Mutex>
 class rotating_file_sink final : public base_sink<Mutex> {
 public:
+    // @param rotation_file_format: the file format for rotation files. 
+    // NOTE: If [index] is 0, [filename] is expected to return.
     rotating_file_sink(filename_t base_filename,
                        std::size_t max_size,
                        std::size_t max_files,
                        bool rotate_on_open = false,
-                       const file_event_handlers &event_handlers = {});
+                       const file_event_handlers &event_handlers = {},
+                       std::function<filename_t(const filename_t &filename, std::size_t index)> rotation_file_format = {});
     // Default function to get rotation filename by base filename and rotation file index.
     static filename_t calc_filename(const filename_t &filename, std::size_t index);
     filename_t filename();
     void rotate_now();
-
-    // Set the file format for rotation files.
-    // NOTE:
-    // 1. The format function is supposed to be called only once, otherwise check failure.
-    // 2. If [index] is 0, [filename] is expected to return.
-    void set_rotate_filename_format(std::function<filename_t(const filename_t &filename, std::size_t index)> rotation_file_format);
 
 protected:
     void sink_it_(const details::log_msg &msg) override;

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -153,7 +153,7 @@ TEST_CASE("rotating_file_logger5", "[rotating_logger]") {
             return filename;
         }
         const auto old_fname = spdlog::sinks::rotating_file_sink_st::calc_filename(filename, index);
-        return old_fname + ".test_suffix";
+        return spdlog::fmt_lib::format("{}.test_suffix", old_fname);
     });
     auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
 

--- a/tests/test_file_logging.cpp
+++ b/tests/test_file_logging.cpp
@@ -147,14 +147,17 @@ TEST_CASE("rotating_file_logger5", "[rotating_logger]") {
     prepare_logdir();
     size_t max_size = 1024 * 10;
     spdlog::filename_t basename = SPDLOG_FILENAME_T(ROTATING_LOG);
-    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(basename, max_size, 2);
-    sink->set_rotate_filename_format([](const spdlog::filename_t &filename, std::size_t index) {
+    auto rotation_file_format = [](const spdlog::filename_t &filename, std::size_t index) -> spdlog::filename_t {
         if (index == 0u) {
             return filename;
         }
         const auto old_fname = spdlog::sinks::rotating_file_sink_st::calc_filename(filename, index);
         return spdlog::fmt_lib::format("{}.test_suffix", old_fname);
-    });
+    };
+    auto sink = std::make_shared<spdlog::sinks::rotating_file_sink_st>(
+        basename, max_size, /*max_files=*/2, /*rotate_on_open=*/false,
+        /*event_handlers=*/spdlog::file_event_handlers{},
+        /*rotation_file_format=*/std::move(rotation_file_format));
     auto logger = std::make_shared<spdlog::logger>("rotating_sink_logger", sink);
 
     logger->info("Test message - pre-rotation");


### PR DESCRIPTION
Address issues:
- https://github.com/gabime/spdlog/issues/3295
- https://github.com/gabime/spdlog/issues/2612
- https://github.com/gabime/spdlog/issues/2491

This PR allows application to customize their own rotation log filename via setting a customized function.

~~Implementation alternative considered:
Pass the functor as an extra argument for constructor
Since in almost all cases, default rotation naming function is used, I think it's better to have an optional setter function.~~

Update: In the PR, I pass a formatter function from application to decide the output rotation filename.