### PR TITLE
Support custom environment variables for load_env_levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,9 @@ void android_example()
 int main (int argc, char *argv[])
 {
     spdlog::cfg::load_env_levels();
+    // or specify the env variable name:
+    // MYAPP_LEVEL=info,mylogger=trace && ./example
+    // spdlog::cfg::load_env_levels("MYAPP_LEVEL");
     // or from the command line:
     // ./example SPDLOG_LEVEL=info,mylogger=trace
     // #include "spdlog/cfg/argv.h" // for loading levels from argv

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -148,6 +148,9 @@ void load_levels_example() {
     // Set the log level to "info" and mylogger to "trace":
     // SPDLOG_LEVEL=info,mylogger=trace && ./example
     spdlog::cfg::load_env_levels();
+    // or specify the env variable name:
+    // MYAPP_LEVEL=info,mylogger=trace && ./example
+    // spdlog::cfg::load_env_levels("MYAPP_LEVEL");
     // or from command line:
     // ./example SPDLOG_LEVEL=info,mylogger=trace
     // #include "spdlog/cfg/argv.h" // for loading levels from argv

--- a/include/spdlog/cfg/env.h
+++ b/include/spdlog/cfg/env.h
@@ -25,8 +25,8 @@
 
 namespace spdlog {
 namespace cfg {
-inline void load_env_levels() {
-    auto env_val = details::os::getenv("SPDLOG_LEVEL");
+inline void load_env_levels(const char* var = "SPDLOG_LEVEL") {
+    auto env_val = details::os::getenv(var);
     if (!env_val.empty()) {
         helpers::load_levels(env_val);
     }

--- a/tests/test_cfg.cpp
+++ b/tests/test_cfg.cpp
@@ -19,6 +19,15 @@ TEST_CASE("env", "[cfg]") {
 #endif
     load_env_levels();
     REQUIRE(l1->level() == spdlog::level::warn);
+
+#ifdef CATCH_PLATFORM_WINDOWS
+    _putenv_s("MYAPP_LEVEL", "l1=trace");
+#else
+    setenv("MYAPP_LEVEL", "l1=trace", 1);
+#endif
+    load_env_levels("MYAPP_LEVEL");
+    REQUIRE(l1->level() == spdlog::level::trace);
+
     spdlog::set_default_logger(spdlog::create<test_sink_st>("cfg-default"));
     REQUIRE(spdlog::default_logger()->level() == spdlog::level::info);
 }


### PR DESCRIPTION
SPDLOG_LEVEL is currently supported to control log levels via load_env_levels.

This patch adds support for other environment variable names, such as MYAPP_LEVEL, for load_env_levels.