### PR TITLE
docs: fix misleading unit wording in comment

### DIFF
--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -17,7 +17,7 @@
 // spdlog::info("Elapsed: {:.6} seconds", sw);  =>  "Elapsed 0.005163 seconds"
 //
 //
-// If other units are needed (e.g. millis instead of double), include "fmt/chrono.h" and use
+// If other units are needed (e.g. millis instead of seconds), include "fmt/chrono.h" and use
 // "duration_cast<..>(sw.elapsed())":
 //
 // #include <spdlog/fmt/chrono.h>


### PR DESCRIPTION
Fixes a misleading comment in `stopwatch.h` where the wording referred to "double" instead of the actual unit ("seconds").

If I've misunderstood and the original wording was intentional, feel free to disregard this PR.