### PR TITLE
Use "if constexpr" in SPDLOG_LOGGER_TRACE

### DIFF
--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -298,7 +298,7 @@ inline void critical(const T &msg) {
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define SPDLOG_LOGGER_TRACE(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__)
+    do { if constexpr (SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE) SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__); } while (0)
 #define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0


### PR DESCRIPTION
To reduce need for `[[maybe_unused]]` when `-Werror=unused` is in effect.

The PR changes only one line, for discussion's sake. If this is approved, I'll do similar to SPDLOG_LOGGER_DEBUG, INFO, etc.

At $WORK, we compile all code with `-Werror=unused-parameter` (and similar options). So an unused function arguments is a show stopper. Yet some functions take an argument that is only used for logging. If SPD_LOGGER_TRACE black-holes the argument to `(void)0`, compilation fails because the argument appears unused. So we have to sprinkle `[[maybe_unused]]` all over the place for arguments and variables that matter only for logging. If SPDLOG_LOGGER_TRACE uses `if constexpr`, then the call to spdlog is still black-holed at compile time but the compiler is satisfied that the argument is "used."