### PR TITLE
fix: remove unused to_string_view overload in fmt >= 11.1

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -364,19 +364,7 @@ SPDLOG_CONSTEXPR_FUNC spdlog::wstring_view_t to_string_view(spdlog::wstring_view
 }
 #endif
 
-#ifndef SPDLOG_USE_STD_FORMAT
-#if FMT_VERSION >= 110100
-template <typename T, typename... Args>
-inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_arg<T> fmt) {
-    return fmt;
-}
-#else
-template <typename T, typename... Args>
-inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt) {
-    return fmt;
-}
-#endif
-#elif __cpp_lib_format >= 202207L
+#if defined(SPDLOG_USE_STD_FORMAT) &&  __cpp_lib_format >= 202207L
 template <typename T, typename... Args>
 SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(
     std::basic_format_string<T, Args...> fmt) SPDLOG_NOEXCEPT {


### PR DESCRIPTION
This overload was added in #3301 based on a compiler error quickfix suggestion.

fmt's  `fmt::format_string` type [has had an implicit conversion operator](https://github.com/fmtlib/fmt/blob/3f864a4505426ed19e5ba55261af37669a123e4c/include/fmt/base.h#L2738C3-L2738C72) to `fmt::string_view` since fmt 8.0 ([introduced here](https://github.com/fmtlib/fmt/commit/8d70c0edab4b2f68f52ab0644bab8e80dee7a604#diff-f5b9e34d142700358618faa7363cd41bc5662525a82c49f7e6e9dfa2ec8bfc93R2930)).

Since [there is already an overload](https://github.com/gabime/spdlog/blob/7f8060d5b280eac9786f92ac74d263cc8359c5ed/include/spdlog/common.h#L350-353) for `to_string_view()` that no-ops `spdlog::string_view_t` (which is typedef'd to `fmt::string_view` when using fmt), we don't need any other overloads for `format_string`.