### PR TITLE
Add systemd_namespace_sink for logging to specific systemd namespace

### DIFF
--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -8,9 +8,6 @@
 #include <spdlog/sinks/base_sink.h>
 
 #include <array>
-#ifndef SD_JOURNAL_SUPPRESS_LOCATION
-#define SD_JOURNAL_SUPPRESS_LOCATION
-#endif
 #include <systemd/sd-journal.h>
 #include <systemd/sd-daemon.h>
 
@@ -29,14 +26,7 @@ public:
     explicit systemd_namespace_sink(std::string ident,
                                     std::string name_space,
                                     bool enable_formatting)
-        : enable_formatting_{enable_formatting},
-          level_prefixes_{{/* spdlog::level::trace      */ SD_DEBUG,
-                           /* spdlog::level::debug      */ SD_DEBUG,
-                           /* spdlog::level::info       */ SD_INFO,
-                           /* spdlog::level::warn       */ SD_WARNING,
-                           /* spdlog::level::err        */ SD_ERR,
-                           /* spdlog::level::critical   */ SD_CRIT,
-                           /* spdlog::level::off        */ SD_INFO}} {
+        : enable_formatting_{enable_formatting} {
         int stream_fd = -1;
         if (name_space.empty()) {
             stream_fd = ::sd_journal_stream_fd(ident.c_str(), LOG_INFO, 1);
@@ -75,7 +65,15 @@ protected:
     FILE *journal_ = nullptr;
     bool enable_formatting_ = false;
     using level_prefix_array = std::array<const char *, 7>;
-    level_prefix_array level_prefixes_;
+    static constexpr level_prefix_array level_prefixes_ = {
+        {/* spdlog::level::trace      */ SD_DEBUG,
+         /* spdlog::level::debug      */ SD_DEBUG,
+         /* spdlog::level::info       */ SD_INFO,
+         /* spdlog::level::warn       */ SD_WARNING,
+         /* spdlog::level::err        */ SD_ERR,
+         /* spdlog::level::critical   */ SD_CRIT,
+         /* spdlog::level::off        */ SD_INFO}};
+    static constexpr size_t level_prefix_length_ = 3;
 
     void sink_it_(const details::log_msg &msg) override {
         string_view_t payload;
@@ -87,44 +85,48 @@ protected:
             payload = msg.payload;
         }
 
+        auto write_or_throw = [this](const void *data, size_t n) {
+            if (!details::os::fwrite_bytes(data, n, journal_)) {
+                throw_spdlog_ex("Failed writing to systemd journal", errno);
+            }
+        };
+
         // Journal stream is line-oriented; if there's newlines in the payload, send each
         // newline-delimited piece separately as its own message.
         size_t pos = 0;
         while (pos < payload.size()) {
             size_t nl_pos = payload.find('\n', pos);
-            size_t end = (nl_pos == std::string_view::npos) ? payload.size() : nl_pos + 1;
-            std::string_view one_message = payload.substr(pos, end - pos);
-
-            // Limit single message size to max int, but take into account the 3 characters of
-            // kernel-style log level prefix
-            size_t length = one_message.size();
-            if ((length + 3) > static_cast<size_t>(std::numeric_limits<int>::max())) {
-                length = static_cast<size_t>(std::numeric_limits<int>::max()) - 3;
-            }
+            size_t end = (nl_pos == string_view_t::npos) ? payload.size() : nl_pos + 1;
+            string_view_t one_message = payload.substr(pos, end - pos);
 
             // Write log level prefix
-            details::os::fwrite_bytes(
-                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)), 3,
-                journal_);
+            write_or_throw(
+                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)),
+                level_prefix_length_);
             // Write the message
-            details::os::fwrite_bytes(one_message.data(), one_message.size(), journal_);
+            write_or_throw(one_message.data(), one_message.size());
             // Append newline if the message didn't have one
-            if (one_message.empty() || one_message.back() != '\n') {
-                details::os::fwrite_bytes("\n", 1, journal_);
+            if (nl_pos == string_view_t::npos) {
+                write_or_throw("\n", 1);
             }
 
             pos = end;
         }
     }
 
