### PR TITLE
Remove the fileapi.h include in os-inl.h

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -23,7 +23,6 @@
 
 #ifdef _WIN32
     #include <spdlog/details/windows_include.h>
-    #include <windows.h>  // for FlushFileBuffers
     #include <io.h>       // for _get_osfhandle, _isatty, _fileno
     #include <process.h>  // for _get_pid
 

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -23,7 +23,7 @@
 
 #ifdef _WIN32
     #include <spdlog/details/windows_include.h>
-    #include <fileapi.h>  // for FlushFileBuffers
+    #include <windows.h>  // for FlushFileBuffers
     #include <io.h>       // for _get_osfhandle, _isatty, _fileno
     #include <process.h>  // for _get_pid
 


### PR DESCRIPTION
As instructed in https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers

The reason for this change is that it causes compilation errors for older SDKs (such as 7.1A)

```cpp
fatal error C1083: Cannot open include file: 'fileapi.h': No such file or directory
```