### PR TITLE
Fix shadow member warning in example file

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -267,16 +267,16 @@ void multi_sink_example() {
 
 // User defined types logging
 struct my_type {
-    int i = 0;
-    explicit my_type(int i)
-        : i(i) {}
+    int value_ = 0;
+    explicit my_type(int value)
+        : value_(value) {}
 };
 
 #ifndef SPDLOG_USE_STD_FORMAT  // when using fmtlib
 template <>
 struct fmt::formatter<my_type> : fmt::formatter<std::string> {
     auto format(my_type my, format_context &ctx) const -> decltype(ctx.out()) {
-        return fmt::format_to(ctx.out(), "[my_type i={}]", my.i);
+        return fmt::format_to(ctx.out(), "[my_type value={}]", my.value_);
     }
 };
 
@@ -284,7 +284,7 @@ struct fmt::formatter<my_type> : fmt::formatter<std::string> {
 template <>
 struct std::formatter<my_type> : std::formatter<std::string> {
     auto format(my_type my, format_context &ctx) const -> decltype(ctx.out()) {
-        return std::format_to(ctx.out(), "[my_type i={}]", my.i);
+        return std::format_to(ctx.out(), "[my_type value={}]", my.value_);
     }
 };
 #endif


### PR DESCRIPTION
Hello,

This PR resolves the following compiler warning occurring in the `example.cpp` file.

```bash
spdlog/example/example.cpp: In constructor 'my_type::my_type(int)':
spdlog/example/example.cpp:271:26: error: declaration of 'i' shadows a member of 'my_type' [-Werror=shadow]
271 | explicit my_type(int i)
| ~~~~^
```

I thought using a different name instead of `i` would be more understandable. Additionally, as you previously mentioned in another PR request, I added an underscore `_` to the end of the member variable, in line with the project approach.

If any other changes are needed, please leave a comment.

---

**Additional Note:** What are your thoughts on additional flags compatible with older compiler versions (GCC 4.8+, Clang 3.3+)? The `-Wold-style-cast` flag came to mind during development #3509. Enabling such flags can help contributors detect these types of errors early on.

I cannot run MSVC tests because I don't have a Windows environment. I can add additional flags to the `utils.cmake` file for GCC/Clang. (`-Wold-style-cast`, `-Wshadow` maybe)

Best Regards.