### PR TITLE
.3493622109966576:415da9903d2dcd69c3823ca484484480_69e61622e46af4f7d61e5e5a.69e64929e46af4f7d61e6236.69e6492854b5be5c3e7fba8d:Trae CN.T(2026/4/20 23:41:29)

### DIFF
--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -578,6 +578,40 @@ public:
     }
 };
 
+// Thread id and time with milliseconds: [TID-xxx HH:MM:SS.mmm]
+template <typename ScopedPadder>
+class tid_time_formatter final : public flag_formatter {
+public:
+    explicit tid_time_formatter(padding_info padinfo)
+        : flag_formatter(padinfo) {}
+
+    void format(const details::log_msg &msg, const std::tm &tm_time, memory_buf_t &dest) override {
+        using std::chrono::milliseconds;
+        
+        const auto tid_digits = ScopedPadder::count_digits(msg.thread_id);
+        const size_t field_size = 7 + tid_digits + 1 + 12; // "[TID-" + tid + " " + "HH:MM:SS.mmm]"
+        
+        ScopedPadder p(field_size, padinfo_, dest);
+
+        dest.push_back('[');
+        fmt_helper::append_string_view("TID-", dest);
+        fmt_helper::append_int(msg.thread_id, dest);
+        dest.push_back(' ');
+
+        fmt_helper::pad2(tm_time.tm_hour, dest);
+        dest.push_back(':');
+        fmt_helper::pad2(tm_time.tm_min, dest);
+        dest.push_back(':');
+        fmt_helper::pad2(tm_time.tm_sec, dest);
+        dest.push_back('.');
+
+        auto millis = fmt_helper::time_fraction<milliseconds>(msg.time);
+        fmt_helper::pad3(static_cast<uint32_t>(millis.count()), dest);
+
+        dest.push_back(']');
+    }
+};
+
 // Current pid
 template <typename ScopedPadder>
 class pid_formatter final : public flag_formatter {
@@ -1051,6 +1085,11 @@ SPDLOG_INLINE void pattern_formatter::handle_flag_(char flag, details::padding_i
 
         case ('t'):  // thread id
             formatters_.push_back(details::make_unique<details::t_formatter<Padder>>(padding));
+            break;
+
+        case ('J'):  // thread id and time with milliseconds: [TID-xxx HH:MM:SS.mmm]
+            formatters_.push_back(details::make_unique<details::tid_time_formatter<Padder>>(padding));
+            need_localtime_ = true;
             break;
 
         case ('v'):  // the message text


### PR DESCRIPTION
新增 'J' 标志符用于输出线程ID和时间毫秒格式 [TID-xxx HH:MM:SS.mmm]，方便调试多线程场景下的日志时序问题