### PR TITLE
Fix #3525: Make level name matching case-insensitive

### DIFF
--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -29,15 +29,31 @@ SPDLOG_INLINE const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOE
 }
 
 SPDLOG_INLINE spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT {
-    auto it = std::find(std::begin(level_string_views), std::end(level_string_views), name);
+    auto it = std::find_if(std::begin(level_string_views), std::end(level_string_views),
+                           [&name](const string_view_t &level_name) {
+                               return level_name.size() == name.size() &&
+                                      std::equal(name.begin(), name.end(), level_name.begin(),
+                                                 [](char a, char b) {
+                                                     return std::tolower(static_cast<unsigned char>(a)) ==
+                                                            std::tolower(static_cast<unsigned char>(b));
+                                                 });
+                           });
     if (it != std::end(level_string_views))
         return static_cast<level::level_enum>(std::distance(std::begin(level_string_views), it));
 
     // check also for "warn" and "err" before giving up..
-    if (name == "warn") {
+    auto iequals = [](const std::string &a, const std::string &b) {
+        return a.size() == b.size() &&
+               std::equal(a.begin(), a.end(), b.begin(), [](char ac, char bc) {
+                   return std::tolower(static_cast<unsigned char>(ac)) ==
+                          std::tolower(static_cast<unsigned char>(bc));
+               });
+    };
+
+    if (iequals(name, "warn")) {
         return level::warn;
     }
-    if (name == "err") {
+    if (iequals(name, "err")) {
         return level::err;
     }
     return level::off;

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -73,6 +73,17 @@ TEST_CASE("to_level_enum", "[convert_to_level_enum]") {
     REQUIRE(spdlog::level::from_str("critical") == spdlog::level::critical);
     REQUIRE(spdlog::level::from_str("off") == spdlog::level::off);
     REQUIRE(spdlog::level::from_str("null") == spdlog::level::off);
+    REQUIRE(spdlog::level::from_str("TRACE") == spdlog::level::trace);
+    REQUIRE(spdlog::level::from_str("DEBUG") == spdlog::level::debug);
+    REQUIRE(spdlog::level::from_str("INFO") == spdlog::level::info);
+    REQUIRE(spdlog::level::from_str("WARNING") == spdlog::level::warn);
+    REQUIRE(spdlog::level::from_str("WARN") == spdlog::level::warn);
+    REQUIRE(spdlog::level::from_str("ERROR") == spdlog::level::err);
+    REQUIRE(spdlog::level::from_str("ERR") == spdlog::level::err);
+    REQUIRE(spdlog::level::from_str("CRITICAL") == spdlog::level::critical);
+    REQUIRE(spdlog::level::from_str("OFF") == spdlog::level::off);
+    REQUIRE(spdlog::level::from_str("TrAcE") == spdlog::level::trace);
+    REQUIRE(spdlog::level::from_str("DeBuG") == spdlog::level::debug);
 }
 
 TEST_CASE("periodic flush", "[periodic_flush]") {


### PR DESCRIPTION
This fixes the issue where uppercase level names in environment variables weren't recognized. The from_str() function now does case-insensitive matching, so SPDLOG_LEVEL="DEBUG" works just like "debug". All existing tests pass plus new tests verify uppercase and mixed-case level names work correctly.