### PR TITLE
Remove unnecessary and inconsistent "final" from color sinks

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -40,7 +40,7 @@ public:
 
     void log(const details::log_msg &msg) override;
     void flush() override;
-    void set_pattern(const std::string &pattern) final override;
+    void set_pattern(const std::string &pattern) override;
     void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
 
     // Formatting codes

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -31,10 +31,10 @@ public:
 
     // change the color for the given level
     void set_color(level::level_enum level, std::uint16_t color);
-    void log(const details::log_msg &msg) final override;
-    void flush() final override;
-    void set_pattern(const std::string &pattern) override final;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override final;
+    void log(const details::log_msg &msg) override;
+    void flush() override;
+    void set_pattern(const std::string &pattern) override;
+    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
     void set_color_mode(color_mode mode);
 
 protected:


### PR DESCRIPTION
The use of "final" differed between ansicolor_sink and wincolor_sink, resulting in the code inheriting from std{err,out}_color_sink classes, which are defined as one or the other on different platforms, being able to override most of the functions under non-Windows platforms, but not under Windows.

This seems gratuitously inconsistent, so just remove all "final" keywords from both classes, especially because there doesn't seem any good reason to use it and the other sink classes don't use it (with the exception of base_sink, which is special).

This also incidentally fixes using "final override" in most places but "override final" in wincolor_sink.h.

Fixes #3429.