### PR TITLE
fix(warning): avoid constexpr warning with GCC 15.2.1

### DIFF
--- a/include/spdlog/fmt/bundled/base.h
+++ b/include/spdlog/fmt/bundled/base.h
@@ -469,12 +469,15 @@ constexpr FMT_ALWAYS_INLINE const char* narrow(const char* s) { return s; }
 template <typename Char>
 FMT_CONSTEXPR auto compare(const Char* s1, const Char* s2, std::size_t n)
     -> int {
-  if (!is_constant_evaluated() && sizeof(Char) == 1) return memcmp(s1, s2, n);
-  for (; n != 0; ++s1, ++s2, --n) {
-    if (*s1 < *s2) return -1;
-    if (*s1 > *s2) return 1;
+  if constexpr (!is_constant_evaluated() && sizeof(Char) == 1) {
+      return memcmp(s1, s2, n);
+  }else {
+    for (; n != 0; ++s1, ++s2, --n) {
+        if (*s1 < *s2) return -1;
+        if (*s1 > *s2) return 1;
+    }
+    return 0;
   }
-  return 0;
 }
 
 namespace adl {


### PR DESCRIPTION
The PR adds a couple of extra parentheses to avoid any complaints from the compiler about unreachable code.
Below is the warning produced by the compiler:
```
spdlog/include/spdlog/fmt/bundled/base.h(473): warning #128-D: loop is not reachable
    for (; n != 0; ++s1, ++s2, --n) {
    ^
          detected during:
            instantiation of "auto fmt::v11::detail::compare(const Char *, const Char *, std::size_t)->int [with Char=char]" at line 591
            instantiation of "auto fmt::v11::basic_string_view<Char>::compare(fmt::v11::basic_string_view<Char>) const->int [with Char=char]" at line 598
            instantiation of class "fmt::v11::basic_string_view<Char> [with Char=char]" at line 2642
            instantiation of "auto fmt::v11::basic_format_args<Context>::get_id(fmt::v11::basic_string_view<Char>) const->int [with Context=fmt::v11::context, Char=char]" at line 2685

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
```
