### PR TITLE
Fix zformatter on Apple and POSIX.1-2024 conforming platforms

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -267,7 +267,8 @@ SPDLOG_INLINE int utc_minutes_offset(const std::tm &tm) {
 
     #if defined(sun) || defined(__sun) || defined(_AIX) || \
         (defined(__NEWLIB__) && !defined(__TM_GMTOFF)) ||  \
-        (!defined(_BSD_SOURCE) && !defined(_GNU_SOURCE))
+        (!defined(__APPLE__) && !defined(_BSD_SOURCE) && !defined(_GNU_SOURCE) && \
+            (!defined(_POSIX_VERSION) || (_POSIX_VERSION < 202405L)))
     // 'tm_gmtoff' field is BSD extension and it's missing on SunOS/Solaris
     struct helper {
         static long int calculate_gmt_offset(const std::tm &localtm = details::os::localtime(),

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -1,6 +1,8 @@
 #include "includes.h"
 #include "test_sink.h"
 
+#include <chrono>
+
 using spdlog::memory_buf_t;
 using spdlog::details::to_string_view;
 
@@ -16,6 +18,21 @@ static std::string log_to_str(const std::string &msg, const Args &...args) {
         std::unique_ptr<spdlog::formatter>(new spdlog::pattern_formatter(args...)));
 
     oss_logger.info(msg);
+    return oss.str();
+}
+
+// log to str and return it
+template <typename... Args>
+static std::string log_to_str(spdlog::log_clock::time_point log_time, const std::string &msg, const Args &...args) {
+    std::ostringstream oss;
+    auto oss_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+    spdlog::logger oss_logger("pattern_tester", oss_sink);
+    oss_logger.set_level(spdlog::level::info);
+
+    oss_logger.set_formatter(
+        std::unique_ptr<spdlog::formatter>(new spdlog::pattern_formatter(args...)));
+
+    oss_logger.log(log_time, {}, spdlog::level::info, msg);
     return oss.str();
 }
 
@@ -56,6 +73,15 @@ TEST_CASE("date MM/DD/YY ", "[pattern_formatter]") {
         << " Some message\n";
     REQUIRE(log_to_str("Some message", "%D %v", spdlog::pattern_time_type::local, "\n") ==
             oss.str());
+}
+
+TEST_CASE("GMT offset ", "[pattern_formatter]") {
+    using namespace std::chrono_literals;
+    const auto now = std::chrono::system_clock::now();
+    const auto yesterday = now - 24h;
+
+    REQUIRE(log_to_str(yesterday, "Some message", "%z", spdlog::pattern_time_type::utc) ==
+            "+00:00\n");
 }
 
 TEST_CASE("color range test1", "[pattern_formatter]") {


### PR DESCRIPTION
Due to a missing test (#3352), Apple and POSIX.1-2024 conforming platforms choose a buggy workaround in `utc_minutes_offset()` (#3351).

This PR adds a test that demonstrate the bug and fixes it for Apple and POSIX.1-2024 by adapting the feature test.