### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ void multi_sink_example()
 ```c++
 
 // Creation of loggers. Registration of loggers.
-// Setting default logger. Setting global level to all registered loggers. 
-void multi_sink_example()
+// Setting a default logger. Setting a global level to all registered loggers. 
+void multi_loggers_example()
 {
     auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/filesink.txt", true);
     file_sink->set_level(spdlog::level::warning);

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ int main()
     spdlog::info("Positional args are {1} {0}..", "too", "supported");
     spdlog::info("{:<30}", "left aligned");
     
-    spdlog::set_level(spdlog::level::debug); // Set global log level to debug
+    spdlog::set_level(spdlog::level::debug); // Set *global* log level to debug
     spdlog::debug("This message should be displayed..");    
     
     // change log pattern
@@ -224,7 +224,7 @@ void binary_example()
 ```c++
 
 // create a logger with 2 targets, with different log levels and formats.
-// The console will show only warnings or errors, while the file will log all.
+// The console will show only warnings or errors, while the file will log all. 
 void multi_sink_example()
 {
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
@@ -238,6 +238,37 @@ void multi_sink_example()
     logger.set_level(spdlog::level::debug);
     logger.warn("this should appear in both console and file");
     logger.info("this message should not appear in the console, only in the file");
+}
+```
+
+---
+#### Register several loggers - each with a different format and log level
+```c++
+
+// Creation of loggers. Registration of loggers.
+// Setting default logger. Setting global level to all registered loggers. 
+void multi_sink_example()
+{
+    auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/filesink.txt", true);
+    file_sink->set_level(spdlog::level::warning);
+
+    spdlog::logger file_logger("file_logger", file_sink);
+    file_logger->set_level(spdlog::level::info);
+    spdlog::register_logger(file_logger); // register manually, because the logger created from sink, and will not be registered automatically
+    spdlog::set_default_logger(file_logger);
+    
+    spdlog::info("info message to file_logger, then passed to sink, but sink will not log it, because sink set to warning level")
+
+    auto basic_logger = spdlog::basic_logger_mt("basic_logger", "logs/basic-log.txt"); // registered automatically
+    spdlog::set_default_logger(basic_logger); // reset default logger to basic_logger
+    spdlog::default_logger()->set_level(spdlog::level::trace); // set level for default logger to trace
+
+    spdlog::trace("trace message to the basic_logger (now specified as default)");
+
+    spdlog::set_level(spdlog::level::off) // (sic!) set level for *all* registered loggers to off (disable)
+  
+    file_logger.warn("warn message will not appear because level set to off");
+    basic_logger.warn("warn message will not appear because level set to off");
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -245,22 +245,16 @@ void multi_sink_example()
 #### Register several loggers - change global level
 ```c++
 
-// Creation of loggers. Registration of loggers.
-// Setting a default logger. Setting a global level to all registered loggers. 
-void multi_loggers_example()
+// Creation of loggers. Set levels to all registered loggers. 
+void set_level_example()
 {
-    auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/sink.txt", true);
-    spdlog::logger logger1("logger1", sink);
-    spdlog::register_logger(logger1);  // register manually, because the logger created from sink, and will not be registered automatically
-    spdlog::set_default_logger(logger1);
-    
-    spdlog::info("info message to the logger1 (now specified as default)")
+    auto logger1 = spdlog::basic_logger_mt("logger1", "logs/logger1.txt");
+    auto logger2 = spdlog::basic_logger_mt("logger2", "logs/logger2.txt");
 
-    auto logger2 = spdlog::basic_logger_mt("logger2", "logs/logger2.txt"); // registered automatically
-    spdlog::set_default_logger(logger2); // reset default logger to logger2
+    spdlog::set_default_logger(logger2);
     spdlog::default_logger()->set_level(spdlog::level::trace); // set level for the default logger (logger2) to trace
 
-    spdlog::trace("trace message to the logger2 (now specified as default)");
+    spdlog::trace("trace message to the logger2 (specified as default)");
 
     spdlog::set_level(spdlog::level::off) // (sic!) set level for *all* registered loggers to off (disable)
   

--- a/README.md
+++ b/README.md
@@ -242,33 +242,31 @@ void multi_sink_example()
 ```
 
 ---
-#### Register several loggers - each with a different format and log level
+#### Register several loggers - change global level
 ```c++
 
 // Creation of loggers. Registration of loggers.
 // Setting a default logger. Setting a global level to all registered loggers. 
 void multi_loggers_example()
 {
-    auto file_sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/filesink.txt", true);
-    file_sink->set_level(spdlog::level::warning);
-
-    spdlog::logger file_logger("file_logger", file_sink);
-    file_logger->set_level(spdlog::level::info);
-    spdlog::register_logger(file_logger); // register manually, because the logger created from sink, and will not be registered automatically
-    spdlog::set_default_logger(file_logger);
+    auto sink = std::make_shared<spdlog::sinks::basic_file_sink_mt>("logs/sink.txt", true);
+    spdlog::logger logger1("logger1", sink);
+    spdlog::register_logger(logger1);  // register manually, because the logger created from sink, and will not be registered automatically
+    spdlog::set_default_logger(logger1);
     
-    spdlog::info("info message to file_logger, then passed to sink, but sink will not log it, because sink set to warning level")
+    spdlog::info("info message to the logger1 (now specified as default)")
 
-    auto basic_logger = spdlog::basic_logger_mt("basic_logger", "logs/basic-log.txt"); // registered automatically
-    spdlog::set_default_logger(basic_logger); // reset default logger to basic_logger
-    spdlog::default_logger()->set_level(spdlog::level::trace); // set level for default logger to trace
+    auto logger2 = spdlog::basic_logger_mt("logger2", "logs/logger2.txt"); // registered automatically
+    spdlog::set_default_logger(logger2); // reset default logger to logger2
+    spdlog::default_logger()->set_level(spdlog::level::trace); // set level for the default logger (logger2) to trace
 
-    spdlog::trace("trace message to the basic_logger (now specified as default)");
+    spdlog::trace("trace message to the logger2 (now specified as default)");
 
     spdlog::set_level(spdlog::level::off) // (sic!) set level for *all* registered loggers to off (disable)
   
-    file_logger.warn("warn message will not appear because level set to off");
-    basic_logger.warn("warn message will not appear because level set to off");
+    logger1.warn("warn message will not appear because the level set to off");
+    logger2.warn("warn message will not appear because the level set to off");
+    spdlog::warn("warn message will not appear because the level set to off");
 }
 ```
 


### PR DESCRIPTION
This pull request updates the `README.md` file and introduces a new example for managing multiple loggers with different formats and levels.

The example showcasing 2 loggers and `spdlog::set_level()`, which set level NOT only to default logger, but to ALL registered loggers

(I won’t say how many hours it took me to figure this out)