### PR TITLE
Fix: Initialize null_atomic_int::value to zero

### DIFF
--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -15,7 +15,7 @@ struct null_mutex {
 };
 
 struct null_atomic_int {
-    int value;
+    int value{0};
     null_atomic_int() = default;
 
     explicit null_atomic_int(int new_value)


### PR DESCRIPTION
Hello,

This PR contain fixes the uninitialized member variable warning reported by Cppcheck.

```bash
spdlog/include/spdlog/details/null_mutex.h:19:warning:uninitMemberVar -> Member variable ‘null_atomic_int::value’ is not initialized in the constructor.
```

The **default constructor**  initialized the ‘value’ to zero only for static/thread-local objects prior to C++20. Since C++20, value initialization is performed for all storage durations [P0883R2](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0883r2.pdf), [cppreference](https://en.cppreference.com/w/cpp/atomic/atomic/atomic).

By tightening the release flags, I receive a warning from the compiler with test code like the following. In Debug mode, the output points to a random value.

Code:
```cpp

#include <iostream>
#include <iomanip>
#include "null_mutex.h"

int main() {
    spdlog::details::null_atomic_int x;
    std::cout << "Value: " << x.load() << " (hex: 0x" << std::hex << x.load() << ")" << std::endl;
    return 0;
}
```

Release Compile with -Wextra/-Werror:
```bash
main.cpp:41:43: error: ‘x.spdlog::details::null_atomic_int::value’ is used uninitialized [-Werror=uninitialized]
   41 |     std::cout << “Value: ” << x.load() << “ (hex: 0x” << std::hex << x.load() << “)” << std::endl;
      |                                           ^~~~~~~~~~~
main.cpp:40:38: note: ‘x.spdlog::details::null_atomic_int::value’ was declared here
   40 |     spdlog::details::null_atomic_int x;
      |                                      ^
cc1plus: all warnings being treated as errors
```

Debug Output:
```bash
Value: 32527 (hex: 0x7f0f)
```

However, it would be good to check that this development has no side effects.

Best regards.