### PR TITLE
Fix ringbuffer sink for zero buffer size

### DIFF
--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -21,7 +21,11 @@ template <typename Mutex>
 class ringbuffer_sink final : public base_sink<Mutex> {
 public:
     explicit ringbuffer_sink(size_t n_items)
-        : q_{n_items} {}
+        : q_{n_items} {
+        if (n_items == 0) {
+            throw_spdlog_ex("ringbuffer_sink: n_items cannot be zero");
+        }
+    }
 
     std::vector<details::log_msg_buffer> last_raw(size_t lim = 0) {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,8 @@ set(SPDLOG_UTESTS_SOURCES
     test_time_point.cpp
     test_stopwatch.cpp
     test_circular_q.cpp
-    test_bin_to_hex.cpp)
+    test_bin_to_hex.cpp
+    test_ringbuffer.cpp)
 
 if(NOT SPDLOG_NO_EXCEPTIONS)
     list(APPEND SPDLOG_UTESTS_SOURCES test_errors.cpp)

--- a/tests/test_ringbuffer.cpp
+++ b/tests/test_ringbuffer.cpp
@@ -1,0 +1,50 @@
+#include "includes.h"
+#include "spdlog/sinks/ringbuffer_sink.h"
+
+TEST_CASE("ringbuffer invalid size", "[ringbuffer]") {
+    REQUIRE_THROWS_AS(spdlog::sinks::ringbuffer_sink_mt(0), spdlog::spdlog_ex);
+}
+
+TEST_CASE("ringbuffer stores formatted messages", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(3);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg1"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg2"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg3"});
+
+    auto formatted = sink.last_formatted();
+    REQUIRE(formatted.size() == 3);
+    REQUIRE(formatted[0] == "msg1");
+    REQUIRE(formatted[1] == "msg2");
+    REQUIRE(formatted[2] == "msg3");
+}
+
+TEST_CASE("ringbuffer overrun keeps last items", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(2);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "first"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "second"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "third"});
+
+    auto formatted = sink.last_formatted();
+    REQUIRE(formatted.size() == 2);
+    REQUIRE(formatted[0] == "second");
+    REQUIRE(formatted[1] == "third");
+}
+
+TEST_CASE("ringbuffer retrieval limit", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(3);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "A"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "B"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "C"});
+
+    auto formatted = sink.last_formatted(2);
+    REQUIRE(formatted.size() == 2);
+    REQUIRE(formatted[0] == "B");
+    REQUIRE(formatted[1] == "C");
+}
+


### PR DESCRIPTION
## Summary
- validate ringbuffer sink constructor arguments
- add regression test for ringbuffer sink
- add comprehensive tests for ringbuffer behavior

## Testing
- `cmake .. -DSPDLOG_BUILD_TESTS=ON` *(fails: unable to clone Catch2)*
- `make -j$(nproc)` *(fails: no makefile due to previous error)*

------
https://chatgpt.com/codex/tasks/task_e_6869935806ac832e9be126ca90069aa5