### PR TITLE
Added timeout for TCP calls such as connect, send, recv

### DIFF
--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -58,58 +58,81 @@ public:
 
     SOCKET fd() const { return socket_; }
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+    // Returns 0 on success, SOCKET_ERROR on failure (check WSAGetLastError()).
     int connect_socket_with_timeout(SOCKET sockfd,
                                     const struct sockaddr *addr,
                                     int addrlen,
                                     const timeval &tv) {
-        // Blocking if no timeout
+        // If no timeout requested, do a normal blocking connect.
         if (tv.tv_sec == 0 && tv.tv_usec == 0) {
             int rv = ::connect(sockfd, addr, addrlen);
-            if (rv == SOCKET_ERROR && WSAGetLastError() == WSAEISCONN) return 0;
+            if (rv == SOCKET_ERROR && WSAGetLastError() == WSAEISCONN) {
+                return 0;
+            }
             return rv;
         }
 
-        // Set non-blocking
+        // Switch to non‐blocking mode
         u_long mode = 1UL;
-        ::ioctlsocket(sockfd, FIONBIO, &mode);
+        if (::ioctlsocket(sockfd, FIONBIO, &mode) == SOCKET_ERROR) {
+            return SOCKET_ERROR;
+        }
 
         int rv = ::connect(sockfd, addr, addrlen);
         int last_error = WSAGetLastError();
         if (rv == 0 || last_error == WSAEISCONN) {
             mode = 0UL;
-            ::ioctlsocket(sockfd, FIONBIO, &mode);
+            if (::ioctlsocket(sockfd, FIONBIO, &mode) == SOCKET_ERROR) {
+                return SOCKET_ERROR;
+            }
             return 0;
         }
         if (last_error != WSAEWOULDBLOCK) {
+            // Real error
             mode = 0UL;
-            ::ioctlsocket(sockfd, FIONBIO, &mode);
+            if (::ioctlsocket(sockfd, FIONBIO, &mode)) {
+                return SOCKET_ERROR;
+            }
             return SOCKET_ERROR;
         }
 
-        // Wait for writability
+        // Wait until socket is writable or timeout expires
         fd_set wfds;
         FD_ZERO(&wfds);
         FD_SET(sockfd, &wfds);
 
-        rv = ::select(0, nullptr, &wfds, nullptr, &tv);
-        mode = 0UL;
-        ::ioctlsocket(sockfd, FIONBIO, &mode);
+        rv = ::select(0, nullptr, &wfds, nullptr, const_cast<timeval *>(&tv));
 
-        if (rv <= 0) {
-            // timeout or error
-            if (rv == 0) WSASetLastError(WSAETIMEDOUT);
+        // Restore blocking mode regardless of select result
+        mode = 0UL;
+        if (::ioctlsocket(sockfd, FIONBIO, &mode) == SOCKET_ERROR) {
             return SOCKET_ERROR;
         }
 
-        // Check socket for errors
+        if (rv == 0) {
+            WSASetLastError(WSAETIMEDOUT);
+            return SOCKET_ERROR;
+        }
+        if (rv == SOCKET_ERROR) {
+            return SOCKET_ERROR;
+        }
+
         int so_error = 0;
         int len = sizeof(so_error);
-        ::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len);
+        if (::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&so_error), &len) ==
+            SOCKET_ERROR) {
+            return SOCKET_ERROR;
+        }
         if (so_error != 0 && so_error != WSAEISCONN) {
+            // connection failed
             WSASetLastError(so_error);
             return SOCKET_ERROR;
         }
-        return 0;
+
+        return 0;  // success
     }
 
     // try to connect or throw on failure

--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -57,11 +57,7 @@ public:
     }
 
     SOCKET fd() const { return socket_; }
