### PR TITLE
Docs: fix misleading comment in blocking_queue header

### DIFF
--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -5,8 +5,8 @@
 
 // multi producer-multi consumer blocking queue.
 // enqueue(..) - will block until room found to put the new message.
-// enqueue_nowait(..) - will return immediately with false if no room left in
-// the queue.
+// enqueue_nowait(..) - enqueue immediately. overruns oldest message if no 
+// room left.
 // dequeue_for(..) - will block until the queue is not empty or timeout have
 // passed.
 


### PR DESCRIPTION
The header comment for enqueue_nowait in blocking_queue.h incorrectly stated that it returns false if the queue is full.

However, the actual implementation uses circular_q which overwrites the oldest item when full, and the function returns void.