### PR TITLE
Fix function arguments names different warnings

### DIFF
--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -57,15 +57,15 @@ SPDLOG_LOGGER_CATCH(source_loc())
 //
 // backend functions - called from the thread pool to do the actual job
 //
-SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg &msg) {
+SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg &incoming_log_msg) {
     for (auto &sink : sinks_) {
-        if (sink->should_log(msg.level)) {
-            SPDLOG_TRY { sink->log(msg); }
-            SPDLOG_LOGGER_CATCH(msg.source)
+        if (sink->should_log(incoming_log_msg.level)) {
+            SPDLOG_TRY { sink->log(incoming_log_msg); }
+            SPDLOG_LOGGER_CATCH(incoming_log_msg.source)
         }
     }
 
-    if (should_flush_(msg)) {
+    if (should_flush_(incoming_log_msg)) {
         backend_flush_();
     }
 }

--- a/include/spdlog/cfg/argv.h
+++ b/include/spdlog/cfg/argv.h
@@ -26,8 +26,8 @@ inline void load_argv_levels(int argc, const char **argv) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
         if (arg.find(spdlog_level_prefix) == 0) {
-            auto levels_string = arg.substr(spdlog_level_prefix.size());
-            helpers::load_levels(levels_string);
+            const auto levels_spec = arg.substr(spdlog_level_prefix.size());
+            helpers::load_levels(levels_spec);
         }
     }
 }

