### PR TITLE
make level_enum from_str() case insensitive #3525

### DIFF
--- a/include/spdlog/cfg/helpers-inl.h
+++ b/include/spdlog/cfg/helpers-inl.h
@@ -19,13 +19,6 @@ namespace spdlog {
 namespace cfg {
 namespace helpers {
 
-// inplace convert to lowercase
-inline std::string &to_lower_(std::string &str) {
-    std::transform(str.begin(), str.end(), str.begin(), [](char ch) {
-        return static_cast<char>((ch >= 'A' && ch <= 'Z') ? ch + ('a' - 'A') : ch);
-    });
-    return str;
-}
 
 // inplace trim spaces
 inline std::string &trim_(std::string &str) {
@@ -82,10 +75,9 @@ SPDLOG_INLINE void load_levels(const std::string &levels_spec) {
 
     for (auto &name_level : key_vals) {
         const auto &logger_name = name_level.first;
-        const auto &level_name = to_lower_(name_level.second);
-        const auto level = level::from_str(level_name);
+        const auto level = level::from_str(name_level.second);
         // ignore unrecognized level names
-        if (level == level::off && level_name != "off") {
+        if (level == level::off && !strings_equal_ci(name_level.second, to_string_view(level::off))) {
             continue;
         }
         if (logger_name.empty())  // no logger name indicates global level

--- a/include/spdlog/cfg/helpers.h
+++ b/include/spdlog/cfg/helpers.h
@@ -19,6 +19,7 @@ namespace helpers {
 // turn off all logging except for logger1 and logger2: "off,logger1=debug,logger2=info"
 //
 SPDLOG_API void load_levels(const std::string &levels_spec);
+
 }  // namespace helpers
 
 }  // namespace cfg

--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -29,15 +29,18 @@ SPDLOG_INLINE const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOE
 }
 
 SPDLOG_INLINE spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT {
-    auto it = std::find(std::begin(level_string_views), std::end(level_string_views), name);
+    auto it = std::find_if(std::begin(level_string_views), std::end(level_string_views),
+                           [name](string_view_t sv) { return strings_equal_ci(name, sv); } );
+
     if (it != std::end(level_string_views))
         return static_cast<level::level_enum>(std::distance(std::begin(level_string_views), it));
 
     // check also for "warn" and "err" before giving up..
-    if (name == "warn") {
+    if (strings_equal_ci(name, "warn") && strings_equal_ci(to_string_view(level::warn), "warning")) {
         return level::warn;
     }
-    if (name == "err") {
+    else if (strings_equal_ci(name, "err") && strings_equal_ci(to_string_view(level::err), "error")) {
+    // if (name == "err") {
         return level::err;
     }
     return level::off;
@@ -64,5 +67,25 @@ SPDLOG_INLINE void throw_spdlog_ex(const std::string &msg, int last_errno) {
 }
 
 SPDLOG_INLINE void throw_spdlog_ex(std::string msg) { SPDLOG_THROW(spdlog_ex(std::move(msg))); }
+
+#if __cplusplus >= 201703L
+constexpr
+#endif
+SPDLOG_API char to_lower(char ch) {
+    return static_cast<char>((ch >= 'A' && ch <= 'Z') ? ch + ('a' - 'A') : ch);
+}
+
+
+SPDLOG_INLINE bool strings_equal_ci(string_view_t s1, string_view_t s2) {
+    if (s1.size() != s2.size()) {
+        return false;
+    }
+    for(size_t idx = 0; idx < s1.size(); idx++) {
+        if (to_lower(s1[idx]) != to_lower(s2[idx])) {
+            return false;
+        }
+    }
+    return true;
+}
 
 }  // namespace spdlog

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -278,6 +278,9 @@ enum level_enum : int {
 
 SPDLOG_API const string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
 SPDLOG_API const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
+
+// Checks whether name is the same as one of the log level names and returns the respective enum.
+// The comparison is case-insensitive.
 SPDLOG_API spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
 
 }  // namespace level
@@ -295,6 +298,11 @@ enum class pattern_time_type {
     local,  // log localtime
     utc     // log utc
 };
+
+//
+// Returns true if two strings are equal, case-insensitive
+//
+SPDLOG_API bool strings_equal_ci(string_view_t s1, string_view_t s2);
 
 //
 // Log exception

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -65,11 +65,13 @@ TEST_CASE("to_short_c_str", "[convert_to_short_c_str]") {
 
 TEST_CASE("to_level_enum", "[convert_to_level_enum]") {
     REQUIRE(spdlog::level::from_str("trace") == spdlog::level::trace);
+    REQUIRE(spdlog::level::from_str("TrAcE") == spdlog::level::trace);
     REQUIRE(spdlog::level::from_str("debug") == spdlog::level::debug);
     REQUIRE(spdlog::level::from_str("info") == spdlog::level::info);
     REQUIRE(spdlog::level::from_str("warning") == spdlog::level::warn);
     REQUIRE(spdlog::level::from_str("warn") == spdlog::level::warn);
     REQUIRE(spdlog::level::from_str("error") == spdlog::level::err);
+    REQUIRE(spdlog::level::from_str("err") == spdlog::level::err);
     REQUIRE(spdlog::level::from_str("critical") == spdlog::level::critical);
     REQUIRE(spdlog::level::from_str("off") == spdlog::level::off);
     REQUIRE(spdlog::level::from_str("null") == spdlog::level::off);


### PR DESCRIPTION
This patch changes the behaviour of from_str() so that the level names are compared case-insensitive.
This has the side effect of making load_levels() work if the names were set to UPPER oder CamelCase in tweakme.h.

Beside that, now also the special cases for "off", "err" and "warn" now check that the names are actually "off", "error" and "warning" and have not been set to something else.
It would be strange behaviour if I would set the name of the error level e.g. to "Fehler" and spdlog would recognize "fehler" and also "err", but not "error" as that level.

The test also checks a mixed case string now, and also "err".