### PR TITLE
Change access scope for ANSI target_file_ from private to protected

### DIFF
--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -78,8 +78,10 @@ public:
     const string_view_t red_bold = "\033[31m\033[1m";
     const string_view_t bold_on_red = "\033[1m\033[41m";
 
-private:
+protected:
     FILE *target_file_;
+
+private:
     mutex_t &mutex_;
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;


### PR DESCRIPTION
This change allows for a custom minimal ANSI color sink implementation that supports, for example, splitting between `stdout` and `stderr` file streams depending on the log level.  An example application specific custom sink that realizes this behavior would look like:

```cpp
template <typename ConsoleMutex>
class SplitSink : public sinks::ansicolor_sink<ConsoleMutex>
{
    using Base = sinks::ansicolor_sink<ConsoleMutex>;

public:
    SplitSink(color_mode mode = color_mode::automatic) : Base(stdout, mode) {}

    void log(const details::log_msg &msg) override
    {
        if (msg.level <= SPDLOG_LEVEL_WARN) {
            this->target_file_ = stdout;
        } else {
            this->target_file_ = stderr;
        }
        Base::log(msg);
    }
};
```

Inspired by https://github.com/gabime/spdlog/issues/345 and https://github.com/eic/EICrecon/issues/456.  This commit aims at reusing all of the `ansicolor_sink` code with the exception of dynamic target file selection that can be implemented in application code based on example above.