### PR TITLE
Run tests in the order they are declared

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,7 +75,7 @@ function(spdlog_prepare_test test_target spdlog_lib)
     elseif(SPDLOG_SANITIZE_THREAD)
         spdlog_enable_thread_sanitizer(${test_target})
     endif()
-    add_test(NAME ${test_target} COMMAND ${test_target})
+    add_test(NAME ${test_target} COMMAND ${test_target} --order decl)
     set_tests_properties(${test_target} PROPERTIES RUN_SERIAL ON)
 endfunction()
 


### PR DESCRIPTION
Run tests in the order they are declared in the source file.

Fixes an issue with running tests in random order in Catch2 3.9.0+. Closes #3449.