-    void flush_() override {}
+    void flush_() override {
+        if (journal_ != nullptr) {
+            if (::fflush(journal_) != 0) {
+                throw_spdlog_ex("Failed flush to systemd journal", errno);
+            }
+        }
+    }
 };
 
 using systemd_namespace_sink_mt = systemd_namespace_sink<std::mutex>;
 using systemd_namespace_sink_st = systemd_namespace_sink<details::null_mutex>;
 }  // namespace sinks
 
-// Create and register a syslog logger
 template <typename Factory = spdlog::synchronous_factory>
 inline std::shared_ptr<logger> systemd_namespace_logger_mt(const std::string &logger_name,
                                                            const std::string &ident,

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -73,7 +73,7 @@ public:
 protected:
     FILE *journal_ = nullptr;
     bool enable_formatting_ = false;
-    using level_prefix_array = std::array<const char *, 7>;
+    using level_prefix_array = std::array<string_view_t, 7>;
     static constexpr level_prefix_array level_prefixes_ = {
         {/* spdlog::level::trace      */ SD_DEBUG,
          /* spdlog::level::debug      */ SD_DEBUG,
@@ -82,7 +82,6 @@ protected:
          /* spdlog::level::err        */ SD_ERR,
          /* spdlog::level::critical   */ SD_CRIT,
          /* spdlog::level::off        */ SD_INFO}};
-    static constexpr size_t level_prefix_length_ = 3;
 
     void sink_it_(const details::log_msg &msg) override {
         string_view_t payload;
@@ -104,8 +103,8 @@ protected:
 
             // Write log level prefix
             write_or_throw_(
-                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)),
-                level_prefix_length_);
+                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)).data(),
+                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)).size());
             // Write the message
             write_or_throw_(one_message.data(), one_message.size());
             // Append newline if the message didn't have one

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -102,9 +102,9 @@ protected:
             string_view_t one_message = payload.substr(pos, end - pos);
 
             // Write log level prefix
