### PR TITLE
tests: fix unit tests to respect default level names

### DIFF
--- a/tests/includes.h
+++ b/tests/includes.h
@@ -23,6 +23,9 @@
 
 #define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_DEBUG
 
+#undef SPDLOG_LEVEL_NAMES
+#undef SPDLOG_SHORT_LEVEL_NAMES
+
 #include "spdlog/spdlog.h"
 #include "spdlog/async.h"
 #include "spdlog/details/fmt_helper.h"


### PR DESCRIPTION
### Description

This PR fixes unit tests to use default level names instead of being affected by custom  or  defined in .

### Problem

When custom level names are defined in , the unit tests fail:
```
REQUIRE( spdlog::level::to_string_view(spdlog::level::trace) == "trace" )
with expansion:
  "TRC" == "trace"
```

### Solution

Added  and  in  after  to ensure unit tests always use the default level names.

### Testing

This change ensures that:
- Unit tests are not affected by user-defined level name customizations
- Tests validate the default behavior of spdlog
- Custom level names in  don't break the test suite

Fixes #3466


Thank you to @tt4g for suggesting this fix
