### PR TITLE
The upd_sink and dist_sink files have been modified to address Passed by value warnings

### DIFF
--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -24,7 +24,7 @@ class dist_sink : public base_sink<Mutex> {
 public:
     dist_sink() = default;
     explicit dist_sink(std::vector<std::shared_ptr<sink>> sinks)
-        : sinks_(sinks) {}
+        : sinks_(std::move(sinks)) {}
 
     dist_sink(const dist_sink &) = delete;
     dist_sink &operator=(const dist_sink &) = delete;

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -36,7 +36,7 @@ template <typename Mutex>
 class udp_sink : public spdlog::sinks::base_sink<Mutex> {
 public:
     // host can be hostname or ip address
-    explicit udp_sink(udp_sink_config sink_config)
+    explicit udp_sink(const udp_sink_config& sink_config)
         : client_{sink_config.server_host, sink_config.server_port} {}
 
     ~udp_sink() override = default;


### PR DESCRIPTION
Hello,

This pull request addresses CppCheck's `Passed By Value` warnings. Additional information on this topic was provided in the discussion section [here](https://github.com/gabime/spdlog/discussions/3517), and unnecessary/misleading warnings were removed from the list.

Remaining Warnings;
```bash
include/spdlog/sinks/udp_sink.h:39:performance:passedByValue -> Function parameter ‘sink_config’ should be passed by const reference.
include/spdlog/sinks/dist_sink.h:26:performance:passedByValue -> Function parameter ‘sinks’ should be passed by const reference.
```

---

**I'm not sure about the explicit constructor in `dist_sink.h`!** 

When `vector<shared_ptr<...>>` is copied here, each shared_ptr is copied, creating shared ownership of the relevant objects. In this case, ownership of the objects is shared between the caller and the objects. 

If the caller provides an rvalue with `std::move`, the container and its elements are moved; the caller's argument becomes moved-from (valid but with undefined content). This does not guarantee absolute sole ownership of the managed objects; if there are other copies of `shared_ptr`, ownership is already shared.

Since this ctor stores the parameter internally, I passed it to the member using `by-value + std::move` to reduce unnecessary copying without changing the API. This approach does not move the caller's argument in lvalue calls; in rvalue calls, it allows direct transfer. 

**However, I'm a bit hesitant about this improvement.** Since this forward-looking constructor is not currently used in the project, it could be removed, or if clearer behavior is desired, `const&` + `&&` overload alternatives could be considered.

---

That said, I fixed warnings as much as possible outside of `fmt` and `tests`. If you notice anything I missed, please let me know via comment/ping; I'll address it when I can. I'll keep the Discussion topic open for a while in case it turns out to be a bug (as I mentioned earlier). (I'm thinking a maximum of 1 week.)

Thank you for your guidance.

Best regards.