### PR TITLE
Fix ringbuffer sink for zero buffer size

### DIFF
--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -21,7 +21,11 @@ template <typename Mutex>
 class ringbuffer_sink final : public base_sink<Mutex> {
 public:
     explicit ringbuffer_sink(size_t n_items)
-        : q_{n_items} {}
+        : q_{n_items} {
+        if (n_items == 0) {
+            throw_spdlog_ex("ringbuffer_sink: n_items cannot be zero");
+        }
+    }
 
     std::vector<details::log_msg_buffer> last_raw(size_t lim = 0) {
         std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,8 @@ set(SPDLOG_UTESTS_SOURCES
     test_time_point.cpp
     test_stopwatch.cpp
     test_circular_q.cpp
-    test_bin_to_hex.cpp)
+    test_bin_to_hex.cpp
+    test_ringbuffer.cpp)
 
 if(NOT SPDLOG_NO_EXCEPTIONS)
     list(APPEND SPDLOG_UTESTS_SOURCES test_errors.cpp)

--- a/tests/test_ringbuffer.cpp
+++ b/tests/test_ringbuffer.cpp
@@ -1,0 +1,53 @@
+#include "includes.h"
+#include "spdlog/sinks/ringbuffer_sink.h"
+
+TEST_CASE("ringbuffer invalid size", "[ringbuffer]") {
+    REQUIRE_THROWS_AS(spdlog::sinks::ringbuffer_sink_mt(0), spdlog::spdlog_ex);
+}
+
+TEST_CASE("ringbuffer stores formatted messages", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(3);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg1"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg2"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "msg3"});
+
+    auto formatted = sink.last_formatted();
+    REQUIRE(formatted.size() == 3);
+    using spdlog::details::os::default_eol;
+    REQUIRE(formatted[0] == spdlog::fmt_lib::format("msg1{}", default_eol));
+    REQUIRE(formatted[1] == spdlog::fmt_lib::format("msg2{}", default_eol));
+    REQUIRE(formatted[2] == spdlog::fmt_lib::format("msg3{}", default_eol));
+}
+
+TEST_CASE("ringbuffer overrun keeps last items", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(2);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "first"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "second"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "third"});
+
+    auto formatted = sink.last_formatted();
+    REQUIRE(formatted.size() == 2);
+    using spdlog::details::os::default_eol;
+    REQUIRE(formatted[0] == spdlog::fmt_lib::format("second{}", default_eol));
+    REQUIRE(formatted[1] == spdlog::fmt_lib::format("third{}", default_eol));
+}
+
+TEST_CASE("ringbuffer retrieval limit", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(3);
+    sink.set_pattern("%v");
+
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "A"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "B"});
+    sink.log(spdlog::details::log_msg{"test", spdlog::level::info, "C"});
+
+    auto formatted = sink.last_formatted(2);
+    REQUIRE(formatted.size() == 2);
+    using spdlog::details::os::default_eol;
+    REQUIRE(formatted[0] == spdlog::fmt_lib::format("B{}", default_eol));
+    REQUIRE(formatted[1] == spdlog::fmt_lib::format("C{}", default_eol));
+}
+


### PR DESCRIPTION
## Summary
- validate ringbuffer sink constructor arguments
- add tests for ring buffer
------
https://chatgpt.com/codex/tasks/task_e_6869935806ac832e9be126ca90069aa5