### PR TITLE
fix sign-compare warning

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -489,7 +489,7 @@ SPDLOG_INLINE void utf8_to_wstrbuf(string_view_t str, wmemory_buf_t &target) {
         result_size =
             ::MultiByteToWideChar(CP_UTF8, 0, str.data(), str_size, target.data(), result_size);
         if (result_size > 0) {
-            assert(result_size == target.size());
+            assert(result_size == static_cast<int>(target.size()));
             return;
         }
     }


### PR DESCRIPTION
I'm using spdlog in my project and I have to set option `-Wno-sign-compare` for compilation with `-Werror`. Because of that I can miss an incorrect comparison in my code.