### PR TITLE
bugfix/qnx-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,13 @@ endif()
 target_compile_definitions(spdlog PUBLIC SPDLOG_COMPILED_LIB)
 target_include_directories(spdlog ${SPDLOG_INCLUDES_LEVEL} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
                                                                   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
-target_link_libraries(spdlog PUBLIC Threads::Threads)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+    target_compile_definitions(spdlog PUBLIC _QNX_SOURCE) 
+    target_link_libraries(spdlog PUBLIC socket)
+else()
+    target_link_libraries(spdlog PUBLIC Threads::Threads)
+endif()
 spdlog_enable_warnings(spdlog)
 
 set_target_properties(spdlog PROPERTIES VERSION ${SPDLOG_VERSION} SOVERSION


### PR DESCRIPTION
This PR fixes QNX 7.0 and 7.1 builds.

```
[2026-03-18T11:53:52.476Z] -- The CXX compiler identification is QCC 5.4.0
[2026-03-18T11:53:52.476Z] -- Detecting CXX compiler ABI info
[2026-03-18T11:53:52.476Z] -- Detecting CXX compiler ABI info - done
[2026-03-18T11:53:52.476Z] -- Check for working CXX compiler: /data/jenkins/qnx700/host/linux/x86_64/usr/bin/q++ - skipped
[2026-03-18T11:53:52.476Z] -- Detecting CXX compile features
[2026-03-18T11:53:52.476Z] -- Detecting CXX compile features - done
[2026-03-18T11:53:52.476Z] -- Build spdlog: 1.17.0
[2026-03-18T11:53:52.476Z] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
[2026-03-18T11:53:52.476Z] -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
[2026-03-18T11:53:52.476Z] -- Looking for pthread_create in pthreads
[2026-03-18T11:53:52.476Z] -- Looking for pthread_create in pthreads - not found
[2026-03-18T11:53:52.476Z] -- Looking for pthread_create in pthread
[2026-03-18T11:53:52.476Z] -- Looking for pthread_create in pthread - not found
[2026-03-18T11:53:52.476Z] -- Check if compiler accepts -pthread
[2026-03-18T11:53:52.731Z] -- Check if compiler accepts -pthread - yes
[2026-03-18T11:53:52.731Z] -- Found Threads: TRUE
[2026-03-18T11:53:52.731Z] -- Build type: Release
[2026-03-18T11:53:52.731Z] -- Looking for fwrite_unlocked
[2026-03-18T11:53:52.731Z] -- Looking for fwrite_unlocked - not found
[2026-03-18T11:53:52.731Z] -- Generating install
[2026-03-18T11:53:52.731Z] -- Configuring done (0.3s)
[2026-03-18T11:53:52.731Z] -- Generating done (0.0s)
[2026-03-18T11:53:52.731Z] CMake Warning:
[2026-03-18T11:53:52.731Z]   Manually-specified variables were not used by the project:
[2026-03-18T11:53:52.731Z] 
[2026-03-18T11:53:52.731Z]     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
[2026-03-18T11:53:52.731Z]     CONAN_CMAKE_POSITION_INDEPENDENT_CODE
[2026-03-18T11:53:52.731Z]     CONAN_COMPILER
[2026-03-18T11:53:52.731Z]     CONAN_COMPILER_VERSION
[2026-03-18T11:53:52.731Z]     CONAN_EXPORTED
[2026-03-18T11:53:52.731Z]     CONAN_IN_LOCAL_CACHE
[2026-03-18T11:53:52.731Z]     CONAN_LIBCXX
[2026-03-18T11:53:52.731Z]     SPDLOG_MSVC_UTF8
[2026-03-18T11:53:52.731Z] 
[2026-03-18T11:53:52.731Z] 
[2026-03-18T11:53:52.731Z] -- Build files have been written to: /data/jenkins/workspace/conan_spdlog/cnn_l_0/.conan/data/spdlog/1.17.0/jenkins/stable/build/1fc870328dc9684ad1d1f87db1fc0e2b43b72ebd/build_subfolder
[2026-03-18T11:53:52.731Z] [ 25%] Building CXX object CMakeFiles/spdlog.dir/src/stdout_sinks.cpp.o
[2026-03-18T11:53:52.731Z] [ 12%] Building CXX object CMakeFiles/spdlog.dir/src/spdlog.cpp.o
[2026-03-18T11:53:52.731Z] [ 37%] Building CXX object CMakeFiles/spdlog.dir/src/color_sinks.cpp.o
[2026-03-18T11:53:52.731Z] [ 50%] Building CXX object CMakeFiles/spdlog.dir/src/file_sinks.cpp.o
[2026-03-18T11:53:52.731Z] [ 62%] Building CXX object CMakeFiles/spdlog.dir/src/async.cpp.o
[2026-03-18T11:53:52.731Z] [ 75%] Building CXX object CMakeFiles/spdlog.dir/src/cfg.cpp.o
[2026-03-18T11:53:52.731Z] cc1plus: error: command line option '-pthread' is valid for the driver but not for C++
```
