### PR TITLE
[bench] Update Google benchmark to version 1.8.4

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -19,7 +19,7 @@ if(NOT benchmark_FOUND)
     # disable tests
     set(BENCHMARK_ENABLE_TESTING OFF CACHE INTERNAL "")
     # Do not build and run googlebenchmark tests
-    FetchContent_Declare(googlebenchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.6.0)
+    FetchContent_Declare(googlebenchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.8.4)
     FetchContent_MakeAvailable(googlebenchmark)
 endif()
 


### PR DESCRIPTION
Fix CMake warning from more recent versions.
Latest benchmark release support C++11.
Does not increase CMake requirements.