-            write_or_throw_(
-                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)).data(),
-                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)).size());
+            const auto &prefix =
+                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level));
+            write_or_throw_(prefix.data(), prefix.size());
             // Write the message
             write_or_throw_(one_message.data(), one_message.size());
             // Append newline if the message didn't have one

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -1,0 +1,145 @@
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/os.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/sinks/base_sink.h>
+
+#include <array>
+#ifndef SD_JOURNAL_SUPPRESS_LOCATION
+#define SD_JOURNAL_SUPPRESS_LOCATION
+#endif
+#include <systemd/sd-journal.h>
+#include <systemd/sd-daemon.h>
+
+namespace spdlog {
+namespace sinks {
+
+/**
+ * Sink that opens a stream to a specific systemd journal namespace using
+ * sd_journal_stream_fd_with_namespace(). This sink cannot utilize extra fields like TID, CODE_LINE,
+ * or CODE_FUNC since sd_journal_send() does not have a namespace-specific counterpart. Journal does
+ * interpret kernel-style log level prefixes though, so PRIORITY field is populated correctly.
+ */
+template <typename Mutex>
+class systemd_namespace_sink : public base_sink<Mutex> {
+public:
+    explicit systemd_namespace_sink(std::string ident,
+                                    std::string name_space,
+                                    bool enable_formatting)
+        : enable_formatting_{enable_formatting},
+          level_prefixes_{{/* spdlog::level::trace      */ SD_DEBUG,
+                           /* spdlog::level::debug      */ SD_DEBUG,
+                           /* spdlog::level::info       */ SD_INFO,
+                           /* spdlog::level::warn       */ SD_WARNING,
+                           /* spdlog::level::err        */ SD_ERR,
+                           /* spdlog::level::critical   */ SD_CRIT,
+                           /* spdlog::level::off        */ SD_INFO}} {
+        int stream_fd = -1;
+        if (name_space.empty()) {
+            stream_fd = ::sd_journal_stream_fd(ident.c_str(), LOG_INFO, 1);
+        } else {
+            stream_fd = ::sd_journal_stream_fd_with_namespace(name_space.c_str(), ident.c_str(),
+                                                              LOG_INFO, 1);
+        }
+        if (stream_fd < 0) {
+            throw_spdlog_ex("Failed opening systemd journal stream to namespace '" + name_space +
+                            "': " + ::strerror(-stream_fd));
+        }
+        journal_ = ::fdopen(stream_fd, "w");
+        if (journal_ == nullptr) {
+            // Capture errno from the failed fdopen() instead of close() (in case that fails too)
+            const int saved_errno = errno;
+            ::close(stream_fd);
+            throw_spdlog_ex(
+                "Failed opening systemd journal stream to namespace '" + name_space + "'",
+                saved_errno);
+        }
+        // Use line buffering which matches with journald's line-oriented protocol
+        ::setvbuf(journal_, nullptr, _IOLBF, 0);
+    }
+
+    ~systemd_namespace_sink() override {
+        if (journal_ != nullptr) {
+            ::fclose(journal_);
+            journal_ = nullptr;
+        }
+    }
+
+    systemd_namespace_sink(const systemd_namespace_sink &) = delete;
+    systemd_namespace_sink &operator=(const systemd_namespace_sink &) = delete;
+
+protected:
+    FILE *journal_ = nullptr;
+    bool enable_formatting_ = false;
+    using level_prefix_array = std::array<const char *, 7>;
+    level_prefix_array level_prefixes_;
+
+    void sink_it_(const details::log_msg &msg) override {
+        string_view_t payload;
+        memory_buf_t formatted;
+        if (enable_formatting_) {
+            base_sink<Mutex>::formatter_->format(msg, formatted);
+            payload = string_view_t(formatted.data(), formatted.size());
+        } else {
+            payload = msg.payload;
+        }
+
+        // Journal stream is line-oriented; if there's newlines in the payload, send each
+        // newline-delimited piece separately as its own message.
+        size_t pos = 0;
+        while (pos < payload.size()) {
+            size_t nl_pos = payload.find('\n', pos);
+            size_t end = (nl_pos == std::string_view::npos) ? payload.size() : nl_pos + 1;
+            std::string_view one_message = payload.substr(pos, end - pos);
+
+            // Limit single message size to max int, but take into account the 3 characters of
+            // kernel-style log level prefix
+            size_t length = one_message.size();
+            if ((length + 3) > static_cast<size_t>(std::numeric_limits<int>::max())) {
+                length = static_cast<size_t>(std::numeric_limits<int>::max()) - 3;
+            }
+
+            // Write log level prefix
+            details::os::fwrite_bytes(
+                level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)), 3,
+                journal_);
+            // Write the message
+            details::os::fwrite_bytes(one_message.data(), one_message.size(), journal_);
+            // Append newline if the message didn't have one
+            if (one_message.empty() || one_message.back() != '\n') {
+                details::os::fwrite_bytes("\n", 1, journal_);
+            }
+
+            pos = end;
+        }
+    }
+
+    void flush_() override {}
+};
+
+using systemd_namespace_sink_mt = systemd_namespace_sink<std::mutex>;
+using systemd_namespace_sink_st = systemd_namespace_sink<details::null_mutex>;
+}  // namespace sinks
+
+// Create and register a syslog logger
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> systemd_namespace_logger_mt(const std::string &logger_name,
+                                                           const std::string &ident,
+                                                           const std::string &name_space,
+                                                           bool enable_formatting) {
+    return Factory::template create<sinks::systemd_namespace_sink_mt>(
+        logger_name, ident, name_space, enable_formatting);
+}
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> systemd_namespace_logger_st(const std::string &logger_name,
+                                                           const std::string &ident,
+                                                           const std::string &name_space,
+                                                           bool enable_formatting) {
+    return Factory::template create<sinks::systemd_namespace_sink_st>(
+        logger_name, ident, name_space, enable_formatting);
+}
+}  // namespace spdlog

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -35,8 +35,9 @@ public:
                                                               LOG_INFO, 1);
         }
         if (stream_fd < 0) {
-            throw_spdlog_ex("Failed opening systemd journal stream to namespace '" + name_space +
-                            "': " + ::strerror(-stream_fd));
+            throw_spdlog_ex(
+                "Failed opening systemd journal stream to namespace '" + name_space + "'",
+                -stream_fd);
         }
         journal_ = ::fdopen(stream_fd, "w");
         if (journal_ == nullptr) {
@@ -48,7 +49,15 @@ public:
                 saved_errno);
         }
         // Use line buffering which matches with journald's line-oriented protocol
