### PR TITLE
fix: Compatibility with external fmtlib 11.1.1

### DIFF
--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -27,4 +27,5 @@
 #else  // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
     #include <fmt/core.h>
     #include <fmt/format.h>
+    #include <fmt/xchar.h>
 #endif


### PR DESCRIPTION
Include fmtlib's `xchar` header to include `fmt::basic_format_string`. Otherwise, compilation with an external fmtlib 11.1.1 fails with

```
In file included from include/spdlog/spdlog.h:12:
include/spdlog/common.h:369:49: error: no template named 'basic_format_string' in namespace 'fmt'; did you mean 'std::basic_format_string'?
  369 | inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
      |                                                 ^~~~~
```