### PR TITLE
Add missing const qualifiers to reference variables

### DIFF
--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -257,7 +257,7 @@ SPDLOG_INLINE void registry::throw_if_exists_(const std::string &logger_name) {
 }
 
 SPDLOG_INLINE void registry::register_logger_(std::shared_ptr<logger> new_logger) {
-    auto &logger_name = new_logger->name();
+    const auto &logger_name = new_logger->name();
     throw_if_exists_(logger_name);
     loggers_[logger_name] = std::move(new_logger);
 }

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -813,7 +813,7 @@ public:
         : flag_formatter(padinfo) {}
 
     void format(const details::log_msg &, const std::tm &, memory_buf_t &dest) override {
-        auto &mdc_map = mdc::get_context();
+        const auto &mdc_map = mdc::get_context();
         if (mdc_map.empty()) {
             ScopedPadder p(0, padinfo_, dest);
             return;
@@ -823,11 +823,10 @@ public:
     }
 
     void format_mdc(const mdc::mdc_map_t &mdc_map, memory_buf_t &dest) {
-        auto last_element = --mdc_map.end();
+        const auto last_element = std::prev(mdc_map.end());
         for (auto it = mdc_map.begin(); it != mdc_map.end(); ++it) {
-            auto &pair = *it;
-            const auto &key = pair.first;
-            const auto &value = pair.second;
+            const auto &key = it->first;
+            const auto &value = it->second;
             size_t content_size = key.size() + value.size() + 1;  // 1 for ':'
 
             if (it != last_element) {


### PR DESCRIPTION
Hello,

This PR was created to resolve CppCheck `constVariableReference` warnings by adding `const` qualifiers to reference variables that remain unchanged after initialization. (I am analyzing the sections I shared in the CppCheck report from my first cppcheck review PR request, filtering false positives, and attempting to resolve them in batches.)

```bash
Const Variable Reference
-------------------------------------
spdlog/include/spdlog/details/registry-inl.h:260:style:constVariableReference -> Variable 'logger_name' can be declared as reference to const
spdlog/include/spdlog/pattern_formatter-inl.h:927:style:constVariableReference -> Variable 'mdc_map' can be declared as reference to const
spdlog/include/spdlog/pattern_formatter-inl.h:828:style:constVariableReference -> Variable 'pair' can be declared as reference to const
```

Changes:
- Generally, references to `registry-inl.h: logger_name` and `pattern_formatter-inl.h: mdc_map` were marked as const.
- pattern_formatter-inl.h: The intermediate `pair` variable was removed, allowing direct access to members via the iterator. The order `auto`, `const auto`, `const auto` in the code caused hesitation at first glance.
- pattern_formatter-inl.h: `std::prev()` was used instead of `--mdc_map.end()` for safer iterator reduction.

---

### Note 1: About the `std::prev()` change:
I'm not entirely sure about replacing `--mdc_map.end()` with `std::prev(mdc_map.end())`.  The original code decays a temporary iterator (rvalue), which could cause undefined behavior in some iterator implementations. `std::prev()` prevents this by internally copying the iterator. However, in this case, **there is a very low cost. However, it introduces a small copying overhead. I leave the final decision to you as to whether the security benefit justifies the cost.**

### Note 2:
The `const` qualifier [here](https://github.com/gabime/spdlog/pull/3514/changes#diff-e591991f61b22b7318224db97cb0bf05f12154667905231b2f21b74f39acf70cR826) is not actually required. It is already clear from the function's parameter that the value does not change. However, I think knowing that it is not modified in the iterator during reading makes for a more comfortable read.

---

Of course, I may make mistakes in a code base I'm not familiar with. If you want to change anything, just leave me a comment.

Best regards.