### PR TITLE
Add const qualifier to some member functions

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -1011,7 +1011,7 @@ SPDLOG_INLINE void pattern_formatter::set_pattern(std::string pattern) {
 
 SPDLOG_INLINE void pattern_formatter::need_localtime(bool need) { need_localtime_ = need; }
 
-SPDLOG_INLINE std::tm pattern_formatter::get_time_(const details::log_msg &msg) {
+SPDLOG_INLINE std::tm pattern_formatter::get_time_(const details::log_msg &msg) const {
     if (pattern_time_type_ == pattern_time_type::local) {
         return details::os::localtime(log_clock::to_time_t(msg.time));
     }

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -99,7 +99,7 @@ private:
     std::vector<std::unique_ptr<details::flag_formatter>> formatters_;
     custom_flags custom_handlers_;
 
-    std::tm get_time_(const details::log_msg &msg);
+    std::tm get_time_(const details::log_msg &msg) const;
     template <typename Padder>
     void handle_flag_(char flag, details::padding_info padding);
 

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -78,8 +78,8 @@ protected:
     }
 
     // return whether the log msg should be displayed (true) or skipped (false)
-    bool filter_(const details::log_msg &msg) {
-        auto filter_duration = msg.time - last_msg_time_;
+    bool filter_(const details::log_msg &msg) const {
+        const auto filter_duration = msg.time - last_msg_time_;
         return (filter_duration > max_skip_duration_) || (msg.payload != last_msg_payload_);
     }
 };


### PR DESCRIPTION
Hello,

This PR was created to resolve CppCheck `functionConst` warnings. Essentially, if we ignore the `tests` directory, the warnings obtained are as follows:

---

### Solved
```bash
include/spdlog/pattern_formatter.h:102:style:functionConst -> Technically the member function 'spdlog::pattern_formatter::get_time_' can be const.
include/spdlog/sinks/dup_filter_sink.h:81:style:functionConst -> Technically the member function 'dup_filter_sink < std :: mutex >::filter_' can be const.
```

The `pattern_formatter.h/inl.h : get_time_()` and `dup_filter_sink.h : filter_()` functions have been modified by marking them as const.

---

### It was ignored due to its large-scale impact:
```bash
include/spdlog/sinks/rotating_file_sink.h:33:style:functionConst -> Technically the member function 'rotating_file_sink < std :: mutex >::get_max_size' can be const.
include/spdlog/sinks/rotating_file_sink.h:35:style:functionConst -> Technically the member function 'rotating_file_sink < std :: mutex >::get_max_files' can be const.
include/spdlog/sinks/rotating_file_sink.h:33:style:functionConst -> Technically the member function 'rotating_file_sink < spdlog :: details :: null_mutex >::get_max_size' can be const.
include/spdlog/sinks/rotating_file_sink.h:35:style:functionConst -> Technically the member function 'rotating_file_sink < spdlog :: details :: null_mutex >::get_max_files' can be const.
include/spdlog/sinks/daily_file_sink.h:100:style:functionConst -> Technically the member function 'spdlog::sinks::daily_file_sink::filename' can be const.
```

These functions use `std::lock_guard<Mutex>` for thread-safety:
```cpp
template <typename Mutex>
SPDLOG_INLINE std::size_t rotating_file_sink<Mutex>::get_max_size() {
    std::lock_guard<Mutex> lock(base_sink<Mutex>::mutex_);
    return max_size_;
}
```

However, the remaining warnings require the `std::mutex` object used from `base_sink` to be declared as `mutable`. Since this would affect all parts using `base_sink`, some of the warnings have been ignored.

---

**NOTE: These changes will result in changes to the function signatures in the API interface. If there is a situation that needs to be tested for this, please let me know.**

There may be errors or omissions. If you leave a comment, I will gladly try to address it.

Best regards.