### PR TITLE
Replace C-style cast with reinterpret_cast in udp_client

### DIFF
--- a/include/spdlog/details/udp_client.h
+++ b/include/spdlog/details/udp_client.h
@@ -69,10 +69,9 @@ public:
     // Send exactly n_bytes of the given data.
     // On error close the connection and throw.
     void send(const char *data, size_t n_bytes) {
-        ssize_t toslen = 0;
-        socklen_t tolen = sizeof(struct sockaddr);
-        if ((toslen = ::sendto(socket_, data, n_bytes, 0, (struct sockaddr *)&sockAddr_, tolen)) ==
-            -1) {
+        socklen_t tolen = sizeof(sockaddr);
+        if (::sendto(socket_, data, n_bytes, 0, reinterpret_cast<const sockaddr *>(&sockAddr_),
+                     tolen) == -1) {
             throw_spdlog_ex("sendto(2) failed", errno);
         }
     }

--- a/include/spdlog/details/udp_client.h
+++ b/include/spdlog/details/udp_client.h
@@ -69,7 +69,7 @@ public:
     // Send exactly n_bytes of the given data.
     // On error close the connection and throw.
     void send(const char *data, size_t n_bytes) {
-        socklen_t tolen = sizeof(sockaddr);
+        socklen_t tolen = sizeof(sockAddr_);
         if (::sendto(socket_, data, n_bytes, 0, reinterpret_cast<const sockaddr *>(&sockAddr_),
                      tolen) == -1) {
             throw_spdlog_ex("sendto(2) failed", errno);


### PR DESCRIPTION
Hello,

I'm not fully familiar with the `spdlog` project, but I wanted to take a quick look by performing a `cppcheck`. Besides the `fmt` library included in the bundle and the `unused` function warnings, I obtained the list at the end of this PR message. If you have anything you'd like to address, please let me know. I'd be happy to help.

For now, to avoid confusion, I've addressed the following two points:
```bash
include/spdlog/details/udp_client.h:74:style:unreadVariable -> Variable 'toslen' is assigned a value that is never used.
include/spdlog/details/udp_client.h:74:style:cstyleCast -> C-style pointer casting
```

Accordingly, I replaced the C-style pointer conversion with `reinterpret_cast<const sockaddr*>` in the `send()` method for better type safety, and removed the unused `toslen` variable in the `send()` method.

I formatted and tested it with the following calls, **but I think we will need additional testing. I can do it if you guide me.**

### Compilation & Testing
```bash
./scripts/format.sh
mkdir build && cd build
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DSPDLOG_BUILD_TESTS=ON ..
cmake --build .
tests/spdlog-utests
```

### CppCheck Command
```bash
cppcheck --project=compile_commands.json --enable=all --inconclusive --platform=unix64 --check-level=exhaustive --suppress=missingIncludeSystem --template="{file}:{line}:{severity}:{id} -> {message}" --output-file=cppcheck_report_spdlog.txt
```

Regards

---

### Full cppcheck Output:
```bash
spdlog/include/spdlog/details/null_mutex.h:19:warning:uninitMemberVar -> Member variable 'null_atomic_int::value' is not initialized in the constructor.
spdlog/include/spdlog/details/backtracer-inl.h:11:warning:missingMemberCopy -> Member variable 'backtracer::mutex_' is not assigned in the copy constructor. Should it be copied?
spdlog/include/spdlog/details/backtracer-inl.h:17:warning:missingMemberCopy -> Member variable 'backtracer::mutex_' is not assigned in the move constructor. Should it be moved?
spdlog/include/spdlog/details/registry-inl.h:44:performance:useInitializationList -> Variable 'default_logger_' is assigned in constructor body. Consider performing initialization in initialization list.
spdlog/include/spdlog/details/null_mutex.h:13:performance:functionStatic -> Technically the member function 'spdlog::details::null_mutex::lock' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/details/null_mutex.h:14:performance:functionStatic -> Technically the member function 'spdlog::details::null_mutex::unlock' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/pattern_formatter.h:102:style:functionConst -> Technically the member function 'spdlog::pattern_formatter::get_time_' can be const.
spdlog/include/spdlog/details/log_msg-inl.h:38:style:funcArgNamesDifferent -> Function 'log_msg' argument 1 names different: declaration 'logger_name' definition 'a_logger_name'.
spdlog/include/spdlog/spdlog-inl.h:42:style:funcArgNamesDifferent -> Function 'should_log' argument 1 names different: declaration 'lvl' definition 'log_level'.
spdlog/include/spdlog/logger-inl.h:167:style:shadowFunction -> Local variable 'flush_level' shadows outer function
spdlog/include/spdlog/logger.h:79:performance:passedByValue -> Function parameter 'loc' should be passed by const reference.
spdlog/include/spdlog/logger.h:102:performance:passedByValue -> Function parameter 'loc' should be passed by const reference.
spdlog/include/spdlog/logger.h:115:performance:passedByValue -> Function parameter 'loc' should be passed by const reference.
spdlog/include/spdlog/spdlog.h:149:performance:passedByValue -> Function parameter 'source' should be passed by const reference.
spdlog/include/spdlog/spdlog.h:192:performance:passedByValue -> Function parameter 'source' should be passed by const reference.
spdlog/include/spdlog/details/registry-inl.h:260:style:constVariableReference -> Variable 'logger_name' can be declared as reference to const
spdlog/include/spdlog/pattern_formatter-inl.h:927:style:constVariableReference -> Variable 'mdc_map' can be declared as reference to const
spdlog/include/spdlog/pattern_formatter-inl.h:828:style:constVariableReference -> Variable 'pair' can be declared as reference to const
spdlog/include/spdlog/sinks/rotating_file_sink.h:33:style:functionConst -> Technically the member function 'rotating_file_sink < std :: mutex >::get_max_size' can be const.
spdlog/include/spdlog/sinks/rotating_file_sink.h:35:style:functionConst -> Technically the member function 'rotating_file_sink < std :: mutex >::get_max_files' can be const.
spdlog/include/spdlog/sinks/rotating_file_sink.h:51:performance:functionStatic -> Technically the member function 'rotating_file_sink < std :: mutex >::rename_file_' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/sinks/rotating_file_sink.h:33:style:functionConst -> Technically the member function 'rotating_file_sink < spdlog :: details :: null_mutex >::get_max_size' can be const.
spdlog/include/spdlog/sinks/rotating_file_sink.h:35:style:functionConst -> Technically the member function 'rotating_file_sink < spdlog :: details :: null_mutex >::get_max_files' can be const.
spdlog/include/spdlog/sinks/rotating_file_sink.h:51:performance:functionStatic -> Technically the member function 'rotating_file_sink < spdlog :: details :: null_mutex >::rename_file_' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/async_logger-inl.h:60:style:funcArgNamesDifferent -> Function 'backend_sink_it_' argument 1 names different: declaration 'incoming_log_msg' definition 'msg'.
spdlog/include/spdlog/cfg/helpers-inl.h:73:style:funcArgNamesDifferent -> Function 'load_levels' argument 1 names different: declaration 'txt' definition 'input'.
spdlog/include/spdlog/sinks/daily_file_sink.h:110:style:shadowFunction -> Local variable 'filename' shadows outer function
spdlog/include/spdlog/sinks/daily_file_sink.h:134:style:shadowFunction -> Local variable 'filename' shadows outer function
spdlog/include/spdlog/spdlog.h:149:performance:passedByValueCallback -> Function parameter 'source' should be passed by const reference. However it seems that 'log' is a callback function.
spdlog/include/spdlog/sinks/udp_sink.h:39:performance:passedByValue -> Function parameter 'sink_config' should be passed by const reference.
spdlog/include/spdlog/sinks/daily_file_sink.h:146:performance:functionStatic -> Technically the member function 'daily_file_sink < std :: mutex , spdlog :: sinks :: daily_filename_calculator >::now_tm' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/sinks/daily_file_sink.h:146:performance:functionStatic -> Technically the member function 'daily_file_sink < std :: mutex , custom_daily_file_name_calculator >::now_tm' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/sinks/daily_file_sink.h:146:performance:functionStatic -> Technically the member function 'daily_file_sink < details :: null_mutex , daily_filename_calculator >::now_tm' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/sinks/daily_file_sink.h:181:warning:accessMoved -> Access of moved variable 'current_file'.
spdlog/include/spdlog/sinks/daily_file_sink.h:100:style:functionConst -> Technically the member function 'spdlog::sinks::daily_file_sink::filename' can be const.
spdlog/include/spdlog/sinks/daily_file_sink.h:146:performance:functionStatic -> Technically the member function 'spdlog::sinks::daily_file_sink::now_tm' can be static (but you may consider moving to unnamed namespace).
spdlog/include/spdlog/sinks/dup_filter_sink.h:81:style:functionConst -> Technically the member function 'dup_filter_sink < std :: mutex >::filter_' can be const.
spdlog/include/spdlog/sinks/dist_sink.h:26:performance:passedByValue -> Function parameter 'sinks' should be passed by const reference.
include/spdlog/details/udp_client.h:74:style:unreadVariable -> Variable 'toslen' is assigned a value that is never used.
include/spdlog/details/udp_client.h:74:style:cstyleCast -> C-style pointer casting


spdlog/tests/test_file_helper.cpp:168:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
spdlog/tests/test_file_logging.cpp:118:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
spdlog/tests/test_misc.cpp:211:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_misc.cpp:215:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_misc.cpp:216:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_misc.cpp:223:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_sink.h:23:style:functionConst -> Technically the member function 'test_sink < std :: mutex >::msg_counter' can be const.
spdlog/tests/test_sink.h:28:style:functionConst -> Technically the member function 'test_sink < std :: mutex >::flush_counter' can be const.
spdlog/tests/test_sink.h:39:style:functionConst -> Technically the member function 'test_sink < std :: mutex >::lines' can be const.
spdlog/tests/test_misc.cpp:209:style:variableScope -> The scope of the variable 'msg' can be reduced.
spdlog/tests/test_sink.h:49:style:variableScope -> The scope of the variable 'eol_len' can be reduced.
spdlog/tests/test_pattern_formatter.cpp:507:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
spdlog/tests/test_async.cpp:173:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_async.cpp:11:style:variableScope -> The scope of the variable 'queue_size' can be reduced.
spdlog/tests/test_async.cpp:79:style:variableScope -> The scope of the variable 'queue_size' can be reduced.
spdlog/tests/test_async.cpp:127:style:variableScope -> The scope of the variable 'queue_size' can be reduced.
spdlog/tests/test_async.cpp:157:style:variableScope -> The scope of the variable 'tp_threads' can be reduced.
spdlog/tests/test_async.cpp:158:style:variableScope -> The scope of the variable 'filename' can be reduced.
spdlog/tests/test_async.cpp:179:style:variableScope -> The scope of the variable 'tp_threads' can be reduced.
spdlog/tests/test_async.cpp:180:style:variableScope -> The scope of the variable 'filename' can be reduced.
spdlog/tests/test_registry.cpp:12:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
spdlog/tests/test_macros.cpp:27:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_macros.cpp:39:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/utils.cpp:95:style:constVariablePointer -> Variable 'ep' can be declared as pointer to const
spdlog/tests/test_mpmc_q.cpp:83:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_mpmc_q.cpp:90:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_sink.h:23:style:functionConst -> Technically the member function 'test_sink < details :: null_mutex >::msg_counter' can be const.
spdlog/tests/test_sink.h:28:style:functionConst -> Technically the member function 'test_sink < details :: null_mutex >::flush_counter' can be const.
spdlog/tests/test_sink.h:39:style:functionConst -> Technically the member function 'test_sink < details :: null_mutex >::lines' can be const.
spdlog/tests/test_create_dir.cpp:19:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:21:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:23:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:25:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:27:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:44:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_create_dir.cpp:45:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_circular_q.cpp:9:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_circular_q.cpp:40:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_circular_q.cpp:49:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:14:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:27:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:40:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:52:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:64:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:68:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:72:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:77:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:90:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_bin_to_hex.cpp:95:style:comparisonOfFuncReturningBoolError -> Comparison of a function returning boolean value using relational (<, >, <= or >=) operator.
spdlog/tests/test_ringbuffer.cpp:5:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
spdlog/tests/test_errors.cpp:45:error:unknownMacro -> There is an unknown macro here somewhere. Configuration is required. If _catch_sr is a macro then please configure it.
```