### PR TITLE
Enabled bin_to_hex utest for stdformat, fixed std::formatter

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,13 +26,13 @@ jobs:
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=11 \
-            -DSPDLOG_BUILD_EXAMPLE=${{ matrix.config.BUILD_EXAMPLE }} `
-            -DSPDLOG_BUILD_EXAMPLE_HO=${{ matrix.config.BUILD_EXAMPLE }} `
+            -DSPDLOG_BUILD_EXAMPLE=${{ matrix.config.BUILD_EXAMPLE }} \
+            -DSPDLOG_BUILD_EXAMPLE_HO=${{ matrix.config.BUILD_EXAMPLE }} \
             -DSPDLOG_BUILD_WARNINGS=ON \
             -DSPDLOG_BUILD_BENCH=OFF \
             -DSPDLOG_BUILD_TESTS=ON \
             -DSPDLOG_BUILD_TESTS_HO=OFF \
-            -DSPDLOG_USE_STD_FORMAT=${{ matrix.config.USE_STD_FORMAT }} `
+            -DSPDLOG_USE_STD_FORMAT=${{ matrix.config.USE_STD_FORMAT }} \
             -DSPDLOG_SANITIZE_ADDRESS=OFF
           make -j 4
           ctest -j 4 --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,15 @@ jobs:
   build:
     runs-on: macOS-latest
     name: "macOS Clang (C++11, Release)"
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+            - USE_STD_FORMAT: 'ON'
+              BUILD_EXAMPLE: 'OFF'
+            - USE_STD_FORMAT: 'OFF'
+              BUILD_EXAMPLE: 'ON'
+              
     steps:
       - uses: actions/checkout@v4
       - name: Build
@@ -17,12 +26,13 @@ jobs:
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CXX_STANDARD=11 \
-            -DSPDLOG_BUILD_EXAMPLE=ON \
-            -DSPDLOG_BUILD_EXAMPLE_HO=ON \
+            -DSPDLOG_BUILD_EXAMPLE=${{ matrix.config.BUILD_EXAMPLE }} `
+            -DSPDLOG_BUILD_EXAMPLE_HO=${{ matrix.config.BUILD_EXAMPLE }} `
             -DSPDLOG_BUILD_WARNINGS=ON \
             -DSPDLOG_BUILD_BENCH=OFF \
             -DSPDLOG_BUILD_TESTS=ON \
             -DSPDLOG_BUILD_TESTS_HO=OFF \
+            -DSPDLOG_USE_STD_FORMAT=${{ matrix.config.USE_STD_FORMAT }} `
             -DSPDLOG_SANITIZE_ADDRESS=OFF
           make -j 4
           ctest -j 4 --output-on-failure

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -102,7 +102,7 @@ namespace
 
 template <typename T>
 struct formatter<spdlog::details::dump_info<T>, char> {
-    const char delimiter = ' ';
+    char delimiter = ' ';
     bool put_newlines = true;
     bool put_delimiters = true;
     bool use_uppercase = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,7 +48,8 @@ set(SPDLOG_UTESTS_SOURCES
     test_cfg.cpp
     test_time_point.cpp
     test_stopwatch.cpp
-    test_circular_q.cpp)
+    test_circular_q.cpp
+    test_bin_to_hex.cpp)
 
 if(NOT SPDLOG_NO_EXCEPTIONS)
     list(APPEND SPDLOG_UTESTS_SOURCES test_errors.cpp)
@@ -56,10 +57,6 @@ endif()
 
 if(systemd_FOUND)
     list(APPEND SPDLOG_UTESTS_SOURCES test_systemd.cpp)
-endif()
-
-if(NOT SPDLOG_USE_STD_FORMAT)
-    list(APPEND SPDLOG_UTESTS_SOURCES test_bin_to_hex.cpp)
 endif()
 
 enable_testing()

--- a/tests/test_custom_callbacks.cpp
+++ b/tests/test_custom_callbacks.cpp
@@ -16,7 +16,8 @@ TEST_CASE("custom_callback_logger", "[custom_callback_logger]") {
             spdlog::memory_buf_t formatted;
             formatter.format(msg, formatted);
             auto eol_len = strlen(spdlog::details::os::default_eol);
-            lines.emplace_back(formatted.begin(), formatted.end() - eol_len);
+            using diff_t = typename std::iterator_traits<decltype(formatted.end())>::difference_type; 
+            lines.emplace_back(formatted.begin(), formatted.end() - static_cast<diff_t>(eol_len));
         });
     std::shared_ptr<spdlog::sinks::test_sink_st> test_sink(new spdlog::sinks::test_sink_st);
 

--- a/tests/test_sink.h
+++ b/tests/test_sink.h
@@ -47,8 +47,9 @@ protected:
         base_sink<Mutex>::formatter_->format(msg, formatted);
         // save the line without the eol
         auto eol_len = strlen(details::os::default_eol);
+        using diff_t = typename std::iterator_traits<typename memory_buf_t::iterator>::difference_type; 
         if (lines_.size() < lines_to_save) {
-            lines_.emplace_back(formatted.begin(), formatted.end() - eol_len);
+            lines_.emplace_back(formatted.begin(), formatted.end() - static_cast<diff_t>(eol_len));
         }
         msg_counter_++;
         std::this_thread::sleep_for(delay_);

--- a/tests/test_sink.h
+++ b/tests/test_sink.h
@@ -47,7 +47,7 @@ protected:
         base_sink<Mutex>::formatter_->format(msg, formatted);
         // save the line without the eol
         auto eol_len = strlen(details::os::default_eol);
-        using diff_t = typename std::iterator_traits<typename memory_buf_t::iterator>::difference_type; 
+        using diff_t = typename std::iterator_traits<decltype(formatted.end())>::difference_type; 
         if (lines_.size() < lines_to_save) {
             lines_.emplace_back(formatted.begin(), formatted.end() - static_cast<diff_t>(eol_len));
         }


### PR DESCRIPTION
Turns out it's not hard to fix bin_to_hex to be compatible with std::format - the std::formatter overload just has to be copyable.

Made the fix, and enabled the utest for bin_to_hex in Mac CI for verification that fix works