### PR TITLE
Fix warning C4530

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ endif ()
 # ---------------------------------------------------------------------------------------
 if (SPDLOG_NO_EXCEPTIONS)
     if (NOT SPDLOG_FMT_EXTERNAL AND NOT SPDLOG_FMT_EXTERNAL_HO)
-        target_compile_definitions(spdlog PUBLIC FMT_EXCEPTIONS=0)
+        target_compile_definitions(spdlog PUBLIC FMT_USE_EXCEPTIONS=0)
     endif ()
     if (NOT MSVC)
         target_compile_options(spdlog PRIVATE -fno-exceptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ if (SPDLOG_NO_EXCEPTIONS)
         target_compile_options(spdlog PRIVATE -fno-exceptions)
     else ()
         target_compile_options(spdlog PRIVATE /EHs-c-)
+        target_compile_definitions(spdlog PRIVATE _HAS_EXCEPTIONS=0)
     endif ()
 endif ()
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
C4530 is because when using `/EHs-c-`, std::chrono and std::string stuff still attempts to use try-catch. Defining `_HAS_EXCEPTIONS=0` can prevent MSVC STL from using try-catch code, bundled fmt is also affected by this：
fmt/bundled/base.h
![image](https://github.com/user-attachments/assets/c1aad050-ed5c-43f7-aade-531d24abb348)