### PR TITLE
.3493622109966576:96bbd433b6292807a26b5970fd0c7259_69e746ca81ef3ff6db540423.69e75ce881ef3ff6db5404b3.69e75ce8e2e0958e9a5cbedf:Trae CN.T(2026/4/21 19:18:00)

### DIFF
--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -24,6 +24,30 @@ public:
     log_msg_buffer &operator=(log_msg_buffer &&other) SPDLOG_NOEXCEPT;
 };
 
+class SPDLOG_API movable_log_msg_buffer : public log_msg_buffer {
+public:
+    movable_log_msg_buffer() = default;
+
+    explicit movable_log_msg_buffer(const log_msg &orig_msg)
+        : log_msg_buffer(orig_msg) {}
+
+    movable_log_msg_buffer(const movable_log_msg_buffer &) = delete;
+    movable_log_msg_buffer &operator=(const movable_log_msg_buffer &) = delete;
+
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+    movable_log_msg_buffer(movable_log_msg_buffer &&other) SPDLOG_NOEXCEPT
+        : log_msg_buffer(std::move(other)) {}
+
+    movable_log_msg_buffer &operator=(movable_log_msg_buffer &&other) SPDLOG_NOEXCEPT {
+        log_msg_buffer::operator=(std::move(other));
+        return *this;
+    }
+#else
+    movable_log_msg_buffer(movable_log_msg_buffer &&) = default;
+    movable_log_msg_buffer &operator=(movable_log_msg_buffer &&) = default;
+#endif
+};
+
 }  // namespace details
 }  // namespace spdlog
 

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -8,12 +8,67 @@
 #endif
 
 #include <spdlog/details/backtracer.h>
+#include <spdlog/details/log_msg_buffer.h>
 #include <spdlog/pattern_formatter.h>
 #include <spdlog/sinks/sink.h>
 
 #include <cstdio>
