### PR TITLE
Update CMake minimum version required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright(c) 2019-present by spdlog authors.
 # Distributed under the MIT License (http://opensource.org/licenses/MIT)
 # ---------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.23)
 include(cmake/utils.cmake)
 include(cmake/ide.cmake)
 spdlog_extract_version()


### PR DESCRIPTION
FILE_SET functionality was introduced in CMake version 3.23.

https://cmake.org/cmake/help/latest/command/target_sources.html