### PR TITLE
set CMAKE_BUILD_TYPE only in top-level project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ include(GNUInstallDirs)
 # Set default build to release
 # ---------------------------------------------------------------------------------------
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
+    # Set CMAKE_BUILD_TYPE only if this project is top-level
+    if((DEFINED PROJECT_IS_TOP_LEVEL AND PROJECT_IS_TOP_LEVEL)
+        OR (NOT DEFINED PROJECT_IS_TOP_LEVEL AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR))
+        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
+    endif()
 endif()
 
 # ---------------------------------------------------------------------------------------


### PR DESCRIPTION
`CMAKE_BUILD_TYPE` should only be set when the project being compiled is top-level. The `PROJECT_IS_TOP_LEVEL` variable was added in cmake 3.21, hence a more hacky solution for older versions. 

Another option would be to simply display a message if `CMAKE_BUILD_TYPE` is unspecified instead of defaulting it to Release.

The issue with the current behavior is that setting the build type flag propagates to the parent project. In some code of mine I'm using spdlog as a git submodule (`add_subdirectory`), and I have not specified build type - however spdlog sets it to Release which was causing some asserts in my code being compiled-out silently. 

As such I think it makes sense to not set any property which propagates to the parent project, since this is a library after all. 