-
-#include <winsock2.h>
-#include <ws2tcpip.h>
-
-    // Returns 0 on success, SOCKET_ERROR on failure (check WSAGetLastError()).
+    
     int connect_socket_with_timeout(SOCKET sockfd,
                                     const struct sockaddr *addr,
                                     int addrlen,

--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -58,18 +58,76 @@ public:
 
     SOCKET fd() const { return socket_; }
 
+    int connect_socket_with_timeout(SOCKET sockfd,
+                                    const struct sockaddr *addr,
+                                    int addrlen,
+                                    const timeval &tv) {
+        // Blocking if no timeout
+        if (tv.tv_sec == 0 && tv.tv_usec == 0) {
+            int rv = ::connect(sockfd, addr, addrlen);
+            if (rv == SOCKET_ERROR && WSAGetLastError() == WSAEISCONN) return 0;
+            return rv;
+        }
+
+        // Set non-blocking
+        u_long mode = 1UL;
+        ::ioctlsocket(sockfd, FIONBIO, &mode);
+
+        int rv = ::connect(sockfd, addr, addrlen);
+        int last_error = WSAGetLastError();
+        if (rv == 0 || last_error == WSAEISCONN) {
+            mode = 0UL;
+            ::ioctlsocket(sockfd, FIONBIO, &mode);
+            return 0;
+        }
+        if (last_error != WSAEWOULDBLOCK) {
+            mode = 0UL;
+            ::ioctlsocket(sockfd, FIONBIO, &mode);
+            return SOCKET_ERROR;
+        }
+
+        // Wait for writability
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(sockfd, &wfds);
+
+        rv = ::select(0, nullptr, &wfds, nullptr, &tv);
+        mode = 0UL;
+        ::ioctlsocket(sockfd, FIONBIO, &mode);
+
+        if (rv <= 0) {
+            // timeout or error
+            if (rv == 0) WSASetLastError(WSAETIMEDOUT);
+            return SOCKET_ERROR;
+        }
+
+        // Check socket for errors
+        int so_error = 0;
+        int len = sizeof(so_error);
+        ::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len);
+        if (so_error != 0 && so_error != WSAEISCONN) {
+            WSASetLastError(so_error);
+            return SOCKET_ERROR;
+        }
+        return 0;
+    }
+
     // try to connect or throw on failure
     void connect(const std::string &host, int port, int timeout_ms) {
         if (is_connected()) {
             close();
         }
-        struct addrinfo hints{};
+        struct addrinfo hints {};
         ZeroMemory(&hints, sizeof(hints));
 
         hints.ai_family = AF_UNSPEC;      // To work with IPv4, IPv6, and so on
         hints.ai_socktype = SOCK_STREAM;  // TCP
         hints.ai_flags = AI_NUMERICSERV;  // port passed as as numeric value
         hints.ai_protocol = 0;
+
+        timeval tv;
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
 
         auto port_str = std::to_string(port);
         struct addrinfo *addrinfo_result;
@@ -82,7 +140,6 @@ public:
         }
 
         // Try each address until we successfully connect(2).
-
         for (auto *rp = addrinfo_result; rp != nullptr; rp = rp->ai_next) {
             socket_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
             if (socket_ == INVALID_SOCKET) {
@@ -90,47 +147,11 @@ public:
                 WSACleanup();
                 continue;
             }
-            // set non-blocking if timeout specified
-            u_long mode = (timeout_ms > 0) ? 1UL : 0UL;
-            ::ioctlsocket(socket_, FIONBIO, &mode);
-
-            rv = ::connect(socket_, rp->ai_addr, (int)rp->ai_addrlen);
-            if (rv == SOCKET_ERROR) {
-                last_error = WSAGetLastError();
-                if (timeout_ms > 0 && last_error == WSAEWOULDBLOCK) {
-                    fd_set wfds;
-                    FD_ZERO(&wfds);
-                    FD_SET(socket_, &wfds);
-                    timeval tv;
-                    tv.tv_sec = timeout_ms / 1000;
-                    tv.tv_usec = (timeout_ms % 1000) * 1000;
-                    rv = ::select(0, nullptr, &wfds, nullptr, &tv);
-                    if (rv > 0) {
-                        int so_error = 0;
-                        int len = sizeof(so_error);
-                        ::getsockopt(socket_, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len);
-                        if (so_error == 0)
-                            rv = 0;
-                        else {
-                            last_error = so_error;
-                            rv = SOCKET_ERROR;
-                        }
-                    } else {
-                        last_error = (rv == 0 ? WSAETIMEDOUT : WSAGetLastError());
-                        rv = SOCKET_ERROR;
-                    }
-                }
-            }
-
-            // restore blocking mode
-            mode = 0UL;
-            ::ioctlsocket(socket_, FIONBIO, &mode);
-
-            if (rv == 0) {
+            if (connect_socket_with_timeout(socket_, rp->ai_addr, (int)rp->ai_addrlen, tv) == 0) {
                 last_error = 0;
                 break;
             }
-
+            last_error = WSAGetLastError();
             ::closesocket(socket_);
             socket_ = INVALID_SOCKET;
         }
@@ -139,10 +160,11 @@ public:
             WSACleanup();
             throw_winsock_error_("connect failed", last_error);
         }
