### PR TITLE
Fix: include <fcntl.h> in tcp_client.h to avoid compilation failures …

### DIFF
--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -17,6 +17,7 @@
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #include <string>
 


### PR DESCRIPTION
Fix missing <fcntl.h> include in tcp_client.h.

This resolves compilation failures on Linux/Unix when building with TCP logging enabled.

Fixes gabime/spdlog#3496