### PR TITLE
docs: fix SPDLOG_LEVEL env example

### DIFF
--- a/include/spdlog/cfg/env.h
+++ b/include/spdlog/cfg/env.h
@@ -17,7 +17,7 @@
 // export SPDLOG_LEVEL=debug
 //
 // turn off all logging except for logger1:
-// export SPDLOG_LEVEL="*=off,logger1=debug"
+// export SPDLOG_LEVEL="off,logger1=debug"
 //
 
 // turn off all logging except for logger1 and logger2:


### PR DESCRIPTION
## Summary

Fix the `SPDLOG_LEVEL` environment variable example in `include/spdlog/cfg/env.h`.

The previous example used:

`*=off,logger1=debug`

However, the current `helpers::load_levels()` implementation treats global
levels as entries without a logger name, so the correct example is:

`off,logger1=debug`

This update aligns the documentation example with the current behavior.