### PR TITLE
Fix sign conversion warnings in qt_sinks.h

### DIFF
--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -160,8 +160,8 @@ protected:
             payload = QString::fromUtf8(str.data(), static_cast<int>(str.size()));
             // convert color ranges from byte index to character index.
             if (msg.color_range_start < msg.color_range_end) {
-                color_range_start = QString::fromUtf8(str.data(), msg.color_range_start).size();
-                color_range_end = QString::fromUtf8(str.data(), msg.color_range_end).size();
+                color_range_start = QString::fromUtf8(str.data(), static_cast<qsizetype>(msg.color_range_start)).size();
+                color_range_end = QString::fromUtf8(str.data(), static_cast<qsizetype>(msg.color_range_end)).size();
             }
         } else {
             payload = QString::fromLatin1(str.data(), static_cast<int>(str.size()));
@@ -171,7 +171,7 @@ protected:
                              qt_text_edit_,          // text edit to append to
                              std::move(payload),     // text to append
                              default_color_,         // default color
-                             colors_.at(msg.level),  // color to apply
+                             colors_.at(static_cast<size_t>(msg.level)),  // color to apply
                              color_range_start,      // color range start
                              color_range_end};       // color range end
 


### PR DESCRIPTION
Fixes #3321

This fixes the compiler warnings when building with `-Werror=sign-conversion` and `-Werror=shorten-64-to-32`.

The issue is that QString::fromUtf8() expects a signed qsizetype but we're passing unsigned size_t values. Also, the array indexing with msg.level (an enum which is signed) triggers a warning.

I added static_cast in three places:

1. `msg.color_range_start` → `static_cast<qsizetype>(msg.color_range_start)`
2. `msg.color_range_end` → `static_cast<qsizetype>(msg.color_range_end)`
3. `colors_.at(msg.level)` → `colors_.at(static_cast<size_t>(msg.level))`

These casts are safe because:
- Qt docs guarantee qsizetype is the same size as size_t
- The color range values come from valid string positions
- msg.level values are from a small enum range (0-6)

Tested with GCC 14.2.0 and Clang 19.1.6 on OpenMandriva.