### PR TITLE
[AI Test] Doubao Seed Code 2.0 Add business-specific rotating log sinks and example

### DIFF
--- a/business_logger.h
+++ b/business_logger.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <memory>
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <sys/stat.h>
+#endif
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/rotating_file_sink.h"
+
+enum class BusinessType {
+    RECORD_SCREEN,
+    OPEN_DESKTOP,
+    RECORD_KEYBOARD,
+    RECORD_AUDIO
+};
+
+class BusinessLogger {
+private:
+    std::unordered_map<BusinessType, std::shared_ptr<spdlog::logger>> loggers_;
+    std::string log_dir_;
+    const size_t max_file_size_;
+    const size_t max_files_;
+
+    std::string get_business_name(BusinessType type) {
+        switch (type) {
+            case BusinessType::RECORD_SCREEN:
+                return "record_screen";
+            case BusinessType::OPEN_DESKTOP:
+                return "open_desktop";
+            case BusinessType::RECORD_KEYBOARD:
+                return "record_keyboard";
+            case BusinessType::RECORD_AUDIO:
+                return "record_audio";
+            default:
+                return "unknown";
+        }
+    }
+
+    std::shared_ptr<spdlog::logger> create_logger(BusinessType type) {
+        std::string business_name = get_business_name(type);
+        std::string log_path = log_dir_ + "/" + business_name + ".log";
+        
+        auto logger = spdlog::rotating_logger_mt(
+            business_name,
+            log_path,
+            max_file_size_,
+            max_files_
+        );
+        
+        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] [%t] %v");
+        logger->set_level(spdlog::level::trace);
+        logger->flush_on(spdlog::level::info);
+        
+        return logger;
+    }
+
+public:
+    BusinessLogger(const std::string& log_dir = "logs", 
+                   size_t max_file_size = 30 * 1024 * 1024, 
+                   size_t max_files = 3)
+        : log_dir_(log_dir)
+        , max_file_size_(max_file_size)
+        , max_files_(max_files) {
+    }
+
+    void create_directory(const std::string& path) {
+#ifdef _WIN32
+        _mkdir(path.c_str());
+#else
+        mkdir(path.c_str(), 0755);
+#endif
+    }
+
+    void init() {
+        create_directory(log_dir_);
+        loggers_[BusinessType::RECORD_SCREEN] = create_logger(BusinessType::RECORD_SCREEN);
+        loggers_[BusinessType::OPEN_DESKTOP] = create_logger(BusinessType::OPEN_DESKTOP);
+        loggers_[BusinessType::RECORD_KEYBOARD] = create_logger(BusinessType::RECORD_KEYBOARD);
+        loggers_[BusinessType::RECORD_AUDIO] = create_logger(BusinessType::RECORD_AUDIO);
+    }
+
+    std::shared_ptr<spdlog::logger> get_logger(BusinessType type) {
+        auto it = loggers_.find(type);
+        if (it != loggers_.end()) {
+            return it->second;
+        }
+        return nullptr;
+    }
+
+    template<typename... Args>
+    void log(BusinessType type, spdlog::level::level_enum level, fmt::format_string<Args...> fmt, Args&&... args) {
+        auto logger = get_logger(type);
+        if (logger) {
+            logger->log(level, fmt, std::forward<Args>(args)...);
+        }
+    }
+
+    template<typename... Args>
+    void info(BusinessType type, fmt::format_string<Args...> fmt, Args&&... args) {
+        log(type, spdlog::level::info, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void debug(BusinessType type, fmt::format_string<Args...> fmt, Args&&... args) {
+        log(type, spdlog::level::debug, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void warn(BusinessType type, fmt::format_string<Args...> fmt, Args&&... args) {
+        log(type, spdlog::level::warn, fmt, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void error(BusinessType type, fmt::format_string<Args...> fmt, Args&&... args) {
+        log(type, spdlog::level::err, fmt, std::forward<Args>(args)...);
+    }
+
+    void flush_all() {
+        for (auto& pair : loggers_) {
+            if (pair.second) {
+                pair.second->flush();
+            }
+        }
+    }
+
+    ~BusinessLogger() {
+        flush_all();
+        spdlog::shutdown();
+    }
+};

--- a/business_logger_example.cpp
+++ b/business_logger_example.cpp
@@ -1,0 +1,44 @@
+#include "business_logger.h"
+#include <iostream>
+
+int main() {
+    try {
+        std::cout << "=== Business Logger System Demo ===\n\n";
+
+        BusinessLogger logger("logs", 30 * 1024 * 1024, 3);
+        logger.init();
+
+        std::cout << "1. Recording screen business logs...\n";
+        logger.info(BusinessType::RECORD_SCREEN, "Started screen recording");
+        logger.info(BusinessType::RECORD_SCREEN, "Resolution: 1920x1080");
+        logger.debug(BusinessType::RECORD_SCREEN, "Frame rate: 30 FPS");
+        logger.warn(BusinessType::RECORD_SCREEN, "Low disk space, please clean up");
+
+        std::cout << "\n2. Opening desktop business logs...\n";
+        logger.info(BusinessType::OPEN_DESKTOP, "User logged in successfully");
+        logger.info(BusinessType::OPEN_DESKTOP, "Desktop environment loaded");
+        logger.debug(BusinessType::OPEN_DESKTOP, "Number of plugins loaded: 15");
+
+        std::cout << "\n3. Recording keyboard business logs...\n";
+        logger.info(BusinessType::RECORD_KEYBOARD, "Started keyboard recording");
+        logger.debug(BusinessType::RECORD_KEYBOARD, "Key: Ctrl+C");
+        logger.debug(BusinessType::RECORD_KEYBOARD, "Key: Ctrl+V");
+        logger.error(BusinessType::RECORD_KEYBOARD, "Keyboard input timeout");
+
+        std::cout << "\n4. Recording audio business logs...\n";
+        logger.info(BusinessType::RECORD_AUDIO, "Started audio recording");
+        logger.info(BusinessType::RECORD_AUDIO, "Sample rate: 44100 Hz");
+        logger.debug(BusinessType::RECORD_AUDIO, "Bit rate: 128 kbps");
+        logger.warn(BusinessType::RECORD_AUDIO, "Microphone volume too low");
+
+        logger.flush_all();
+
+        std::cout << "\n=== Logging completed, check the logs directory\n";
+
+    } catch (const spdlog::spdlog_ex &ex) {
+        std::cout << "Log initialization failed: " << ex.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,6 +15,13 @@ add_executable(example example.cpp)
 target_link_libraries(example PRIVATE spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>)
 
 # ---------------------------------------------------------------------------------------
+# Business Logger Example
+# ---------------------------------------------------------------------------------------
+add_executable(business_logger_example ../business_logger_example.cpp)
+target_include_directories(business_logger_example PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(business_logger_example PRIVATE spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>)
+
+# ---------------------------------------------------------------------------------------
 # Example of using header-only library
 # ---------------------------------------------------------------------------------------
 if(SPDLOG_BUILD_EXAMPLE_HO)


### PR DESCRIPTION
## 测试背景
本次提交为 众测任务**，旨在评估 AI 编程模型对 C++ 项目（spdlog）的功能开发能力。

## 测试题目要求
基于 spdlog（C++11 日志库）增加以下功能：
1. 根据不同的业务逻辑（录制屏幕、打开桌面、录制键盘、录制声音）生成不同的日志文件。
2. 相同业务的日志文件最多保留 3 个，每个不超过 30MB。
3. 写日志时通过传入业务标识写入对应的日志文件。

## 本次提交内容
- 新增 `business_logger.h`：封装了基于 `BusinessType` 枚举的日志管理器，利用 spdlog 的 `rotating_file_sink` 实现按业务分离的日志轮转。
- 新增 `business_logger_example.cpp`：演示四种业务日志的写入示例。
- 修改 `example/CMakeLists.txt`：添加示例程序构建配置。

## 测试模型
- 模型名称：[Doubao Seed Code 2.0]
- 交互轮次：1
- Session ID：.151071770328167:561471d800925b6709c10be50a15da99_69da13afc6ff8e4d4efe52bb.69da1813c6ff8e4d4efe52c0.69da1812fb5db4ade1d4c0e1:Trae CN.T(2026/4/11 17:44:51)

## 如何验证
1. 编译示例程序：
   ```bash
   cd example && mkdir build && cd build
   cmake .. && make