-
-        DWORD tv = static_cast<DWORD>(timeout_ms);
-        ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
-        ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
+        if (timeout_ms > 0) {
+            DWORD tv = static_cast<DWORD>(timeout_ms);
+            ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+            ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
+        }
 
         // set TCP_NODELAY
         int enable_flag = 1;

--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -113,7 +113,7 @@ public:
     }
 
     // try to connect or throw on failure
-    void connect(const std::string &host, int port, int timeout_ms) {
+    void connect(const std::string &host, int port, int timeout_ms = 0) {
         if (is_connected()) {
             close();
         }

--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -59,11 +59,11 @@ public:
     SOCKET fd() const { return socket_; }
 
     // try to connect or throw on failure
-    void connect(const std::string &host, int port) {
+    void connect(const std::string &host, int port, int timeout_ms) {
         if (is_connected()) {
             close();
         }
-        struct addrinfo hints {};
+        struct addrinfo hints{};
         ZeroMemory(&hints, sizeof(hints));
 
         hints.ai_family = AF_UNSPEC;      // To work with IPv4, IPv6, and so on
@@ -90,18 +90,59 @@ public:
                 WSACleanup();
                 continue;
             }
-            if (::connect(socket_, rp->ai_addr, (int)rp->ai_addrlen) == 0) {
-                break;
-            } else {
-                last_error = ::WSAGetLastError();
-                close();
+            // set non-blocking if timeout specified
+            u_long mode = (timeout_ms > 0) ? 1UL : 0UL;
+            ::ioctlsocket(socket_, FIONBIO, &mode);
+
+            rv = ::connect(socket_, rp->ai_addr, (int)rp->ai_addrlen);
+            if (rv == SOCKET_ERROR) {
+                last_error = WSAGetLastError();
+                if (timeout_ms > 0 && last_error == WSAEWOULDBLOCK) {
+                    fd_set wfds;
+                    FD_ZERO(&wfds);
+                    FD_SET(socket_, &wfds);
+                    timeval tv;
+                    tv.tv_sec = timeout_ms / 1000;
+                    tv.tv_usec = (timeout_ms % 1000) * 1000;
+                    rv = ::select(0, nullptr, &wfds, nullptr, &tv);
+                    if (rv > 0) {
+                        int so_error = 0;
+                        int len = sizeof(so_error);
+                        ::getsockopt(socket_, SOL_SOCKET, SO_ERROR, (char *)&so_error, &len);
+                        if (so_error == 0)
+                            rv = 0;
+                        else {
+                            last_error = so_error;
+                            rv = SOCKET_ERROR;
+                        }
+                    } else {
+                        last_error = (rv == 0 ? WSAETIMEDOUT : WSAGetLastError());
+                        rv = SOCKET_ERROR;
+                    }
+                }
             }
+
+            // restore blocking mode
+            mode = 0UL;
+            ::ioctlsocket(socket_, FIONBIO, &mode);
+
+            if (rv == 0) {
+                last_error = 0;
+                break;
+            }
+
+            ::closesocket(socket_);
+            socket_ = INVALID_SOCKET;
         }
         ::freeaddrinfo(addrinfo_result);
         if (socket_ == INVALID_SOCKET) {
             WSACleanup();
             throw_winsock_error_("connect failed", last_error);
         }
+
+        DWORD tv = static_cast<DWORD>(timeout_ms);
+        ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+        ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
 
         // set TCP_NODELAY
         int enable_flag = 1;

--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -106,7 +106,7 @@ public:
     // try to connect or throw on failure
     void connect(const std::string &host, int port, int timeout_ms = 0) {
         close();
-        struct addrinfo hints{};
+        struct addrinfo hints {};
         memset(&hints, 0, sizeof(struct addrinfo));
         hints.ai_family = AF_UNSPEC;      // To work with IPv4, IPv6, and so on
         hints.ai_socktype = SOCK_STREAM;  // TCP
@@ -151,9 +151,11 @@ public:
             throw_spdlog_ex("::connect failed", last_errno);
         }
 
-        // Set timeouts for send and recv
-        ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
-        ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
+        if (timeout_ms > 0) {
+            // Set timeouts for send and recv
+            ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+            ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
+        }
 
         // set TCP_NODELAY
         int enable_flag = 1;

--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -39,15 +39,83 @@ public:
 
     ~tcp_client() { close(); }
 
+    int connect_socket_with_timeout(int sockfd,
+                                    const struct sockaddr *addr,
+                                    socklen_t addrlen,
+                                    const timeval &tv) {
+        // Blocking connect if timeout is zero
+        if (tv.tv_sec == 0 && tv.tv_usec == 0) {
+            int rv = ::connect(sockfd, addr, addrlen);
+            if (rv < 0 && errno == EISCONN) {
+                // already connected, treat as success
+                return 0;
+            }
+            return rv;
+        }
+
+        // Non-blocking path
+        int orig_flags = ::fcntl(sockfd, F_GETFL, 0);
+        if (orig_flags < 0) {
+            return -1;
+        }
+        if (::fcntl(sockfd, F_SETFL, orig_flags | O_NONBLOCK) < 0) {
+            return -1;
+        }
+
+        int rv = ::connect(sockfd, addr, addrlen);
+        if (rv == 0 || (rv < 0 && errno == EISCONN)) {
+            // immediate connect or already connected
+            ::fcntl(sockfd, F_SETFL, orig_flags);
+            return 0;
+        }
+        if (errno != EINPROGRESS) {
+            ::fcntl(sockfd, F_SETFL, orig_flags);
+            return -1;
+        }
+
+        // wait for writability
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(sockfd, &wfds);
+
+        struct timeval tv_copy = tv;
+        rv = ::select(sockfd + 1, nullptr, &wfds, nullptr, &tv_copy);
+        if (rv <= 0) {
+            // timeout or error
+            ::fcntl(sockfd, F_SETFL, orig_flags);
+            if (rv == 0) errno = ETIMEDOUT;
+            return -1;
+        }
+
+        // check socket error
+        int so_error = 0;
+        socklen_t len = sizeof(so_error);
+        if (::getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &so_error, &len) < 0) {
+            ::fcntl(sockfd, F_SETFL, orig_flags);
+            return -1;
+        }
+        ::fcntl(sockfd, F_SETFL, orig_flags);
+        if (so_error != 0 && so_error != EISCONN) {
+            errno = so_error;
+            return -1;
+        }
+
+        return 0;
+    }
+
     // try to connect or throw on failure
-    void connect(const std::string &host, int port) {
+    void connect(const std::string &host, int port, int timeout_ms = 0) {
         close();
-        struct addrinfo hints {};
+        struct addrinfo hints{};
         memset(&hints, 0, sizeof(struct addrinfo));
         hints.ai_family = AF_UNSPEC;      // To work with IPv4, IPv6, and so on
         hints.ai_socktype = SOCK_STREAM;  // TCP
         hints.ai_flags = AI_NUMERICSERV;  // port passed as as numeric value
         hints.ai_protocol = 0;
+
+        struct timeval tv;
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
 
         auto port_str = std::to_string(port);
         struct addrinfo *addrinfo_result;
@@ -69,8 +137,9 @@ public:
                 last_errno = errno;
                 continue;
             }
-            rv = ::connect(socket_, rp->ai_addr, rp->ai_addrlen);
-            if (rv == 0) {
+            ::fcntl(socket_, F_SETFD, FD_CLOEXEC);
+            if (connect_socket_with_timeout(socket_, rp->ai_addr, rp->ai_addrlen, tv) == 0) {
+                last_errno = 0;
                 break;
             }
             last_errno = errno;
@@ -81,6 +150,10 @@ public:
         if (socket_ == -1) {
             throw_spdlog_ex("::connect failed", last_errno);
         }
+
+        // Set timeouts for send and recv
+        ::setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, (const char *)&tv, sizeof(tv));
+        ::setsockopt(socket_, SOL_SOCKET, SO_SNDTIMEO, (const char *)&tv, sizeof(tv));
 
         // set TCP_NODELAY
         int enable_flag = 1;

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -31,7 +31,7 @@ namespace sinks {
 struct tcp_sink_config {
     std::string server_host;
     int server_port;
-    int timeout_ms = 0;
+    int timeout_ms = 0; // The timeout for all 3 major socket operations that is connect, send, and recv
     bool lazy_connect = false;  // if true connect on first log call instead of on construction
 
     tcp_sink_config(std::string host, int port)

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -31,6 +31,7 @@ namespace sinks {
 struct tcp_sink_config {
     std::string server_host;
     int server_port;
+    int timeout_ms = 0;
     bool lazy_connect = false;  // if true connect on first log call instead of on construction
 
     tcp_sink_config(std::string host, int port)
@@ -44,10 +45,22 @@ public:
     // connect to tcp host/port or throw if failed
     // host can be hostname or ip address
 
+    explicit tcp_sink(const std::string &host,
+                      int port,
+                      int timeout_ms = 0,
+                      bool lazy_connect = false)
+        : config_{host, port} {
+        config_.timeout_ms = timeout_ms;
+        config_.lazy_connect = lazy_connect;
+        if (!config_.lazy_connect) {
+            client_.connect(config_.server_host, config_.server_port, config_.timeout_ms);
+        }
+    }
+
     explicit tcp_sink(tcp_sink_config sink_config)
         : config_{std::move(sink_config)} {
         if (!config_.lazy_connect) {
-            this->client_.connect(config_.server_host, config_.server_port);
+            client_.connect(config_.server_host, config_.server_port, config_.timeout_ms);
         }
     }
 
@@ -58,7 +71,7 @@ protected:
         spdlog::memory_buf_t formatted;
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
         if (!client_.is_connected()) {
-            client_.connect(config_.server_host, config_.server_port);
+            client_.connect(config_.server_host, config_.server_port, config_.timeout_ms);
         }
         client_.send(formatted.data(), formatted.size());
     }


### PR DESCRIPTION
**Add optional timeout API to TCP connect, send, and recv calls**  
*Worked on issue #2682*

## Overview

This pull request introduces an **optional timeout parameter** (`timeout_ms`) to the existing TCP sink in **spdlog**, enabling users to specify a maximum duration for:

- **Connecting** to a remote host
- **Sending** log data over an established socket
- **Receiving** acknowledgments or responses (where applicable)

By default, `timeout_ms = 0`, preserving the original **blocking** behavior. Setting a non-zero value switches to a **non-blocking** socket with `select`-based waiting.

---

## Key Changes

1. **API Extension**

   - **`tcp_client::connect(host, port, timeout_ms = 0)`** (both Windows and Linux implementations)
     - `timeout_ms = 0` → original blocking `connect`
     - `timeout_ms > 0` → non-blocking connect with `select` timeout

2. **Send/Receive Timeouts**

   - After a successful connection, `SO_SNDTIMEO` and `SO_RCVTIMEO` are set to `timeout_ms` (on platforms supporting these).
   - Ensures that `send(…)` and `recv(…)` calls will return with an error if they block longer than the specified duration.

3. **Configuration Struct**

   - Extended **`tcp_sink_config`** to include an **optional** `timeout_ms` field.
   - Legacy code using `tcp_sink_config` without `timeout_ms` continues to default to blocking behavior.

4. **Cross-Platform Helper Function**

   - Extracted non-blocking timeout logic into `connect_socket_with_timeout(...)` for Windows, mirroring the Linux implementation.

---

## Usage
- Optional non-blocking timeout behavior
  ```cpp
  auto sink   = std::make_shared<spdlog::sinks::tcp_sink_mt>(
            "127.10.0.1",  // host
            5000,           // port
            10000           // timeout in milliseconds
        );
  ```
- Blocking behavior (no timeouts):
  ```cpp
  auto sink = std::make_shared<spdlog::sinks::tcp_sink_mt>("127.0.0.1", 5000);
  ```
  — identical to pre-PR behavior.