--- a/include/spdlog/cfg/env.h
+++ b/include/spdlog/cfg/env.h
@@ -26,9 +26,9 @@
 namespace spdlog {
 namespace cfg {
 inline void load_env_levels(const char* var = "SPDLOG_LEVEL") {
-    auto env_val = details::os::getenv(var);
-    if (!env_val.empty()) {
-        helpers::load_levels(env_val);
+    const auto levels_spec = details::os::getenv(var);
+    if (!levels_spec.empty()) {
+        helpers::load_levels(levels_spec);
     }
 }
 

--- a/include/spdlog/cfg/helpers-inl.h
+++ b/include/spdlog/cfg/helpers-inl.h
@@ -70,12 +70,12 @@ inline std::unordered_map<std::string, std::string> extract_key_vals_(const std:
     return rv;
 }
 
-SPDLOG_INLINE void load_levels(const std::string &input) {
-    if (input.empty() || input.size() >= 32768) {
+SPDLOG_INLINE void load_levels(const std::string &levels_spec) {
+    if (levels_spec.empty() || levels_spec.size() >= 32768) {
         return;
     }
 
-    auto key_vals = extract_key_vals_(input);
+    auto key_vals = extract_key_vals_(levels_spec);
     std::unordered_map<std::string, level::level_enum> levels;
     level::level_enum global_level = level::info;
     bool global_level_found = false;
@@ -83,7 +83,7 @@ SPDLOG_INLINE void load_levels(const std::string &input) {
     for (auto &name_level : key_vals) {
         const auto &logger_name = name_level.first;
         const auto &level_name = to_lower_(name_level.second);
-        auto level = level::from_str(level_name);
+        const auto level = level::from_str(level_name);
         // ignore unrecognized level names
         if (level == level::off && level_name != "off") {
             continue;

--- a/include/spdlog/cfg/helpers.h
+++ b/include/spdlog/cfg/helpers.h
@@ -18,7 +18,7 @@ namespace helpers {
 // turn off all logging except for logger1: "off,logger1=debug"
 // turn off all logging except for logger1 and logger2: "off,logger1=debug,logger2=info"
 //
-SPDLOG_API void load_levels(const std::string &txt);
+SPDLOG_API void load_levels(const std::string &levels_spec);
 }  // namespace helpers
 
 }  // namespace cfg

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -75,7 +75,7 @@ SPDLOG_API level::level_enum get_level();
 SPDLOG_API void set_level(level::level_enum log_level);
 
 // Determine whether the default logger should log messages with a certain level
-SPDLOG_API bool should_log(level::level_enum lvl);
+SPDLOG_API bool should_log(level::level_enum log_level);
 
 // Set a global flush level
 SPDLOG_API void flush_on(level::level_enum log_level);


### PR DESCRIPTION
Hello,

This pull request addresses CppCheck's `Function Arguments Names Different` warnings. Additional information on this topic was provided in the discussion section [here](https://github.com/gabime/spdlog/discussions/3517). 

Here is the list of warnings:
```bash
include/spdlog/details/log_msg-inl.h:38:style:funcArgNamesDifferent -> Function 'log_msg' argument 1 names different: declaration 'logger_name' definition 'a_logger_name'.
include/spdlog/spdlog-inl.h:42:style:funcArgNamesDifferent -> Function 'should_log' argument 1 names different: declaration 'lvl' definition 'log_level'.
include/spdlog/async_logger-inl.h:60:style:funcArgNamesDifferent -> Function 'backend_sink_it_' argument 1 names different: declaration 'incoming_log_msg' definition 'msg'.
include/spdlog/cfg/helpers-inl.h:73:style:funcArgNamesDifferent -> Function 'load_levels' argument 1 names different: declaration 'txt' definition 'input'.
```
---

**While fixing the warnings, I ended up making more changes than I initially anticipated.** Therefore, to make it easier for you to review and understand, I created a separate commit for each warning and will summarize my actions. **After the review, I can squash them into a single commit.**

Looking at the commits in the branch from the end to the beginning;

* helpers-inl.h - load_levels -> ‘txt’ -> ‘input’

    Although there are many different names used for the `load_levels` function and its parameter, such as `txt`, `input`, and `levels_string`, it serves multiple purposes. Its primary purpose is to parse a string in the format `off,logger1=debug,logger2=info` and set the log levels.

    To resolve the naming confusion here, I updated the name to `levels_spec`. It is a specification that defines how levels are configured. This term is commonly used in technical literature for format strings and DSL-like structures.

    This does not affect API compatibility.

* async_logger-inl.h - backend_sink_it_ -> ‘incoming_log_msg’ -> 'msg'

    There is a deliberate semantic distinction between the frontend (`sink_it_`) and backend (`backend_sink_it_`) functions in the `async_logger` class. In the frontend, the message is processed in the context of the thread that called it immediately, while in the backend, the message has been queued, is time-delayed, and has changed ownership. _Please correct me if I'm misunderstanding the design intent._
    
    While the name `incoming_log_msg` was used in the declaration to reflect this distinction, the definition simply used `msg`. The definition was corrected to `incoming_log_msg` to match the declaration. This both resolved the warning and preserved the semantic distinction in the design.

    Does not affect API compatibility.

* spdlog-inl.h - should_log -> ‘lvl’ -> 'log_level'

    `lvl` was used in the declaration, while `log_level` was used in the definition. Since the `set_level` and `flush_on` functions in the same file pair (`spdlog.h` / `spdlog-inl.h`) also use the `log_level` parameter, the declaration was updated to `log_level` for consistency.

    This does not affect API compatibility.

---

Unimplemented Change:

* log_msg-inl.h - log_msg -> ‘logger_name’ - 'a_logger_name'

    In this case, the easy solution would be to change the content of the `logger_name` parameter in the second constructor function to `a_logger_name`. However, this would create a significant inconsistency by affecting the readability and understanding of the header file. The question is likely to arise: why is there no `a_` prefix in the other parameters?

    I believe the most appropriate approach is to add the `m_` (member) prefix to the `log_msg` struct member variables and adjust the signatures accordingly. However, this would require modifying all member variables in their accessible areas (which would be quite extensive!). Therefore, I decided not to intervene on this point as it would also affect API compatibility.

    _Perhaps we can address this in the future or in a separate PR if you wish, and I can assist you._ FYI @tt4g

---

I may always have mistakes and omissions, so just leave a comment. I will look into it when I have time.

Best regards.