-        ::setvbuf(journal_, nullptr, _IOLBF, 0);
+        if (::setvbuf(journal_, nullptr, _IOLBF, 0) != 0) {
+            // Capture errno from the failed setvbuf() instead of close() (in case that fails too)
+            const int saved_errno = errno;
+            ::close(stream_fd);
+            throw_spdlog_ex(
+                "Failed setting line buffering mode for systemd journal stream to namespace '" +
+                    name_space + "'",
+                saved_errno);
+        }
     }
 
     ~systemd_namespace_sink() override {
@@ -85,12 +94,6 @@ protected:
             payload = msg.payload;
         }
 
-        auto write_or_throw = [this](const void *data, size_t n) {
-            if (!details::os::fwrite_bytes(data, n, journal_)) {
-                throw_spdlog_ex("Failed writing to systemd journal", errno);
-            }
-        };
-
         // Journal stream is line-oriented; if there's newlines in the payload, send each
         // newline-delimited piece separately as its own message.
         size_t pos = 0;
@@ -100,14 +103,14 @@ protected:
             string_view_t one_message = payload.substr(pos, end - pos);
 
             // Write log level prefix
-            write_or_throw(
+            write_or_throw_(
                 level_prefixes_.at(static_cast<level_prefix_array::size_type>(msg.level)),
                 level_prefix_length_);
             // Write the message
-            write_or_throw(one_message.data(), one_message.size());
+            write_or_throw_(one_message.data(), one_message.size());
             // Append newline if the message didn't have one
             if (nl_pos == string_view_t::npos) {
-                write_or_throw("\n", 1);
+                write_or_throw_("\n", 1);
             }
 
             pos = end;
@@ -118,6 +121,15 @@ protected:
         if (journal_ != nullptr) {
             if (::fflush(journal_) != 0) {
                 throw_spdlog_ex("Failed flush to systemd journal", errno);
+            }
+        }
+    }
+
+private:
+    void write_or_throw_(const void *data, size_t n) {
+        if (journal_ != nullptr) {
+            if (!details::os::fwrite_bytes(data, n, journal_)) {
+                throw_spdlog_ex("Failed writing to systemd journal", errno);
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,9 @@ endif()
 
 if(systemd_FOUND)
     list(APPEND SPDLOG_UTESTS_SOURCES test_systemd.cpp)
+    if(systemd_VERSION VERSION_GREATER_EQUAL "256")
+        list(APPEND SPDLOG_UTESTS_SOURCES test_systemd_namespace.cpp)
+    endif()
 endif()
 
 enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 
 if(systemd_FOUND)
     list(APPEND SPDLOG_UTESTS_SOURCES test_systemd.cpp)
+    # systemd v256 added support for namespace stream API
     if(systemd_VERSION VERSION_GREATER_EQUAL "256")
         list(APPEND SPDLOG_UTESTS_SOURCES test_systemd_namespace.cpp)
     endif()

--- a/tests/test_systemd_namespace.cpp
+++ b/tests/test_systemd_namespace.cpp
@@ -1,0 +1,192 @@
+#include "includes.h"
+#include "spdlog/sinks/systemd_namespace_sink.h"
+#include <chrono>
+
+// Used as a helper struct to store journal entries when verifying the custom namespace journal
+// output automatically.
+struct JournalEntry {
+    std::string message;
+    std::string priority;
+    std::string syslog_identifier;
+    uint64_t realtime_usec = 0;
+};
+
+// Used as a helper class to test the custom namespace journal output automatically.
+class JournalReader {
+public:
+    explicit JournalReader(const std::string& name_space) {
+        int r = -1;
+        if (name_space.empty()) {
+            r = sd_journal_open(&j_, SD_JOURNAL_LOCAL_ONLY);
+        } else {
+            r = sd_journal_open_namespace(&j_, name_space.c_str(), SD_JOURNAL_LOCAL_ONLY);
+        }
+        if (r < 0) {
+            throw std::runtime_error(std::string("sd_journal_open failed: ") + strerror(-r));
+        }
+    }
+
+    ~JournalReader() {
+        if (j_ != nullptr) {
+            sd_journal_close(j_);
+        }
+    }
+
+    JournalReader(const JournalReader&) = delete;
+    JournalReader& operator=(const JournalReader&) = delete;
+
+    // Position the cursor at "now" so we only see entries written after this point.
+    void seek_to_now() {
+        uint64_t now_usec = std::chrono::duration_cast<std::chrono::microseconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count();
+        int r = sd_journal_seek_realtime_usec(j_, now_usec);
+        if (r < 0) {
+            throw std::runtime_error(std::string("seek_realtime_usec failed: ") + strerror(-r));
+        }
+        // After seek, you must call sd_journal_next/previous before reading.
+        // We don't call next() here because there may not be an entry yet.
+    }
+
+    // Add a match filter, e.g. "SYSLOG_IDENTIFIER=myapp".
+    // Multiple matches on the same field are OR'd; matches on different fields are AND'd.
+    void add_match(const std::string& match) {
+        int r = sd_journal_add_match(j_, match.data(), match.size());
+        if (r < 0) {
+            throw std::runtime_error(std::string("add_match failed: ") + strerror(-r));
+        }
+    }
+
+    // Read up to max_entries new entries, waiting up to timeout for each.
+    // Returns whatever was collected when either max_entries is reached or
+    // a wait times out.
+    std::vector<JournalEntry> wait_and_read(size_t max_entries, std::chrono::milliseconds timeout) {
+        std::vector<JournalEntry> out;
+        out.reserve(max_entries);
+
+        while (out.size() < max_entries) {
+            int r = sd_journal_next(j_);
+            if (r < 0) {
+                throw std::runtime_error(std::string("sd_journal_next failed: ") + strerror(-r));
+            }
+            if (r == 0) {
+                // No new entry available yet; wait a moment.
+                uint64_t timeout_usec = static_cast<uint64_t>(timeout.count()) * 1000;
+                int w = sd_journal_wait(j_, timeout_usec);
+                if (w < 0) {
+                    throw std::runtime_error(std::string("sd_journal_wait failed: ") +
+                                             strerror(-w));
+                }
+                if (w == SD_JOURNAL_NOP) {
+                    // Timeout
+                    break;
+                }
+                continue;
+            }
+
+            out.push_back(read_current_entry());
+        }
+        return out;
+    }
+
+private:
+    JournalEntry read_current_entry() {
+        JournalEntry e;
+
+        const void* data = nullptr;
+        size_t len = 0;
+
+        if (sd_journal_get_data(j_, "MESSAGE", &data, &len) >= 0) {
+            e.message = field_value(data, len);
+        }
+        if (sd_journal_get_data(j_, "PRIORITY", &data, &len) >= 0) {
+            e.priority = field_value(data, len);
+        }
+        if (sd_journal_get_data(j_, "SYSLOG_IDENTIFIER", &data, &len) >= 0) {
+            e.syslog_identifier = field_value(data, len);
+        }
+        sd_journal_get_realtime_usec(j_, &e.realtime_usec);
+        return e;
+    }
+
+    // Strip "KEY=value" pair to just value.
+    static std::string field_value(const void* data, size_t len) {
+        const char* p = static_cast<const char*>(data);
+        const char* eq = static_cast<const char*>(std::memchr(p, '=', len));
+        if (!eq) return std::string(p, len);
+        return std::string(eq + 1, len - (eq + 1 - p));
+    }
+
+    sd_journal* j_ = nullptr;
+};
+
+TEST_CASE("systemd_namespace to default namespace", "[all]") {
+    auto logger = spdlog::systemd_namespace_logger_st("spdlog_systemd_namespace_all_test",
+                                                      "spdlog-utests", "", false);
+    logger->set_level(spdlog::level::trace);
+    logger->trace("test spdlog trace unformatted");
+    logger->debug("test spdlog debug unformatted");
+    SPDLOG_LOGGER_INFO((logger), "test spdlog info unformatted");
+    SPDLOG_LOGGER_WARN((logger), "test spdlog warn unformatted");
+    SPDLOG_LOGGER_ERROR((logger), "test spdlog error unformatted");
+    SPDLOG_LOGGER_CRITICAL((logger), "test spdlog critical unformatted");
+    logger->info("Long message\nthat spans\nmultiple lines unformatted");
+
+    auto f_logger = spdlog::systemd_namespace_logger_st("spdlog_systemd_namespace_all_test_formatted",
+                                                      "spdlog-utests", "", true);
+    f_logger->set_level(spdlog::level::trace);
+    f_logger->trace("test spdlog trace formatted");
+    f_logger->debug("test spdlog debug formatted");
+    SPDLOG_LOGGER_INFO((f_logger), "test spdlog info formatted");
+    SPDLOG_LOGGER_WARN((f_logger), "test spdlog warn formatted");
+    SPDLOG_LOGGER_ERROR((f_logger), "test spdlog error formatted");
+    SPDLOG_LOGGER_CRITICAL((f_logger), "test spdlog critical formatted");
+    f_logger->info("Long message\nthat spans\nmultiple lines formatted");
+}
+
+TEST_CASE("systemd_namespace to custom namespace", "[.systemd_namespace]") {
+    // This test is skipped from the default set since it requires extra preparation.
+    // Running this test requires you to start journald on namespace 'custom', for example by
+    // running: sudo systemctl start systemd-journald@custom.service
+    //
+    // This test also automatically verifies the output, so the user running the test must have
+    // access to read the custom journal namespace.
+    auto logger = spdlog::systemd_namespace_logger_st("spdlog_systemd_namespace_custom_test",
+                                                      "spdlog-utests", "custom", false);
+    JournalReader reader("custom");
+    reader.add_match("SYSLOG_IDENTIFIER=spdlog-utests");
+    reader.seek_to_now();
+
+    logger->set_level(spdlog::level::trace);
+    logger->trace("test spdlog trace");
+    logger->debug("test spdlog debug");
+    SPDLOG_LOGGER_INFO((logger), "test spdlog info");
+    SPDLOG_LOGGER_WARN((logger), "test spdlog warn");
+    SPDLOG_LOGGER_ERROR((logger), "test spdlog error");
+    SPDLOG_LOGGER_CRITICAL((logger), "test spdlog critical");
+    logger->info("Long message\nthat spans\nmultiple lines");
+    logger->warn("");
+
+    const int expected_message_count = 9;
+    auto entries = reader.wait_and_read(expected_message_count, std::chrono::seconds(2));
+
+    REQUIRE(entries.size() == expected_message_count);
+    REQUIRE(entries[0].message == "test spdlog trace");
+    REQUIRE(entries[0].priority == "7");
+    REQUIRE(entries[1].message == "test spdlog debug");
+    REQUIRE(entries[1].priority == "7");
+    REQUIRE(entries[2].message == "test spdlog info");
+    REQUIRE(entries[2].priority == "6");
+    REQUIRE(entries[3].message == "test spdlog warn");
+    REQUIRE(entries[3].priority == "4");
+    REQUIRE(entries[4].message == "test spdlog error");
+    REQUIRE(entries[4].priority == "3");
+    REQUIRE(entries[5].message == "test spdlog critical");
+    REQUIRE(entries[5].priority == "2");
+    REQUIRE(entries[6].message == "Long message");
+    REQUIRE(entries[6].priority == "6");
+    REQUIRE(entries[7].message == "that spans");
+    REQUIRE(entries[7].priority == "6");
+    REQUIRE(entries[8].message == "multiple lines");
+    REQUIRE(entries[8].priority == "6");
+}


### PR DESCRIPTION
Adds systemd_namespace_sink that can open a stream to a specific systemd journal namespace for logging. This was created as a separate sink from systemd_sink because it has significant difference due to systemd's journal API: `sd_journal_send()` does not have namespace-specific counterpart and thus this cannot utilize other extra journal fields than `PRIORITY` (via kernel-style log level prefixes).

Another difference is that this namespace stream API is only available from systemd version 256, thus a version check was added to CMake file for the unit tests so that they are not automatically included if `libsystemd` is not new enough.

Unit tests are split to two parts: first one runs always and it just uses the stream to log to default namespace (should always work). Second one requires manual setting up of "custom" journal namespace and thus is ignored from the default set of tests (can be run by specifying `[systemd_namespace]` tag explicitly when running tests). On the other hand, the second part also automatically checks the output correctness from journal.