### PR TITLE
fix: update `to_string_view` function for fmt 11.1

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -365,10 +365,17 @@ SPDLOG_CONSTEXPR_FUNC spdlog::wstring_view_t to_string_view(spdlog::wstring_view
 #endif
 
 #ifndef SPDLOG_USE_STD_FORMAT
+#if FMT_VERSION >= 110100
+template <typename T, typename... Args>
+inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_arg<T> fmt) {
+    return fmt;
+}
+#else
 template <typename T, typename... Args>
 inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
     return fmt;
 }
+#endif
 #elif __cpp_lib_format >= 202207L
 template <typename T, typename... Args>
 SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(


### PR DESCRIPTION
update `to_string_view` function for fmt 11.1

```
/tmp/spdlog-20241225-25576-12pt7n/spdlog-1.15.0/include/spdlog/common.h:369:54: error: no template named 'basic_format_string' in namespace 'fmt'; did you mean 'basic_format_arg'?
  369 | inline fmt::basic_string_view<Tasic_sfmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
      |                                                 ~~~~~^~~~~~~~~~~~~~~~~~~
      |                                                      basic_format_arg
/opt/homebrew/include/fmt/base.h:2428:35: note: 'basic_format_arg' declared here
 2428 | template <typename Context> class basic_format_arg {
      |                                   ^
```

relates to https://github.com/Homebrew/homebrew-core/pull/202442