### PR TITLE
Rename local variables to avoid shadowing member functions

### DIFF
--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -164,8 +164,7 @@ SPDLOG_INLINE void logger::dump_backtrace_() {
 }
 
 SPDLOG_INLINE bool logger::should_flush_(const details::log_msg &msg) const {
-    auto flush_level = flush_level_.load(std::memory_order_relaxed);
-    return (msg.level >= flush_level) && (msg.level != level::off);
+    return (msg.level >= flush_level()) && (msg.level != level::off);
 }
 
 SPDLOG_INLINE void logger::err_handler_(const std::string &msg) const {

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -88,8 +88,8 @@ public:
         }
 
         auto now = log_clock::now();
-        auto filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
-        file_helper_.open(filename, truncate_);
+        const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
+        file_helper_.open(new_filename, truncate_);
         rotation_tp_ = next_rotation_tp_();
 
         if (max_files_ > 0) {
@@ -107,8 +107,8 @@ protected:
         auto time = msg.time;
         bool should_rotate = time >= rotation_tp_;
         if (should_rotate) {
-            auto filename = FileNameCalc::calc_filename(base_filename_, now_tm(time));
-            file_helper_.open(filename, truncate_);
+            const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(time));
+            file_helper_.open(new_filename, truncate_);
             rotation_tp_ = next_rotation_tp_();
         }
         memory_buf_t formatted;
@@ -131,11 +131,11 @@ private:
         std::vector<filename_t> filenames;
         auto now = log_clock::now();
         while (filenames.size() < max_files_) {
-            auto filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
-            if (!path_exists(filename)) {
+            const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
+            if (!path_exists(new_filename)) {
                 break;
             }
-            filenames.emplace_back(filename);
+            filenames.emplace_back(new_filename);
             now -= std::chrono::hours(24);
         }
         for (auto iter = filenames.rbegin(); iter != filenames.rend(); ++iter) {


### PR DESCRIPTION
Hello,

This PR addresses CppCheck `shadowFunction` style warnings by renaming local variables that shadow member functions. These warnings can often be ignored, as modern compilers handle this well, but I believe it's good to strengthen the fundamentals.

CppCheck style warning messages addressed:
```bash
Shadow Function
-------------------------------------
include/spdlog/logger-inl.h:167:style:shadowFunction -> Local variable 'flush_level' shadows outer function
include/spdlog/sinks/daily_file_sink.h:110:style:shadowFunction -> Local variable 'filename' shadows outer function
include/spdlog/sinks/daily_file_sink.h:134:style:shadowFunction -> Local variable 'filename' shadows outer function
```

- `should_flush_()`: The local variable `flush_level` was directly modified by a call to the member function `flush_level()`. This returns the appropriately converted `level::level_enum` return type instead of the raw `int` from the atomic load (prevents implicit type conversion). 

   **However, it would be good to verify this change for atomic. I am not sure this!**

- I updated the naming of local variables with the `new_` prefix for the `filename()` function declaration in the `daily_file_sink.h` file. 

   For consistency, I also adjusted the constructor method for compatibility. This shadowing warning is not given because the `filename()` member function is not yet accessible in the constructor body (the object has not been fully created).

Best regards.