### PR TITLE
Fix deprecated copy constructor usage of fmt::format_string

### DIFF
--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -340,38 +340,6 @@ struct file_event_handlers {
 
 namespace details {
 
-// to_string_view
-
-SPDLOG_CONSTEXPR_FUNC spdlog::string_view_t to_string_view(const memory_buf_t &buf)
-    SPDLOG_NOEXCEPT {
-    return spdlog::string_view_t{buf.data(), buf.size()};
-}
-
-SPDLOG_CONSTEXPR_FUNC spdlog::string_view_t to_string_view(spdlog::string_view_t str)
-    SPDLOG_NOEXCEPT {
-    return str;
-}
-
-#if defined(SPDLOG_WCHAR_FILENAMES) || defined(SPDLOG_WCHAR_TO_UTF8_SUPPORT)
-SPDLOG_CONSTEXPR_FUNC spdlog::wstring_view_t to_string_view(const wmemory_buf_t &buf)
-    SPDLOG_NOEXCEPT {
-    return spdlog::wstring_view_t{buf.data(), buf.size()};
-}
-
-SPDLOG_CONSTEXPR_FUNC spdlog::wstring_view_t to_string_view(spdlog::wstring_view_t str)
-    SPDLOG_NOEXCEPT {
-    return str;
-}
-#endif
-
-#if defined(SPDLOG_USE_STD_FORMAT) && __cpp_lib_format >= 202207L
-template <typename T, typename... Args>
-SPDLOG_CONSTEXPR_FUNC std::basic_string_view<T> to_string_view(
-    std::basic_format_string<T, Args...> fmt) SPDLOG_NOEXCEPT {
-    return fmt.get();
-}
-#endif
-
 // make_unique support for pre c++14
 #if __cplusplus >= 201402L  // C++14 and beyond
 using std::enable_if_t;

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -158,12 +158,12 @@ public:
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
     template <typename... Args>
     void log(source_loc loc, level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-        log_(loc, lvl, fmt.str, std::forward<Args>(args)...);
+        log_(loc, lvl, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-        log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
+        log(source_loc{}, lvl, fmt.get(), std::forward<Args>(args)...);
     }
 
     void log(log_clock::time_point log_time,
@@ -199,32 +199,32 @@ public:
 
     template <typename... Args>
     void trace(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::trace, fmt.str, std::forward<Args>(args)...);
+        log(level::trace, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void debug(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::debug, fmt.str, std::forward<Args>(args)...);
+        log(level::debug, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void info(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::info, fmt.str, std::forward<Args>(args)...);
+        log(level::info, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void warn(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::warn, fmt.str, std::forward<Args>(args)...);
+        log(level::warn, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void error(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::err, fmt.str, std::forward<Args>(args)...);
+        log(level::err, fmt.get(), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void critical(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::critical, fmt.str, std::forward<Args>(args)...);
+        log(level::critical, fmt.get(), std::forward<Args>(args)...);
     }
 #endif
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -77,12 +77,12 @@ public:
 
     template <typename... Args>
     void log(source_loc loc, level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
-        log_(loc, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
+        log_(loc, lvl, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void log(level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
-        log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+        log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename T>
@@ -127,43 +127,43 @@ public:
 
     template <typename... Args>
     void trace(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::trace, fmt, std::forward<Args>(args)...);
+        log(level::trace, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void debug(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::debug, fmt, std::forward<Args>(args)...);
+        log(level::debug, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void info(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::info, fmt, std::forward<Args>(args)...);
+        log(level::info, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void warn(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::warn, fmt, std::forward<Args>(args)...);
+        log(level::warn, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void error(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::err, fmt, std::forward<Args>(args)...);
+        log(level::err, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void critical(format_string_t<Args...> fmt, Args &&...args) {
-        log(level::critical, fmt, std::forward<Args>(args)...);
+        log(level::critical, fmt.str, std::forward<Args>(args)...);
     }
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
     template <typename... Args>
     void log(source_loc loc, level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-        log_(loc, lvl, details::to_string_view(fmt), std::forward<Args>(args)...);
+        log_(loc, lvl, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-        log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+        log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
     }
 
     void log(log_clock::time_point log_time,
@@ -199,32 +199,32 @@ public:
 
     template <typename... Args>
     void trace(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::trace, fmt, std::forward<Args>(args)...);
+        log(level::trace, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void debug(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::debug, fmt, std::forward<Args>(args)...);
+        log(level::debug, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void info(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::info, fmt, std::forward<Args>(args)...);
+        log(level::info, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void warn(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::warn, fmt, std::forward<Args>(args)...);
+        log(level::warn, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void error(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::err, fmt, std::forward<Args>(args)...);
+        log(level::err, fmt.str, std::forward<Args>(args)...);
     }
 
     template <typename... Args>
     void critical(wformat_string_t<Args...> fmt, Args &&...args) {
-        log(level::critical, fmt, std::forward<Args>(args)...);
+        log(level::critical, fmt.str, std::forward<Args>(args)...);
     }
 #endif
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -77,12 +77,20 @@ public:
 
     template <typename... Args>
     void log(source_loc loc, level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log_(loc, lvl, fmt.get(), std::forward<Args>(args)...);
+#else
         log_(loc, lvl, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void log(level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+#else
         log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename T>
@@ -127,32 +135,56 @@ public:
 
     template <typename... Args>
     void trace(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::trace, fmt, std::forward<Args>(args)...);
+#else
         log(level::trace, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void debug(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::debug, fmt, std::forward<Args>(args)...);
+#else
         log(level::debug, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void info(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::info, fmt, std::forward<Args>(args)...);
+#else
         log(level::info, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void warn(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::warn, fmt, std::forward<Args>(args)...);
+#else
         log(level::warn, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void error(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::err, fmt, std::forward<Args>(args)...);
+#else
         log(level::err, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void critical(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::critical, fmt, std::forward<Args>(args)...);
+#else
         log(level::critical, fmt.str, std::forward<Args>(args)...);
+#endif
     }
 
 #ifdef SPDLOG_WCHAR_TO_UTF8_SUPPORT
@@ -163,7 +195,11 @@ public:
 
     template <typename... Args>
     void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+#else
         log(source_loc{}, lvl, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     void log(log_clock::time_point log_time,
@@ -199,32 +235,56 @@ public:
 
     template <typename... Args>
     void trace(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::trace, fmt, std::forward<Args>(args)...);
+#else
         log(level::trace, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void debug(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::debug, fmt, std::forward<Args>(args)...);
+#else
         log(level::debug, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void info(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::info, fmt, std::forward<Args>(args)...);
+#else
         log(level::info, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void warn(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::warn, fmt, std::forward<Args>(args)...);
+#else
         log(level::warn, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void error(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::err, fmt, std::forward<Args>(args)...);
+#else
         log(level::err, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 
     template <typename... Args>
     void critical(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+        log(level::critical, fmt, std::forward<Args>(args)...);
+#else
         log(level::critical, fmt.get(), std::forward<Args>(args)...);
+#endif
     }
 #endif
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -204,42 +204,42 @@ inline void log(source_loc source,
                 level::level_enum lvl,
                 wformat_string_t<Args...> fmt,
                 Args &&...args) {
-    default_logger_raw()->log(source, lvl, fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->log(source, lvl, fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->log(source_loc{}, lvl, fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void trace(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->trace(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->trace(fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void debug(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->debug(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->debug(fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->info(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->info(fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warn(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->warn(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->warn(fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->error(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->error(fmt.get(), std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void critical(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->critical(fmt.str, std::forward<Args>(args)...);
+    default_logger_raw()->critical(fmt.get(), std::forward<Args>(args)...);
 }
 #endif
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -150,42 +150,42 @@ inline void log(source_loc source,
                 level::level_enum lvl,
                 format_string_t<Args...> fmt,
                 Args &&...args) {
-    default_logger_raw()->log(source, lvl, fmt, std::forward<Args>(args)...);
+    default_logger_raw()->log(source, lvl, fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void log(level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+    default_logger_raw()->log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void trace(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->trace(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->trace(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void debug(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->debug(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->info(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warn(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->warn(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->warn(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->error(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->error(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void critical(format_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->critical(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename T>
@@ -204,42 +204,42 @@ inline void log(source_loc source,
                 level::level_enum lvl,
                 wformat_string_t<Args...> fmt,
                 Args &&...args) {
-    default_logger_raw()->log(source, lvl, fmt, std::forward<Args>(args)...);
+    default_logger_raw()->log(source, lvl, fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+    default_logger_raw()->log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void trace(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->trace(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->trace(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void debug(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->debug(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void info(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->info(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void warn(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->warn(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->warn(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void error(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->error(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->error(fmt.str, std::forward<Args>(args)...);
 }
 
 template <typename... Args>
 inline void critical(wformat_string_t<Args...> fmt, Args &&...args) {
-    default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+    default_logger_raw()->critical(fmt.str, std::forward<Args>(args)...);
 }
 #endif
 

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -150,42 +150,74 @@ inline void log(source_loc source,
                 level::level_enum lvl,
                 format_string_t<Args...> fmt,
                 Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->log(source, lvl, fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->log(source, lvl, fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void log(level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->log(source_loc{}, lvl, fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void trace(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->trace(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->trace(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void debug(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->debug(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void info(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->info(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void warn(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->warn(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->warn(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void error(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->error(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->error(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void critical(format_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->critical(fmt.str, std::forward<Args>(args)...);
+#endif
 }
 
 template <typename T>
@@ -204,42 +236,74 @@ inline void log(source_loc source,
                 level::level_enum lvl,
                 wformat_string_t<Args...> fmt,
                 Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->log(source, lvl, fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->log(source, lvl, fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void log(level::level_enum lvl, wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->log(source_loc{}, lvl, fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->log(source_loc{}, lvl, fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void trace(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->trace(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->trace(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void debug(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->debug(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->debug(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void info(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->info(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->info(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void warn(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->warn(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->warn(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void error(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->error(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->error(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 
 template <typename... Args>
 inline void critical(wformat_string_t<Args...> fmt, Args &&...args) {
+#ifdef SPDLOG_USE_STD_FORMAT
+    default_logger_raw()->critical(fmt, std::forward<Args>(args)...);
+#else
     default_logger_raw()->critical(fmt.get(), std::forward<Args>(args)...);
+#endif
 }
 #endif
 

--- a/tests/test_fmt_helper.cpp
+++ b/tests/test_fmt_helper.cpp
@@ -2,7 +2,11 @@
 #include "includes.h"
 
 using spdlog::memory_buf_t;
-using spdlog::details::to_string_view;
+
+SPDLOG_CONSTEXPR_FUNC spdlog::string_view_t to_string_view(const memory_buf_t &buf)
+    SPDLOG_NOEXCEPT {
+    return spdlog::string_view_t{buf.data(), buf.size()};
+}
 
 void test_pad2(int n, const char *expected) {
     memory_buf_t buf;

--- a/tests/test_pattern_formatter.cpp
+++ b/tests/test_pattern_formatter.cpp
@@ -4,7 +4,11 @@
 #include <chrono>
 
 using spdlog::memory_buf_t;
-using spdlog::details::to_string_view;
+
+SPDLOG_CONSTEXPR_FUNC spdlog::string_view_t to_string_view(const memory_buf_t &buf)
+    SPDLOG_NOEXCEPT {
+    return spdlog::string_view_t{buf.data(), buf.size()};
+}
 
 // log to str and return it
 template <typename... Args>


### PR DESCRIPTION
The copy constructor of `fmt::format_string` has been marked as deprecated in this commit: <https://github.com/fmtlib/fmt/commit/f3d510c10c53819a60aeb443d709fe021094b787>

I chose this fix because it mirrors how {fmt} itself passes `fmt::format_string` internally.