+#include <vector>
+#include <utility>
 
 namespace spdlog {
+namespace details {
+
+class transaction_context {
+public:
+    using buffer_type = std::vector<movable_log_msg_buffer>;
+    using entry_type = std::pair<const logger*, buffer_type>;
+
+    buffer_type* find(const logger* l) {
+        for (auto& entry : entries_) {
+            if (entry.first == l) {
+                return &entry.second;
+            }
+        }
+        return nullptr;
+    }
+
+    const buffer_type* find(const logger* l) const {
+        for (const auto& entry : entries_) {
+            if (entry.first == l) {
+                return &entry.second;
+            }
+        }
+        return nullptr;
+    }
+
+    buffer_type& get_or_create(const logger* l) {
+        auto* existing = find(l);
+        if (existing) {
+            return *existing;
+        }
+        entries_.emplace_back(l, buffer_type{});
+        return entries_.back().second;
+    }
+
+    void remove(const logger* l) {
+        for (auto it = entries_.begin(); it != entries_.end(); ++it) {
+            if (it->first == l) {
+                entries_.erase(it);
+                return;
+            }
+        }
+    }
+
+    bool empty() const { return entries_.empty(); }
+
+private:
+    std::vector<entry_type> entries_;
+};
+
+}  // namespace details
+
+thread_local details::transaction_context tls_transaction_context;
 
 // public methods
 SPDLOG_INLINE logger::logger(const logger &other)
@@ -120,10 +175,62 @@ SPDLOG_INLINE std::shared_ptr<logger> logger::clone(std::string logger_name) {
     return cloned;
 }
 
+// transactional logging support
+SPDLOG_INLINE void logger::start_transaction() {
+    transaction_refcount_.fetch_add(1, std::memory_order_relaxed);
+    tls_transaction_context.get_or_create(this);
+}
+
+SPDLOG_INLINE void logger::commit_transaction() {
+    auto* buffer = tls_transaction_context.find(this);
+    if (buffer == nullptr) {
+        return;
+    }
+
+    for (const auto& msg : *buffer) {
+        sink_it_(msg);
+    }
+
+    buffer->clear();
+    tls_transaction_context.remove(this);
+    transaction_refcount_.fetch_sub(1, std::memory_order_relaxed);
+}
+
+SPDLOG_INLINE void logger::rollback_transaction() {
+    auto* buffer = tls_transaction_context.find(this);
+    if (buffer == nullptr) {
+        return;
+    }
+
+    buffer->clear();
+    tls_transaction_context.remove(this);
+    transaction_refcount_.fetch_sub(1, std::memory_order_relaxed);
+}
+
+SPDLOG_INLINE bool logger::in_transaction() const {
+    if (transaction_refcount_.load(std::memory_order_relaxed) == 0) {
+        return false;
+    }
+    return tls_transaction_context.find(this) != nullptr;
+}
+
 // protected methods
 SPDLOG_INLINE void logger::log_it_(const spdlog::details::log_msg &log_msg,
                                    bool log_enabled,
                                    bool traceback_enabled) {
+    if (transaction_refcount_.load(std::memory_order_relaxed) > 0) {
+        auto* buffer = tls_transaction_context.find(this);
+        if (buffer != nullptr) {
+            if (log_enabled) {
+                buffer->emplace_back(log_msg);
+            }
+            if (traceback_enabled) {
+                tracer_.push_back(log_msg);
+            }
+            return;
+        }
+    }
+
     if (log_enabled) {
         sink_it_(log_msg);
     }

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -26,6 +26,7 @@
 #endif
 
 #include <vector>
+#include <atomic>
 
 #ifndef SPDLOG_NO_EXCEPTIONS
 #define SPDLOG_LOGGER_CATCH(location)                                                 \
@@ -301,6 +302,12 @@ public:
     void flush_on(level::level_enum log_level);
     level::level_enum flush_level() const;
 
+    // transactional logging support
+    void start_transaction();
+    void commit_transaction();
+    void rollback_transaction();
+    bool in_transaction() const;
+
     // sinks
     const std::vector<sink_ptr> &sinks() const;
 
@@ -319,6 +326,7 @@ protected:
     spdlog::level_t flush_level_{level::off};
     err_handler custom_err_handler_{nullptr};
     details::backtracer tracer_;
+    std::atomic<size_t> transaction_refcount_{0};
 
     // common implementation for after templated public api has been resolved
     template <typename... Args>

--- a/include/spdlog/sinks/adaptive_buffer_sink.h
+++ b/include/spdlog/sinks/adaptive_buffer_sink.h
@@ -1,0 +1,111 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/details/log_msg_buffer.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/sink.h>
+
+#include <mutex>
+#include <vector>
+#include <memory>
+#include <utility>
+
+namespace spdlog {
+namespace sinks {
+
+template <typename Mutex>
+class adaptive_buffer_sink final : public sink {
+public:
+    explicit adaptive_buffer_sink(std::shared_ptr<sink> target_sink, size_t buffer_size = 8192)
+        : target_sink_(std::move(target_sink)),
+          buffer_size_(buffer_size) {
+        if (buffer_size_ == 0) {
+            throw_spdlog_ex("adaptive_buffer_sink: buffer_size cannot be zero");
+        }
+        std::lock_guard<Mutex> lock(mutex_);
+        buffer_.reserve(buffer_size_);
+    }
+
+    adaptive_buffer_sink(const adaptive_buffer_sink &) = delete;
+    adaptive_buffer_sink(adaptive_buffer_sink &&) = delete;
+    adaptive_buffer_sink &operator=(const adaptive_buffer_sink &) = delete;
+    adaptive_buffer_sink &operator=(adaptive_buffer_sink &&) = delete;
+
+    ~adaptive_buffer_sink() override {
+        try {
+            flush();
+        } catch (...) {
+        }
+    }
+
+    void log(const details::log_msg &msg) override {
+        std::unique_lock<Mutex> lock(mutex_);
+        buffer_.emplace_back(msg);
+        if (buffer_.size() >= buffer_size_) {
+            std::vector<details::movable_log_msg_buffer> local_buffer = std::move(buffer_);
+            buffer_.reserve(buffer_size_);
+            lock.unlock();
+            flush_local_buffer_(local_buffer);
+        }
+    }
+
+    void flush() override {
+        std::vector<details::movable_log_msg_buffer> local_buffer;
+        {
+            std::lock_guard<Mutex> lock(mutex_);
+            if (buffer_.empty()) {
+                return;
+            }
+            local_buffer = std::move(buffer_);
+            buffer_.reserve(buffer_size_);
+        }
+        flush_local_buffer_(local_buffer);
+        target_sink_->flush();
+    }
+
+    void set_pattern(const std::string &pattern) override {
+        target_sink_->set_pattern(pattern);
+    }
+
+    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override {
+        target_sink_->set_formatter(std::move(sink_formatter));
+    }
+
+private:
+    void flush_local_buffer_(std::vector<details::movable_log_msg_buffer> &local_buffer) {
+        for (const auto &msg : local_buffer) {
+            target_sink_->log(msg);
+        }
+    }
+
+    std::shared_ptr<sink> target_sink_;
+    size_t buffer_size_;
+    std::vector<details::movable_log_msg_buffer> buffer_;
+    Mutex mutex_;
+};
+
+using adaptive_buffer_sink_mt = adaptive_buffer_sink<std::mutex>;
+using adaptive_buffer_sink_st = adaptive_buffer_sink<details::null_mutex>;
+
+}  // namespace sinks
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> adaptive_buffer_logger_mt(const std::string &logger_name,
+                                                          std::shared_ptr<sinks::sink> target_sink,
+                                                          size_t buffer_size = 8192) {
+    return Factory::template create<sinks::adaptive_buffer_sink_mt>(logger_name, std::move(target_sink),
+                                                                      buffer_size);
+}
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> adaptive_buffer_logger_st(const std::string &logger_name,
+                                                          std::shared_ptr<sinks::sink> target_sink,
+                                                          size_t buffer_size = 8192) {
+    return Factory::template create<sinks::adaptive_buffer_sink_st>(logger_name, std::move(target_sink),
+                                                                      buffer_size);
+}
+
+}  // namespace spdlog

--- a/tests/test_transaction.cpp
+++ b/tests/test_transaction.cpp
@@ -1,0 +1,139 @@
+#ifdef _WIN32
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "includes.h"
+#include "test_sink.h"
+
+TEST_CASE("transactional_logging_basic", "[transactional_logging]") {
+    using spdlog::sinks::test_sink_mt;
+    auto logger = spdlog::create<test_sink_mt>("transactional_logger");
+    auto test_sink = std::static_pointer_cast<test_sink_mt>(logger->sinks()[0]);
+    logger->set_pattern("%v");
+
+    logger->info("message 1");
+    REQUIRE(test_sink->msg_counter() == 1);
+    REQUIRE(test_sink->lines()[0] == "message 1");
+
+    logger->start_transaction();
+    REQUIRE(logger->in_transaction() == true);
+
+    logger->info("message 2");
+    logger->info("message 3");
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    logger->commit_transaction();
+    REQUIRE(logger->in_transaction() == false);
+    REQUIRE(test_sink->msg_counter() == 3);
+    REQUIRE(test_sink->lines()[1] == "message 2");
+    REQUIRE(test_sink->lines()[2] == "message 3");
+
+    spdlog::drop_all();
+}
+
+TEST_CASE("transactional_logging_rollback", "[transactional_logging]") {
+    using spdlog::sinks::test_sink_mt;
+    auto logger = spdlog::create<test_sink_mt>("transactional_logger");
+    auto test_sink = std::static_pointer_cast<test_sink_mt>(logger->sinks()[0]);
+    logger->set_pattern("%v");
+
+    logger->info("message 1");
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    logger->start_transaction();
+    logger->info("message 2");
+    logger->info("message 3");
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    logger->rollback_transaction();
+    REQUIRE(logger->in_transaction() == false);
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    logger->info("message 4");
+    REQUIRE(test_sink->msg_counter() == 2);
+    REQUIRE(test_sink->lines()[1] == "message 4");
+
+    spdlog::drop_all();
+}
+
+TEST_CASE("transactional_logging_nested_not_supported", "[transactional_logging]") {
+    using spdlog::sinks::test_sink_mt;
+    auto logger = spdlog::create<test_sink_mt>("transactional_logger");
+    auto test_sink = std::static_pointer_cast<test_sink_mt>(logger->sinks()[0]);
+    logger->set_pattern("%v");
+
+    logger->start_transaction();
+    logger->info("message 1");
+
+    logger->start_transaction();
+    logger->info("message 2");
+
+    logger->commit_transaction();
+    REQUIRE(test_sink->msg_counter() == 1);
+    REQUIRE(test_sink->lines()[0] == "message 2");
+
+    REQUIRE(logger->in_transaction() == true);
+
+    logger->commit_transaction();
+    REQUIRE(test_sink->msg_counter() == 2);
+    REQUIRE(test_sink->lines()[1] == "message 1");
+
+    spdlog::drop_all();
+}
+
+TEST_CASE("transactional_logging_multiple_loggers", "[transactional_logging]") {
+    using spdlog::sinks::test_sink_mt;
+    auto logger1 = spdlog::create<test_sink_mt>("logger1");
+    auto logger2 = spdlog::create<test_sink_mt>("logger2");
+    auto test_sink1 = std::static_pointer_cast<test_sink_mt>(logger1->sinks()[0]);
+    auto test_sink2 = std::static_pointer_cast<test_sink_mt>(logger2->sinks()[0]);
+    logger1->set_pattern("%v");
+    logger2->set_pattern("%v");
+
+    logger1->info("logger1 message 1");
+    logger2->info("logger2 message 1");
+    REQUIRE(test_sink1->msg_counter() == 1);
+    REQUIRE(test_sink2->msg_counter() == 1);
+
+    logger1->start_transaction();
+    REQUIRE(logger1->in_transaction() == true);
+    REQUIRE(logger2->in_transaction() == false);
+
+    logger1->info("logger1 message 2");
+    logger2->info("logger2 message 2");
+    REQUIRE(test_sink1->msg_counter() == 1);
+    REQUIRE(test_sink2->msg_counter() == 2);
+
+    logger1->commit_transaction();
+    REQUIRE(test_sink1->msg_counter() == 2);
+    REQUIRE(test_sink1->lines()[1] == "logger1 message 2");
+
+    spdlog::drop_all();
+}
+
+TEST_CASE("transactional_logging_exception_safety", "[transactional_logging]") {
+    using spdlog::sinks::test_sink_mt;
+    auto logger = spdlog::create<test_sink_mt>("transactional_logger");
+    auto test_sink = std::static_pointer_cast<test_sink_mt>(logger->sinks()[0]);
+    logger->set_pattern("%v");
+
+    logger->info("before transaction");
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    try {
+        logger->start_transaction();
+        logger->info("during transaction");
+        throw std::runtime_error("test exception");
+    } catch (...) {
+        logger->rollback_transaction();
+    }
+
+    REQUIRE(logger->in_transaction() == false);
+    REQUIRE(test_sink->msg_counter() == 1);
+
+    logger->info("after rollback");
+    REQUIRE(test_sink->msg_counter() == 2);
+    REQUIRE(test_sink->lines()[1] == "after rollback");
+
+    spdlog::drop_all();
+}


### PR DESCRIPTION
实现事务性日志功能，允许在事务中缓冲日志消息并在提交时一次性写入
新增事务管理API：start_transaction/commit_transaction/rollback_transaction 添加adaptive_buffer_sink用于缓冲日志消息
包含完整的单元测试验证事务功能