### PR TITLE
Revert "fix: Compatibility with external fmtlib 11.1.1 (#3312)"

### DIFF
--- a/include/spdlog/fmt/fmt.h
+++ b/include/spdlog/fmt/fmt.h
@@ -27,5 +27,4 @@
 #else  // SPDLOG_FMT_EXTERNAL is defined - use external fmtlib
     #include <fmt/core.h>
     #include <fmt/format.h>
-    #include <fmt/xchar.h>
 #endif


### PR DESCRIPTION
This reverts commit 7f8060d5b280eac9786f92ac74d263cc8359c5ed.

It was added to fix compatibility with fmt 11.1.1, but a different fix was already added in previous commit (276ee5f5c0eb13626bd367b006ace5eae9526d8a) and the problematic function was removed in next commit (96a8f6250cbf4e8c76387c614f666710a2fa9bad) so it should not be necessary to include fmt/xchar.h unconditionally.

This include was deemed expensive (https://github.com/gabime/spdlog/pull/3277#issuecomment-2509134270) if not needed and fails to compile on some embedded toolchains with missing/broken wchar_t support :(