### PR TITLE
dup_filter_sink: Add option to use log level of duplicated messages for notification message

### DIFF
--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -45,7 +45,7 @@ public:
                              bool use_message_level_for_notification = false)
         : max_skip_duration_{max_skip_duration},
           log_level_{notification_level},
-          use_message_level_for_notification_(use_message_level_for_notification) {}
+          use_message_level_for_notification_{use_message_level_for_notification} {}
 
 protected:
     std::chrono::microseconds max_skip_duration_;

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -59,6 +59,9 @@ protected:
         bool filtered = filter_(msg);
         if (!filtered) {
             skip_counter_ += 1;
+            if (use_message_level_for_notification_) {
+                log_level_ = msg.level;
+            }
             return;
         }
 
@@ -68,8 +71,7 @@ protected:
             auto msg_size = ::snprintf(buf, sizeof(buf), "Skipped %u duplicate messages..",
                                        static_cast<unsigned>(skip_counter_));
             if (msg_size > 0 && static_cast<size_t>(msg_size) < sizeof(buf)) {
-                details::log_msg skipped_msg{msg.source, msg.logger_name,
-                                             use_message_level_for_notification_ ? msg.level : log_level_,
+                details::log_msg skipped_msg{msg.source, msg.logger_name, log_level_,
                                              string_view_t{buf, static_cast<size_t>(msg_size)}};
                 dist_sink<Mutex>::sink_it_(skipped_msg);
             }

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -41,9 +41,11 @@ class dup_filter_sink : public dist_sink<Mutex> {
 public:
     template <class Rep, class Period>
     explicit dup_filter_sink(std::chrono::duration<Rep, Period> max_skip_duration,
-                             level::level_enum notification_level = level::info)
+                             level::level_enum notification_level = level::info,
+                             bool use_message_level_for_notification = false)
         : max_skip_duration_{max_skip_duration},
-          log_level_{notification_level} {}
+          log_level_{notification_level},
+          use_message_level_for_notification_(use_message_level_for_notification) {}
 
 protected:
     std::chrono::microseconds max_skip_duration_;
@@ -51,6 +53,7 @@ protected:
     std::string last_msg_payload_;
     size_t skip_counter_ = 0;
     level::level_enum log_level_;
+    bool use_message_level_for_notification_;
 
     void sink_it_(const details::log_msg &msg) override {
         bool filtered = filter_(msg);
@@ -65,7 +68,8 @@ protected:
             auto msg_size = ::snprintf(buf, sizeof(buf), "Skipped %u duplicate messages..",
                                        static_cast<unsigned>(skip_counter_));
             if (msg_size > 0 && static_cast<size_t>(msg_size) < sizeof(buf)) {
-                details::log_msg skipped_msg{msg.source, msg.logger_name, log_level_,
+                details::log_msg skipped_msg{msg.source, msg.logger_name,
+                                             use_message_level_for_notification_ ? msg.level : log_level_,
                                              string_view_t{buf, static_cast<size_t>(msg_size)}};
                 dist_sink<Mutex>::sink_it_(skipped_msg);
             }


### PR DESCRIPTION
In current implementation of dup_filter_sink, we set it up with some log level (info by default) and all notification messages use this log level.
There are some problems with that approach:
For example, I have file sink that has log level info (it ignores debug messages). When we get debug duplicates - it will generate [info] notification about it, and this notification will get to my file, even though it is information about debug messages that I would like to discard. I have added option to make it "dynamic" and fix this problem. So, for debug duplicates I will get debug notification, for error duplicates I will get error notification, and so on.

To not break any existing code, I have added third argument to the constructor, and it is false by default. So, behaviour will remain same unless third argument will be explicitly specified. I understand that second argument does not have any sense if we specify "use_message_level_for_notification" as true, however, this is the only backward-compatible approach I could make up.