### PR TITLE
Fix: Missing error handling when a version component is not found

### DIFF
--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -15,3 +15,8 @@ with open(config_h, 'r') as fp:
             data[m.group(1)] = int(m.group(2))
 
 print(f"{data['MAJOR']}.{data['MINOR']}.{data['PATCH']}")
+if not all(data.values()):
+    raise ValueError(
+        f"Could not find all version components in {config_h}. Found: {data}"
+    )
+


### PR DESCRIPTION
The code assumes that `MAJOR`, `MINOR`, and `PATCH` are always found in the `version.h` file. If one of these definitions is missing, a `KeyError` will be raised when trying to access `data['MAJOR']`, `data['MINOR']`, or `data['PATCH']` during the final print statement.

Applied fixes:
--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -15,4 +15,9 @@
         if m:
             data[m.group(1)] = int(m.group(2))
 
+if not all(data.values()):
+    raise ValueError(
+        f"Could not find all version components in {config_h}. Found: {data}"
+    )
+
 print(f"{data['MAJOR']}.{data['MINOR']}.{data['PATCH']}")