### PR TITLE
Enable defining custom namespace for spdlog

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,6 +62,53 @@ jobs:
           ctest -j 4 --output-on-failure
 
   # -----------------------------------------------------------------------
+  # Namespace customization regression tests
+  # -----------------------------------------------------------------------
+  build_namespace_override:
+    runs-on: ubuntu-latest
+    container: gcc:12
+    defaults:
+      run:
+        shell: bash
+    name: "Namespace override"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup
+        run: |
+          apt-get update
+          apt-get install -y curl git pkg-config libsystemd-dev
+          CMAKE_VERSION="3.24.2"
+          curl -sSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh -o install-cmake.sh
+          chmod +x install-cmake.sh
+          ./install-cmake.sh --prefix=/usr/local --skip-license
+      - name: "Strict rename — library compile-only"
+        run: |
+          mkdir -p build/ns-rename && cd build/ns-rename
+          cmake ../.. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DSPDLOG_BUILD_SHARED=ON \
+            -DCMAKE_CXX_FLAGS="-DSPDLOG_NAMESPACE=spdlog_ns_ci_test"
+          make spdlog -j 4
+      - name: "Inline-namespace wrap — full build and tests"
+        run: |
+          mkdir -p build/ns-inline
+          cat > build/ns_inline_wrap.h <<'EOF'
+          #pragma once
+          #define SPDLOG_NAMESPACE_BEGIN namespace spdlog { inline namespace ns_ci_test {
+          #define SPDLOG_NAMESPACE_END } }
+          EOF
+          cd build/ns-inline
+          cmake ../.. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DSPDLOG_BUILD_EXAMPLE=ON \
+            -DSPDLOG_BUILD_TESTS=ON \
+            -DCMAKE_CXX_FLAGS="-include $GITHUB_WORKSPACE/build/ns_inline_wrap.h"
+          make -j 4
+          ctest -j 4 --output-on-failure
+
+  # -----------------------------------------------------------------------
   # OS X build matrix
   # -----------------------------------------------------------------------
   build_osx:

--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -59,14 +59,14 @@ using async_factory = async_factory_impl<async_overflow_policy::block>;
 using async_factory_nonblock = async_factory_impl<async_overflow_policy::overrun_oldest>;
 
 template <typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create_async(std::string logger_name,
+inline std::shared_ptr<logger> create_async(std::string logger_name,
                                                     SinkArgs &&...sink_args) {
     return async_factory::create<Sink>(std::move(logger_name),
                                        std::forward<SinkArgs>(sink_args)...);
 }
 
 template <typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create_async_nb(std::string logger_name,
+inline std::shared_ptr<logger> create_async_nb(std::string logger_name,
                                                        SinkArgs &&...sink_args) {
     return async_factory_nonblock::create<Sink>(std::move(logger_name),
                                                 std::forward<SinkArgs>(sink_args)...);
@@ -93,7 +93,7 @@ inline void init_thread_pool(size_t q_size, size_t thread_count) {
 }
 
 // get the global thread pool.
-inline std::shared_ptr<spdlog::details::thread_pool> thread_pool() {
+inline std::shared_ptr<details::thread_pool> thread_pool() {
     return details::registry::instance().get_tp();
 }
 }  // namespace spdlog

--- a/include/spdlog/async.h
+++ b/include/spdlog/async.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <mutex>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace details {
 static const size_t default_async_q_size = 8192;
@@ -96,4 +96,4 @@ inline void init_thread_pool(size_t q_size, size_t thread_count) {
 inline std::shared_ptr<details::thread_pool> thread_pool() {
     return details::registry::instance().get_tp();
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -13,7 +13,7 @@
 #include <memory>
 #include <string>
 
-SPDLOG_INLINE spdlog::async_logger::async_logger(std::string logger_name,
+SPDLOG_INLINE async_logger::async_logger(std::string logger_name,
                                                  sinks_init_list sinks_list,
                                                  std::weak_ptr<details::thread_pool> tp,
                                                  async_overflow_policy overflow_policy)
@@ -23,7 +23,7 @@ SPDLOG_INLINE spdlog::async_logger::async_logger(std::string logger_name,
                    std::move(tp),
                    overflow_policy) {}
 
-SPDLOG_INLINE spdlog::async_logger::async_logger(std::string logger_name,
+SPDLOG_INLINE async_logger::async_logger(std::string logger_name,
                                                  sink_ptr single_sink,
                                                  std::weak_ptr<details::thread_pool> tp,
                                                  async_overflow_policy overflow_policy)
@@ -31,7 +31,7 @@ SPDLOG_INLINE spdlog::async_logger::async_logger(std::string logger_name,
           std::move(logger_name), {std::move(single_sink)}, std::move(tp), overflow_policy) {}
 
 // send the log message to the thread pool
-SPDLOG_INLINE void spdlog::async_logger::sink_it_(const details::log_msg &msg){
+SPDLOG_INLINE void async_logger::sink_it_(const details::log_msg &msg){
     SPDLOG_TRY{if (auto pool_ptr = thread_pool_.lock()){
         pool_ptr -> post_log(shared_from_this(), msg, overflow_policy_);
 }
@@ -43,7 +43,7 @@ SPDLOG_LOGGER_CATCH(msg.source)
 }
 
 // send flush request to the thread pool
-SPDLOG_INLINE void spdlog::async_logger::flush_(){
+SPDLOG_INLINE void async_logger::flush_(){
     SPDLOG_TRY{if (auto pool_ptr = thread_pool_.lock()){
         pool_ptr -> post_flush(shared_from_this(), overflow_policy_);
 }
@@ -57,7 +57,7 @@ SPDLOG_LOGGER_CATCH(source_loc())
 //
 // backend functions - called from the thread pool to do the actual job
 //
-SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg &incoming_log_msg) {
+SPDLOG_INLINE void async_logger::backend_sink_it_(const details::log_msg &incoming_log_msg) {
     for (auto &sink : sinks_) {
         if (sink->should_log(incoming_log_msg.level)) {
             SPDLOG_TRY { sink->log(incoming_log_msg); }
@@ -70,15 +70,15 @@ SPDLOG_INLINE void spdlog::async_logger::backend_sink_it_(const details::log_msg
     }
 }
 
-SPDLOG_INLINE void spdlog::async_logger::backend_flush_() {
+SPDLOG_INLINE void async_logger::backend_flush_() {
     for (auto &sink : sinks_) {
         SPDLOG_TRY { sink->flush(); }
         SPDLOG_LOGGER_CATCH(source_loc())
     }
 }
 
-SPDLOG_INLINE std::shared_ptr<spdlog::logger> spdlog::async_logger::clone(std::string new_name) {
-    auto cloned = std::make_shared<spdlog::async_logger>(*this);
+SPDLOG_INLINE std::shared_ptr<logger> async_logger::clone(std::string new_name) {
+    auto cloned = std::make_shared<async_logger>(*this);
     cloned->name_ = std::move(new_name);
     return cloned;
 }

--- a/include/spdlog/async_logger-inl.h
+++ b/include/spdlog/async_logger-inl.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <string>
 
+SPDLOG_NAMESPACE_BEGIN
+
 SPDLOG_INLINE async_logger::async_logger(std::string logger_name,
                                                  sinks_init_list sinks_list,
                                                  std::weak_ptr<details::thread_pool> tp,
@@ -82,3 +84,5 @@ SPDLOG_INLINE std::shared_ptr<logger> async_logger::clone(std::string new_name) 
     cloned->name_ = std::move(new_name);
     return cloned;
 }
+
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/async_logger.h
+++ b/include/spdlog/async_logger.h
@@ -16,7 +16,7 @@
 
 #include <spdlog/logger.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // Async overflow policy - block by default.
 enum class async_overflow_policy {
@@ -67,7 +67,7 @@ private:
     std::weak_ptr<details::thread_pool> thread_pool_;
     async_overflow_policy overflow_policy_;
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "async_logger-inl.h"

--- a/include/spdlog/cfg/argv.h
+++ b/include/spdlog/cfg/argv.h
@@ -17,7 +17,7 @@
 // turn off all logging except for logger1 and logger2:
 // example.exe "SPDLOG_LEVEL=off,logger1=debug,logger2=info"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace cfg {
 
 // search for SPDLOG_LEVEL= in the args and use it to init the levels
@@ -37,4 +37,4 @@ inline void load_argv_levels(int argc, char **argv) {
 }
 
 }  // namespace cfg
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/cfg/env.h
+++ b/include/spdlog/cfg/env.h
@@ -23,7 +23,7 @@
 // turn off all logging except for logger1 and logger2:
 // export SPDLOG_LEVEL="off,logger1=debug,logger2=info"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace cfg {
 inline void load_env_levels(const char* var = "SPDLOG_LEVEL") {
     const auto levels_spec = details::os::getenv(var);
@@ -33,4 +33,4 @@ inline void load_env_levels(const char* var = "SPDLOG_LEVEL") {
 }
 
 }  // namespace cfg
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/cfg/helpers-inl.h
+++ b/include/spdlog/cfg/helpers-inl.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <utility>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace cfg {
 namespace helpers {
 
@@ -103,4 +103,4 @@ SPDLOG_INLINE void load_levels(const std::string &levels_spec) {
 
 }  // namespace helpers
 }  // namespace cfg
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/cfg/helpers.h
+++ b/include/spdlog/cfg/helpers.h
@@ -6,7 +6,7 @@
 #include <spdlog/common.h>
 #include <unordered_map>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace cfg {
 namespace helpers {
 //
@@ -22,7 +22,7 @@ SPDLOG_API void load_levels(const std::string &levels_spec);
 }  // namespace helpers
 
 }  // namespace cfg
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "helpers-inl.h"

--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -11,7 +11,7 @@
 #include <iterator>
 #include <cctype>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace level {
 
 #if __cplusplus >= 201703L
@@ -82,4 +82,4 @@ SPDLOG_INLINE void throw_spdlog_ex(const std::string &msg, int last_errno) {
 
 SPDLOG_INLINE void throw_spdlog_ex(std::string msg) { SPDLOG_THROW(spdlog_ex(std::move(msg))); }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/common-inl.h
+++ b/include/spdlog/common-inl.h
@@ -21,15 +21,15 @@ constexpr
 
 static const char *short_level_names[] SPDLOG_SHORT_LEVEL_NAMES;
 
-SPDLOG_INLINE const string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT {
+SPDLOG_INLINE const string_view_t &to_string_view(level::level_enum l) SPDLOG_NOEXCEPT {
     return level_string_views[l];
 }
 
-SPDLOG_INLINE const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT {
+SPDLOG_INLINE const char *to_short_c_str(level::level_enum l) SPDLOG_NOEXCEPT {
     return short_level_names[l];
 }
 
-SPDLOG_INLINE spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT {
+SPDLOG_INLINE level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT {
     auto it = std::find_if(std::begin(level_string_views), std::end(level_string_views),
                            [&name](const string_view_t &level_name) {
                                return level_name.size() == name.size() &&

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -255,13 +255,13 @@ enum level_enum : int {
     n_levels
 };
 
-#define SPDLOG_LEVEL_NAME_TRACE SPDLOG_NS__::string_view_t("trace", 5)
-#define SPDLOG_LEVEL_NAME_DEBUG SPDLOG_NS__::string_view_t("debug", 5)
-#define SPDLOG_LEVEL_NAME_INFO SPDLOG_NS__::string_view_t("info", 4)
-#define SPDLOG_LEVEL_NAME_WARNING SPDLOG_NS__::string_view_t("warning", 7)
-#define SPDLOG_LEVEL_NAME_ERROR SPDLOG_NS__::string_view_t("error", 5)
-#define SPDLOG_LEVEL_NAME_CRITICAL SPDLOG_NS__::string_view_t("critical", 8)
-#define SPDLOG_LEVEL_NAME_OFF SPDLOG_NS__::string_view_t("off", 3)
+#define SPDLOG_LEVEL_NAME_TRACE SPDLOG_NAMESPACE::string_view_t("trace", 5)
+#define SPDLOG_LEVEL_NAME_DEBUG SPDLOG_NAMESPACE::string_view_t("debug", 5)
+#define SPDLOG_LEVEL_NAME_INFO SPDLOG_NAMESPACE::string_view_t("info", 4)
+#define SPDLOG_LEVEL_NAME_WARNING SPDLOG_NAMESPACE::string_view_t("warning", 7)
+#define SPDLOG_LEVEL_NAME_ERROR SPDLOG_NAMESPACE::string_view_t("error", 5)
+#define SPDLOG_LEVEL_NAME_CRITICAL SPDLOG_NAMESPACE::string_view_t("critical", 8)
+#define SPDLOG_LEVEL_NAME_OFF SPDLOG_NAMESPACE::string_view_t("off", 3)
 
 #if !defined(SPDLOG_LEVEL_NAMES)
 #define SPDLOG_LEVEL_NAMES                                                                  \

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -120,7 +120,9 @@
     }
 #endif
 
-namespace spdlog {
+#include "./namespace.h"
+
+SPDLOG_NAMESPACE_BEGIN
 
 class formatter;
 
@@ -367,7 +369,7 @@ constexpr T conditional_static_cast(U value) {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "common-inl.h"

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -255,13 +255,13 @@ enum level_enum : int {
     n_levels
 };
 
-#define SPDLOG_LEVEL_NAME_TRACE spdlog::string_view_t("trace", 5)
-#define SPDLOG_LEVEL_NAME_DEBUG spdlog::string_view_t("debug", 5)
-#define SPDLOG_LEVEL_NAME_INFO spdlog::string_view_t("info", 4)
-#define SPDLOG_LEVEL_NAME_WARNING spdlog::string_view_t("warning", 7)
-#define SPDLOG_LEVEL_NAME_ERROR spdlog::string_view_t("error", 5)
-#define SPDLOG_LEVEL_NAME_CRITICAL spdlog::string_view_t("critical", 8)
-#define SPDLOG_LEVEL_NAME_OFF spdlog::string_view_t("off", 3)
+#define SPDLOG_LEVEL_NAME_TRACE SPDLOG_NS__::string_view_t("trace", 5)
+#define SPDLOG_LEVEL_NAME_DEBUG SPDLOG_NS__::string_view_t("debug", 5)
+#define SPDLOG_LEVEL_NAME_INFO SPDLOG_NS__::string_view_t("info", 4)
+#define SPDLOG_LEVEL_NAME_WARNING SPDLOG_NS__::string_view_t("warning", 7)
+#define SPDLOG_LEVEL_NAME_ERROR SPDLOG_NS__::string_view_t("error", 5)
+#define SPDLOG_LEVEL_NAME_CRITICAL SPDLOG_NS__::string_view_t("critical", 8)
+#define SPDLOG_LEVEL_NAME_OFF SPDLOG_NS__::string_view_t("off", 3)
 
 #if !defined(SPDLOG_LEVEL_NAMES)
 #define SPDLOG_LEVEL_NAMES                                                                  \

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -276,9 +276,9 @@ enum level_enum : int {
     { "T", "D", "I", "W", "E", "C", "O" }
 #endif
 
-SPDLOG_API const string_view_t &to_string_view(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
-SPDLOG_API const char *to_short_c_str(spdlog::level::level_enum l) SPDLOG_NOEXCEPT;
-SPDLOG_API spdlog::level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
+SPDLOG_API const string_view_t &to_string_view(level::level_enum l) SPDLOG_NOEXCEPT;
+SPDLOG_API const char *to_short_c_str(level::level_enum l) SPDLOG_NOEXCEPT;
+SPDLOG_API level::level_enum from_str(const std::string &name) SPDLOG_NOEXCEPT;
 
 }  // namespace level
 

--- a/include/spdlog/details/backtracer-inl.h
+++ b/include/spdlog/details/backtracer-inl.h
@@ -6,7 +6,7 @@
 #ifndef SPDLOG_HEADER_ONLY
 #include <spdlog/details/backtracer.h>
 #endif
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 SPDLOG_INLINE backtracer::backtracer(const backtracer &other) {
     std::lock_guard<std::mutex> lock(other.mutex_);
@@ -60,4 +60,4 @@ SPDLOG_INLINE void backtracer::foreach_pop(std::function<void(const details::log
     }
 }
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/backtracer.h
+++ b/include/spdlog/details/backtracer.h
@@ -13,7 +13,7 @@
 // Store log messages in circular buffer.
 // Useful for storing debug data in case of error/warning happens.
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class SPDLOG_API backtracer {
     mutable std::mutex mutex_;
@@ -38,7 +38,7 @@ public:
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "backtracer-inl.h"

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -9,7 +9,7 @@
 
 #include "spdlog/common.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 template <typename T>
 class circular_q {
@@ -112,4 +112,4 @@ private:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/console_globals.h
+++ b/include/spdlog/details/console_globals.h
@@ -6,7 +6,7 @@
 #include <mutex>
 #include <spdlog/details/null_mutex.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 struct console_mutex {
@@ -25,4 +25,4 @@ struct console_nullmutex {
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/file_helper-inl.h
+++ b/include/spdlog/details/file_helper-inl.h
@@ -15,7 +15,7 @@
 #include <string>
 #include <tuple>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 SPDLOG_INLINE file_helper::file_helper(const file_event_handlers &event_handlers)
@@ -148,4 +148,4 @@ SPDLOG_INLINE std::tuple<filename_t, filename_t> file_helper::split_by_extension
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -6,7 +6,7 @@
 #include <spdlog/common.h>
 #include <tuple>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // Helper class for file sinks.
@@ -54,7 +54,7 @@ private:
     file_event_handlers event_handlers_;
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "file_helper-inl.h"

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -14,7 +14,7 @@
 #endif
 
 // Some fmt helpers to efficiently format and pad ints and strings
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace fmt_helper {
 
@@ -138,4 +138,4 @@ inline ToDuration time_fraction(log_clock::time_point tp) {
 
 }  // namespace fmt_helper
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -18,7 +18,7 @@ namespace spdlog {
 namespace details {
 namespace fmt_helper {
 
-inline void append_string_view(spdlog::string_view_t view, memory_buf_t &dest) {
+inline void append_string_view(string_view_t view, memory_buf_t &dest) {
     auto *buf_ptr = view.data();
     dest.append(buf_ptr, buf_ptr + view.size());
 }

--- a/include/spdlog/details/log_msg-inl.h
+++ b/include/spdlog/details/log_msg-inl.h
@@ -9,7 +9,7 @@
 
 #include <spdlog/details/os.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 SPDLOG_INLINE log_msg::log_msg(log_clock::time_point log_time,
@@ -41,4 +41,4 @@ SPDLOG_INLINE log_msg::log_msg(string_view_t a_logger_name,
     : log_msg(os::now(), source_loc{}, a_logger_name, lvl, msg) {}
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/log_msg-inl.h
+++ b/include/spdlog/details/log_msg-inl.h
@@ -12,11 +12,11 @@
 namespace spdlog {
 namespace details {
 
-SPDLOG_INLINE log_msg::log_msg(spdlog::log_clock::time_point log_time,
-                               spdlog::source_loc loc,
+SPDLOG_INLINE log_msg::log_msg(log_clock::time_point log_time,
+                               source_loc loc,
                                string_view_t a_logger_name,
-                               spdlog::level::level_enum lvl,
-                               spdlog::string_view_t msg)
+                               level::level_enum lvl,
+                               string_view_t msg)
     : logger_name(a_logger_name),
       level(lvl),
       time(log_time)
@@ -29,15 +29,15 @@ SPDLOG_INLINE log_msg::log_msg(spdlog::log_clock::time_point log_time,
       payload(msg) {
 }
 
-SPDLOG_INLINE log_msg::log_msg(spdlog::source_loc loc,
+SPDLOG_INLINE log_msg::log_msg(source_loc loc,
                                string_view_t a_logger_name,
-                               spdlog::level::level_enum lvl,
-                               spdlog::string_view_t msg)
+                               level::level_enum lvl,
+                               string_view_t msg)
     : log_msg(os::now(), loc, a_logger_name, lvl, msg) {}
 
 SPDLOG_INLINE log_msg::log_msg(string_view_t a_logger_name,
-                               spdlog::level::level_enum lvl,
-                               spdlog::string_view_t msg)
+                               level::level_enum lvl,
+                               string_view_t msg)
     : log_msg(os::now(), source_loc{}, a_logger_name, lvl, msg) {}
 
 }  // namespace details

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -6,7 +6,7 @@
 #include <spdlog/common.h>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 struct SPDLOG_API log_msg {
     log_msg() = default;
@@ -33,7 +33,7 @@ struct SPDLOG_API log_msg {
     string_view_t payload;
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "log_msg-inl.h"

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -7,7 +7,7 @@
 #include <spdlog/details/log_msg_buffer.h>
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 SPDLOG_INLINE log_msg_buffer::log_msg_buffer(const log_msg &orig_msg)
@@ -51,4 +51,4 @@ SPDLOG_INLINE void log_msg_buffer::update_string_views() {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -5,7 +5,7 @@
 
 #include <spdlog/details/log_msg.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // Extend log_msg with internal buffer to store its payload.
@@ -25,7 +25,7 @@ public:
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "log_msg_buffer-inl.h"

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -16,7 +16,7 @@
 #include <condition_variable>
 #include <mutex>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 template <typename T>
@@ -174,4 +174,4 @@ private:
     std::atomic<size_t> discard_counter_{0};
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -170,7 +170,7 @@ private:
     std::mutex queue_mutex_;
     std::condition_variable push_cv_;
     std::condition_variable pop_cv_;
-    spdlog::details::circular_q<T> q_;
+    circular_q<T> q_;
     std::atomic<size_t> discard_counter_{0};
 };
 }  // namespace details

--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <spdlog/namespace.h>
+
 #include <atomic>
 #include <utility>
 // null, no cost dummy "mutex" and dummy "atomic" int
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 struct null_mutex {
     void lock() const {}
@@ -32,4 +34,4 @@ struct null_atomic_int {
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -72,7 +72,7 @@ namespace spdlog {
 namespace details {
 namespace os {
 
-SPDLOG_INLINE spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT {
+SPDLOG_INLINE log_clock::time_point now() SPDLOG_NOEXCEPT {
 #if defined __linux__ && defined SPDLOG_CLOCK_COARSE
     timespec ts;
     ::clock_gettime(CLOCK_REALTIME_COARSE, &ts);

--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -68,7 +68,7 @@
 #define __has_feature(x) 0  // Compatibility with non-clang compilers.
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
@@ -567,4 +567,4 @@ SPDLOG_INLINE bool fwrite_bytes(const void *ptr, const size_t n_bytes, FILE *fp)
 
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -6,7 +6,7 @@
 #include <ctime>  // std::time_t
 #include <spdlog/common.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
@@ -120,7 +120,7 @@ SPDLOG_API bool fwrite_bytes(const void *ptr, const size_t n_bytes, FILE *fp);
 
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "os-inl.h"

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -10,7 +10,7 @@ namespace spdlog {
 namespace details {
 namespace os {
 
-SPDLOG_API spdlog::log_clock::time_point now() SPDLOG_NOEXCEPT;
+SPDLOG_API log_clock::time_point now() SPDLOG_NOEXCEPT;
 
 SPDLOG_API std::tm localtime(const std::time_t &time_tt) SPDLOG_NOEXCEPT;
 

--- a/include/spdlog/details/periodic_worker-inl.h
+++ b/include/spdlog/details/periodic_worker-inl.h
@@ -7,7 +7,7 @@
 #include <spdlog/details/periodic_worker.h>
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // stop the worker thread and join it
@@ -23,4 +23,4 @@ SPDLOG_INLINE periodic_worker::~periodic_worker() {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/periodic_worker.h
+++ b/include/spdlog/details/periodic_worker.h
@@ -15,7 +15,7 @@
 #include <functional>
 #include <mutex>
 #include <thread>
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 class SPDLOG_API periodic_worker {
@@ -51,7 +51,7 @@ private:
     std::condition_variable cv_;
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "periodic_worker-inl.h"

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -27,7 +27,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 SPDLOG_INLINE registry::registry()
@@ -267,4 +267,4 @@ SPDLOG_INLINE void registry::register_or_replace_(std::shared_ptr<logger> new_lo
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/registry-inl.h
+++ b/include/spdlog/details/registry-inl.h
@@ -41,7 +41,7 @@ SPDLOG_INLINE registry::registry()
 #endif
 
     const char *default_logger_name = "";
-    default_logger_ = std::make_shared<spdlog::logger>(default_logger_name, std::move(color_sink));
+    default_logger_ = std::make_shared<logger>(default_logger_name, std::move(color_sink));
     loggers_[default_logger_name] = default_logger_;
 
 #endif  // SPDLOG_DISABLE_DEFAULT_LOGGER

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class logger;
 
 namespace details {
@@ -124,7 +124,7 @@ private:
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "registry-inl.h"

--- a/include/spdlog/details/registry.h
+++ b/include/spdlog/details/registry.h
@@ -113,7 +113,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<logger>> loggers_;
     log_levels log_levels_;
     std::unique_ptr<formatter> formatter_;
-    spdlog::level::level_enum global_log_level_ = level::info;
+    level::level_enum global_log_level_ = level::info;
     level::level_enum flush_level_ = level::off;
     err_handler err_handler_;
     std::shared_ptr<thread_pool> tp_;

--- a/include/spdlog/details/synchronous_factory.h
+++ b/include/spdlog/details/synchronous_factory.h
@@ -5,7 +5,7 @@
 
 #include "registry.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // Default logger factory-  creates synchronous loggers
 class logger;
@@ -19,4 +19,4 @@ struct synchronous_factory {
         return new_logger;
     }
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/synchronous_factory.h
+++ b/include/spdlog/details/synchronous_factory.h
@@ -12,9 +12,9 @@ class logger;
 
 struct synchronous_factory {
     template <typename Sink, typename... SinkArgs>
-    static std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs &&...args) {
+    static std::shared_ptr<logger> create(std::string logger_name, SinkArgs &&...args) {
         auto sink = std::make_shared<Sink>(std::forward<SinkArgs>(args)...);
-        auto new_logger = std::make_shared<spdlog::logger>(std::move(logger_name), std::move(sink));
+        auto new_logger = std::make_shared<logger>(std::move(logger_name), std::move(sink));
         details::registry::instance().initialize_logger(new_logger);
         return new_logger;
     }

--- a/include/spdlog/details/tcp_client-windows.h
+++ b/include/spdlog/details/tcp_client-windows.h
@@ -19,7 +19,7 @@
 #pragma comment(lib, "Mswsock.lib")
 #pragma comment(lib, "AdvApi32.lib")
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class tcp_client {
     SOCKET socket_ = INVALID_SOCKET;
@@ -213,4 +213,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/tcp_client.h
+++ b/include/spdlog/details/tcp_client.h
@@ -21,7 +21,7 @@
 
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class tcp_client {
     int socket_ = -1;
@@ -200,4 +200,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <spdlog/common.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items,
@@ -122,4 +122,4 @@ bool SPDLOG_INLINE thread_pool::process_next_msg_() {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/thread_pool-inl.h
+++ b/include/spdlog/details/thread_pool-inl.h
@@ -20,7 +20,7 @@ SPDLOG_INLINE thread_pool::thread_pool(size_t q_max_items,
     : q_(q_max_items) {
     if (threads_n == 0 || threads_n > 1000) {
         throw_spdlog_ex(
-            "spdlog::thread_pool(): invalid threads_n param (valid "
+            "thread_pool(): invalid threads_n param (valid "
             "range is 1-1000)");
     }
     for (size_t i = 0; i < threads_n; i++) {

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -13,7 +13,7 @@
 #include <thread>
 #include <vector>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class async_logger;
 
 namespace details {
@@ -110,7 +110,7 @@ private:
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "thread_pool-inl.h"

--- a/include/spdlog/details/thread_pool.h
+++ b/include/spdlog/details/thread_pool.h
@@ -18,7 +18,7 @@ class async_logger;
 
 namespace details {
 
-using async_logger_ptr = std::shared_ptr<spdlog::async_logger>;
+using async_logger_ptr = std::shared_ptr<async_logger>;
 
 enum class async_msg_type { log, flush, terminate };
 

--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -21,7 +21,7 @@
 #pragma comment(lib, "AdvApi32.lib")
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class udp_client {
     static constexpr int TX_BUFFER_SIZE = 1024 * 10;
@@ -95,4 +95,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/udp_client.h
+++ b/include/spdlog/details/udp_client.h
@@ -22,7 +22,7 @@
 
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 class udp_client {
@@ -77,4 +77,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -36,7 +36,7 @@
 // logger->info("Some buffer {:X}", spdlog::to_hex(std::begin(buf), std::end(buf)));
 // logger->info("Some buffer {:X}", spdlog::to_hex(std::begin(buf), std::end(buf), 16));
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 template <typename It>
@@ -90,7 +90,7 @@ inline details::dump_info<It> to_hex(const It range_begin,
     return details::dump_info<It>(range_begin, range_end, size_per_line);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 namespace
 #ifdef SPDLOG_USE_STD_FORMAT

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -101,7 +101,7 @@ namespace
 {
 
 template <typename T>
-struct formatter<spdlog::details::dump_info<T>, char> {
+struct formatter<SPDLOG_NS__::details::dump_info<T>, char> {
     char delimiter = ' ';
     bool put_newlines = true;
     bool put_delimiters = true;
@@ -142,7 +142,7 @@ struct formatter<spdlog::details::dump_info<T>, char> {
 
     // format the given bytes range as hex
     template <typename FormatContext, typename Container>
-    auto format(const spdlog::details::dump_info<Container> &the_range,
+    auto format(const SPDLOG_NS__::details::dump_info<Container> &the_range,
                 FormatContext &ctx) const -> decltype(ctx.out()) {
         SPDLOG_CONSTEXPR const char *hex_upper = "0123456789ABCDEF";
         SPDLOG_CONSTEXPR const char *hex_lower = "0123456789abcdef";
@@ -217,7 +217,7 @@ struct formatter<spdlog::details::dump_info<T>, char> {
         *inserter++ = '\n';
 
         if (put_positions) {
-            spdlog::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
+            SPDLOG_NS__::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
         }
     }
 };

--- a/include/spdlog/fmt/bin_to_hex.h
+++ b/include/spdlog/fmt/bin_to_hex.h
@@ -101,7 +101,7 @@ namespace
 {
 
 template <typename T>
-struct formatter<SPDLOG_NS__::details::dump_info<T>, char> {
+struct formatter<SPDLOG_NAMESPACE::details::dump_info<T>, char> {
     char delimiter = ' ';
     bool put_newlines = true;
     bool put_delimiters = true;
@@ -142,7 +142,7 @@ struct formatter<SPDLOG_NS__::details::dump_info<T>, char> {
 
     // format the given bytes range as hex
     template <typename FormatContext, typename Container>
-    auto format(const SPDLOG_NS__::details::dump_info<Container> &the_range,
+    auto format(const SPDLOG_NAMESPACE::details::dump_info<Container> &the_range,
                 FormatContext &ctx) const -> decltype(ctx.out()) {
         SPDLOG_CONSTEXPR const char *hex_upper = "0123456789ABCDEF";
         SPDLOG_CONSTEXPR const char *hex_lower = "0123456789abcdef";
@@ -217,7 +217,7 @@ struct formatter<SPDLOG_NS__::details::dump_info<T>, char> {
         *inserter++ = '\n';
 
         if (put_positions) {
-            SPDLOG_NS__::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
+            SPDLOG_NAMESPACE::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
         }
     }
 };

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -6,7 +6,7 @@
 #include <spdlog/details/log_msg.h>
 #include <spdlog/fmt/fmt.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 class formatter {
 public:
@@ -14,4 +14,4 @@ public:
     virtual void format(const details::log_msg &msg, memory_buf_t &dest) = 0;
     virtual std::unique_ptr<formatter> clone() const = 0;
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/fwd.h
+++ b/include/spdlog/fwd.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class logger;
 class formatter;
 
@@ -15,4 +15,4 @@ namespace level {
 enum level_enum : int;
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/fwd.h
+++ b/include/spdlog/fwd.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "spdlog/namespace.h"
+
 SPDLOG_NAMESPACE_BEGIN
 class logger;
 class formatter;

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -39,7 +39,7 @@ SPDLOG_INLINE logger &logger::operator=(logger other) SPDLOG_NOEXCEPT {
     return *this;
 }
 
-SPDLOG_INLINE void logger::swap(spdlog::logger &other) SPDLOG_NOEXCEPT {
+SPDLOG_INLINE void logger::swap(logger &other) SPDLOG_NOEXCEPT {
     name_.swap(other.name_);
     sinks_.swap(other.sinks_);
 
@@ -121,7 +121,7 @@ SPDLOG_INLINE std::shared_ptr<logger> logger::clone(std::string logger_name) {
 }
 
 // protected methods
-SPDLOG_INLINE void logger::log_it_(const spdlog::details::log_msg &log_msg,
+SPDLOG_INLINE void logger::log_it_(const details::log_msg &log_msg,
                                    bool log_enabled,
                                    bool traceback_enabled) {
     if (log_enabled) {

--- a/include/spdlog/logger-inl.h
+++ b/include/spdlog/logger-inl.h
@@ -13,7 +13,7 @@
 
 #include <cstdio>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // public methods
 SPDLOG_INLINE logger::logger(const logger &other)
@@ -194,4 +194,4 @@ SPDLOG_INLINE void logger::err_handler_(const std::string &msg) const {
 #endif
     }
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -45,7 +45,7 @@
 #define SPDLOG_LOGGER_CATCH(location)
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 class SPDLOG_API logger {
 public:
@@ -380,7 +380,7 @@ protected:
 
 void swap(logger &a, logger &b) noexcept;
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "logger-inl.h"

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -315,8 +315,8 @@ public:
 protected:
     std::string name_;
     std::vector<sink_ptr> sinks_;
-    spdlog::level_t level_{level::info};
-    spdlog::level_t flush_level_{level::off};
+    level_t level_{level::info};
+    level_t flush_level_{level::off};
     err_handler custom_err_handler_{nullptr};
     details::backtracer tracer_;
 

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -73,7 +73,7 @@ public:
     logger(const logger &other);
     logger(logger &&other) SPDLOG_NOEXCEPT;
     logger &operator=(logger other) SPDLOG_NOEXCEPT;
-    void swap(spdlog::logger &other) SPDLOG_NOEXCEPT;
+    void swap(logger &other) SPDLOG_NOEXCEPT;
 
     template <typename... Args>
     void log(source_loc loc, level::level_enum lvl, format_string_t<Args...> fmt, Args &&...args) {

--- a/include/spdlog/mdc.h
+++ b/include/spdlog/mdc.h
@@ -21,7 +21,7 @@
 // spdlog::info("Hello, {}", "World!");  // => [2024-04-26 02:08:05.040] [info]
 // [mdc_key_1:mdc_value_1] Hello, World!
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class SPDLOG_API mdc {
 public:
     using mdc_map_t = std::map<std::string, std::string>;
@@ -49,4 +49,4 @@ public:
     }
 };
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/namespace.h
+++ b/include/spdlog/namespace.h
@@ -13,8 +13,8 @@
 // declaration, defaulting to "namespace SPDLOG_NAMESPACE { ... }".
 // Override both to use a more complex namespace expression, e.g. to wrap
 // symbols in an inline sub-namespace (keeps "spdlog::" accessible):
-//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog::inline my_copy {
-//   #define SPDLOG_NAMESPACE_END    }
+//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog { inline namespace my_copy {
+//   #define SPDLOG_NAMESPACE_END    } }
 #ifndef SPDLOG_NAMESPACE_BEGIN
     #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NAMESPACE {
 #endif

--- a/include/spdlog/namespace.h
+++ b/include/spdlog/namespace.h
@@ -3,20 +3,20 @@
 
 #pragma once
 
-// SPDLOG_NS__ is the outermost namespace token used to qualify spdlog names
+// SPDLOG_NAMESPACE is the outermost namespace token used to qualify spdlog names
 // in contexts outside a SPDLOG_NAMESPACE_BEGIN block (e.g. logging macros).
 // Override it to rename the outer namespace.
-#ifndef SPDLOG_NS__
-    #define SPDLOG_NS__ spdlog
+#ifndef SPDLOG_NAMESPACE
+    #define SPDLOG_NAMESPACE spdlog
 #endif
 // SPDLOG_NAMESPACE_BEGIN / SPDLOG_NAMESPACE_END delimit every spdlog
-// declaration, defaulting to "namespace SPDLOG_NS__ { ... }".
+// declaration, defaulting to "namespace SPDLOG_NAMESPACE { ... }".
 // Override both to use a more complex namespace expression, e.g. to wrap
 // symbols in an inline sub-namespace (keeps "spdlog::" accessible):
 //   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog::inline my_copy {
 //   #define SPDLOG_NAMESPACE_END    }
 #ifndef SPDLOG_NAMESPACE_BEGIN
-    #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NS__ {
+    #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NAMESPACE {
 #endif
 #ifndef SPDLOG_NAMESPACE_END
     #define SPDLOG_NAMESPACE_END }

--- a/include/spdlog/namespace.h
+++ b/include/spdlog/namespace.h
@@ -12,9 +12,13 @@
 // SPDLOG_NAMESPACE_BEGIN / SPDLOG_NAMESPACE_END delimit every spdlog
 // declaration, defaulting to "namespace SPDLOG_NAMESPACE { ... }".
 // Override both to use a more complex namespace expression, e.g. to wrap
-// symbols in an inline sub-namespace (keeps "spdlog::" accessible):
+// symbols in an inline sub-namespace (keeps "spdlog::" accessible).
+// In C++11/17:
 //   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog { inline namespace my_copy {
 //   #define SPDLOG_NAMESPACE_END    } }
+// In C++20, the nested inline-namespace syntax may be used instead:
+//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog::inline my_copy {
+//   #define SPDLOG_NAMESPACE_END    }
 #ifndef SPDLOG_NAMESPACE_BEGIN
     #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NAMESPACE {
 #endif

--- a/include/spdlog/namespace.h
+++ b/include/spdlog/namespace.h
@@ -1,0 +1,23 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+// SPDLOG_NS__ is the outermost namespace token used to qualify spdlog names
+// in contexts outside a SPDLOG_NAMESPACE_BEGIN block (e.g. logging macros).
+// Override it to rename the outer namespace.
+#ifndef SPDLOG_NS__
+    #define SPDLOG_NS__ spdlog
+#endif
+// SPDLOG_NAMESPACE_BEGIN / SPDLOG_NAMESPACE_END delimit every spdlog
+// declaration, defaulting to "namespace SPDLOG_NS__ { ... }".
+// Override both to use a more complex namespace expression, e.g. to wrap
+// symbols in an inline sub-namespace (keeps "spdlog::" accessible):
+//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog::inline my_copy {
+//   #define SPDLOG_NAMESPACE_END    }
+#ifndef SPDLOG_NAMESPACE_BEGIN
+    #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NS__ {
+#endif
+#ifndef SPDLOG_NAMESPACE_END
+    #define SPDLOG_NAMESPACE_END }
+#endif

--- a/include/spdlog/pattern_formatter-inl.h
+++ b/include/spdlog/pattern_formatter-inl.h
@@ -32,7 +32,7 @@
 #include <utility>
 #include <vector>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 ///////////////////////////////////////////////////////////////////////
@@ -1347,4 +1347,4 @@ SPDLOG_INLINE void pattern_formatter::compile_pattern_(const std::string &patter
         formatters_.push_back(std::move(user_chars));
     }
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -68,12 +68,12 @@ public:
 
     explicit pattern_formatter(std::string pattern,
                                pattern_time_type time_type = pattern_time_type::local,
-                               std::string eol = spdlog::details::os::default_eol,
+                               std::string eol = details::os::default_eol,
                                custom_flags custom_user_flags = custom_flags());
 
     // use default pattern is not given
     explicit pattern_formatter(pattern_time_type time_type = pattern_time_type::local,
-                               std::string eol = spdlog::details::os::default_eol);
+                               std::string eol = details::os::default_eol);
 
     pattern_formatter(const pattern_formatter &other) = delete;
     pattern_formatter &operator=(const pattern_formatter &other) = delete;

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -16,7 +16,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // padding information.
@@ -111,7 +111,7 @@ private:
 
     void compile_pattern_(const std::string &pattern);
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "pattern_formatter-inl.h"

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -22,7 +22,7 @@
 #define SPDLOG_ANDROID_RETRIES 2
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -132,6 +132,6 @@ inline std::shared_ptr<logger> android_logger_st(const std::string &logger_name,
     return Factory::template create<sinks::android_sink_st>(logger_name, tag);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #endif  // __ANDROID__

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -85,7 +85,7 @@ private:
         return __android_log_buf_write(ID, prio, tag, text);
     }
 
-    static android_LogPriority convert_to_android_(spdlog::level::level_enum level) {
+    static android_LogPriority convert_to_android_(level::level_enum level) {
         switch (level) {
             case spdlog::level::trace:
                 return ANDROID_LOG_VERBOSE;
@@ -120,13 +120,13 @@ using android_sink_buf_st = android_sink<details::null_mutex, BufferId>;
 
 // Create and register android syslog logger
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> android_logger_mt(const std::string &logger_name,
                                                  const std::string &tag = "spdlog") {
     return Factory::template create<sinks::android_sink_mt>(logger_name, tag);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> android_logger_st(const std::string &logger_name,
                                                  const std::string &tag = "spdlog") {
     return Factory::template create<sinks::android_sink_st>(logger_name, tag);

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -87,17 +87,17 @@ private:
 
     static android_LogPriority convert_to_android_(level::level_enum level) {
         switch (level) {
-            case spdlog::level::trace:
+            case level::trace:
                 return ANDROID_LOG_VERBOSE;
-            case spdlog::level::debug:
+            case level::debug:
                 return ANDROID_LOG_DEBUG;
-            case spdlog::level::info:
+            case level::info:
                 return ANDROID_LOG_INFO;
-            case spdlog::level::warn:
+            case level::warn:
                 return ANDROID_LOG_WARN;
-            case spdlog::level::err:
+            case level::err:
                 return ANDROID_LOG_ERROR;
-            case spdlog::level::critical:
+            case level::critical:
                 return ANDROID_LOG_FATAL;
             default:
                 return ANDROID_LOG_DEFAULT;

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -17,7 +17,7 @@ template <typename ConsoleMutex>
 SPDLOG_INLINE ansicolor_sink<ConsoleMutex>::ansicolor_sink(FILE *target_file, color_mode mode)
     : target_file_(target_file),
       mutex_(ConsoleMutex::mutex()),
-      formatter_(details::make_unique<spdlog::pattern_formatter>())
+      formatter_(details::make_unique<pattern_formatter>())
 
 {
     set_color_mode_(mode);
@@ -71,12 +71,12 @@ SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::flush() {
 template <typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern) {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<formatter>(new pattern_formatter(pattern));
 }
 
 template <typename ConsoleMutex>
 SPDLOG_INLINE void ansicolor_sink<ConsoleMutex>::set_formatter(
-    std::unique_ptr<spdlog::formatter> sink_formatter) {
+    std::unique_ptr<formatter> sink_formatter) {
     std::lock_guard<mutex_t> lock(mutex_);
     formatter_ = std::move(sink_formatter);
 }

--- a/include/spdlog/sinks/ansicolor_sink-inl.h
+++ b/include/spdlog/sinks/ansicolor_sink-inl.h
@@ -10,7 +10,7 @@
 #include <spdlog/details/os.h>
 #include <spdlog/pattern_formatter.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename ConsoleMutex>
@@ -139,4 +139,4 @@ SPDLOG_INLINE ansicolor_stderr_sink<ConsoleMutex>::ansicolor_stderr_sink(color_m
     : ansicolor_sink<ConsoleMutex>(stderr, mode) {}
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -41,7 +41,7 @@ public:
     void log(const details::log_msg &msg) override;
     void flush() override;
     void set_pattern(const std::string &pattern) override;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
+    void set_formatter(std::unique_ptr<formatter> sink_formatter) override;
 
     // Formatting codes
     const string_view_t reset = "\033[m";
@@ -84,7 +84,7 @@ protected:
 private:
     mutex_t &mutex_;
     bool should_do_colors_;
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<formatter> formatter_;
     std::array<std::string, level::n_levels> colors_;
     void set_color_mode_(color_mode mode);
     void print_ccode_(const string_view_t &color_code) const;

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -11,7 +11,7 @@
 #include <spdlog/sinks/sink.h>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /**
@@ -111,7 +111,7 @@ using ansicolor_stderr_sink_mt = ansicolor_stderr_sink<details::console_mutex>;
 using ansicolor_stderr_sink_st = ansicolor_stderr_sink<details::console_nullmutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "ansicolor_sink-inl.h"

--- a/include/spdlog/sinks/base_sink-inl.h
+++ b/include/spdlog/sinks/base_sink-inl.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <mutex>
 
+SPDLOG_NAMESPACE_BEGIN
+
 template <typename Mutex>
 SPDLOG_INLINE sinks::base_sink<Mutex>::base_sink()
     : formatter_{details::make_unique<pattern_formatter>()} {}
@@ -57,3 +59,5 @@ void SPDLOG_INLINE
 sinks::base_sink<Mutex>::set_formatter_(std::unique_ptr<formatter> sink_formatter) {
     formatter_ = std::move(sink_formatter);
 }
+
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/base_sink-inl.h
+++ b/include/spdlog/sinks/base_sink-inl.h
@@ -14,46 +14,46 @@
 #include <mutex>
 
 template <typename Mutex>
-SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::base_sink()
-    : formatter_{details::make_unique<spdlog::pattern_formatter>()} {}
+SPDLOG_INLINE sinks::base_sink<Mutex>::base_sink()
+    : formatter_{details::make_unique<pattern_formatter>()} {}
 
 template <typename Mutex>
-SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::base_sink(
-    std::unique_ptr<spdlog::formatter> formatter)
+SPDLOG_INLINE sinks::base_sink<Mutex>::base_sink(
+    std::unique_ptr<formatter> formatter)
     : formatter_{std::move(formatter)} {}
 
 template <typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::log(const details::log_msg &msg) {
+void SPDLOG_INLINE sinks::base_sink<Mutex>::log(const details::log_msg &msg) {
     std::lock_guard<Mutex> lock(mutex_);
     sink_it_(msg);
 }
 
 template <typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::flush() {
+void SPDLOG_INLINE sinks::base_sink<Mutex>::flush() {
     std::lock_guard<Mutex> lock(mutex_);
     flush_();
 }
 
 template <typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern(const std::string &pattern) {
+void SPDLOG_INLINE sinks::base_sink<Mutex>::set_pattern(const std::string &pattern) {
     std::lock_guard<Mutex> lock(mutex_);
     set_pattern_(pattern);
 }
 
 template <typename Mutex>
 void SPDLOG_INLINE
-spdlog::sinks::base_sink<Mutex>::set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) {
+sinks::base_sink<Mutex>::set_formatter(std::unique_ptr<formatter> sink_formatter) {
     std::lock_guard<Mutex> lock(mutex_);
     set_formatter_(std::move(sink_formatter));
 }
 
 template <typename Mutex>
-void SPDLOG_INLINE spdlog::sinks::base_sink<Mutex>::set_pattern_(const std::string &pattern) {
-    set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+void SPDLOG_INLINE sinks::base_sink<Mutex>::set_pattern_(const std::string &pattern) {
+    set_formatter_(details::make_unique<pattern_formatter>(pattern));
 }
 
 template <typename Mutex>
 void SPDLOG_INLINE
-spdlog::sinks::base_sink<Mutex>::set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter) {
+sinks::base_sink<Mutex>::set_formatter_(std::unique_ptr<formatter> sink_formatter) {
     formatter_ = std::move(sink_formatter);
 }

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -19,7 +19,7 @@ template <typename Mutex>
 class SPDLOG_API base_sink : public sink {
 public:
     base_sink();
-    explicit base_sink(std::unique_ptr<spdlog::formatter> formatter);
+    explicit base_sink(std::unique_ptr<formatter> formatter);
     ~base_sink() override = default;
 
     base_sink(const base_sink &) = delete;
@@ -31,17 +31,17 @@ public:
     void log(const details::log_msg &msg) final override;
     void flush() final override;
     void set_pattern(const std::string &pattern) final override;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final override;
+    void set_formatter(std::unique_ptr<formatter> sink_formatter) final override;
 
 protected:
     // sink formatter
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<formatter> formatter_;
     Mutex mutex_;
 
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;
     virtual void set_pattern_(const std::string &pattern);
-    virtual void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter);
+    virtual void set_formatter_(std::unique_ptr<formatter> sink_formatter);
 };
 }  // namespace sinks
 }  // namespace spdlog

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -13,7 +13,7 @@
 #include <spdlog/details/log_msg.h>
 #include <spdlog/sinks/sink.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class SPDLOG_API base_sink : public sink {
@@ -44,7 +44,7 @@ protected:
     virtual void set_formatter_(std::unique_ptr<formatter> sink_formatter);
 };
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "base_sink-inl.h"

--- a/include/spdlog/sinks/basic_file_sink-inl.h
+++ b/include/spdlog/sinks/basic_file_sink-inl.h
@@ -10,7 +10,7 @@
 #include <spdlog/common.h>
 #include <spdlog/details/os.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -45,4 +45,4 @@ SPDLOG_INLINE void basic_file_sink<Mutex>::flush_() {
 }
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -41,7 +41,7 @@ using basic_file_sink_st = basic_file_sink<details::null_mutex>;
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> basic_logger_mt(const std::string &logger_name,
                                                const filename_t &filename,
                                                bool truncate = false,
@@ -50,7 +50,7 @@ inline std::shared_ptr<logger> basic_logger_mt(const std::string &logger_name,
                                                                event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> basic_logger_st(const std::string &logger_name,
                                                const filename_t &filename,
                                                bool truncate = false,

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Trivial file sink with single file as target
@@ -59,7 +59,7 @@ inline std::shared_ptr<logger> basic_logger_st(const std::string &logger_name,
                                                                event_handlers);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "basic_file_sink-inl.h"

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // callbacks type
 typedef std::function<void(const details::log_msg &msg)> custom_log_callback;
@@ -53,4 +53,4 @@ inline std::shared_ptr<logger> callback_logger_st(const std::string &logger_name
     return Factory::template create<sinks::callback_sink_st>(logger_name, callback);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -41,13 +41,13 @@ using callback_sink_st = callback_sink<details::null_mutex>;
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> callback_logger_mt(const std::string &logger_name,
                                                   const custom_log_callback &callback) {
     return Factory::template create<sinks::callback_sink_mt>(logger_name, callback);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> callback_logger_st(const std::string &logger_name,
                                                   const custom_log_callback &callback) {
     return Factory::template create<sinks::callback_sink_st>(logger_name, callback);

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -251,4 +251,4 @@ inline std::shared_ptr<logger> daily_logger_format_st(
     return Factory::template create<sinks::daily_file_format_sink_st>(
         logger_name, filename, hour, minute, truncate, max_files, event_handlers);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -145,7 +145,7 @@ private:
 
     tm now_tm(log_clock::time_point tp) {
         time_t tnow = log_clock::to_time_t(tp);
-        return spdlog::details::os::localtime(tnow);
+        return details::os::localtime(tnow);
     }
 
     log_clock::time_point next_rotation_tp_() {
@@ -202,7 +202,7 @@ using daily_file_format_sink_st =
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> daily_logger_mt(const std::string &logger_name,
                                                const filename_t &filename,
                                                int hour = 0,
@@ -214,7 +214,7 @@ inline std::shared_ptr<logger> daily_logger_mt(const std::string &logger_name,
                                                                truncate, max_files, event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> daily_logger_format_mt(
     const std::string &logger_name,
     const filename_t &filename,
@@ -227,7 +227,7 @@ inline std::shared_ptr<logger> daily_logger_format_mt(
         logger_name, filename, hour, minute, truncate, max_files, event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> daily_logger_st(const std::string &logger_name,
                                                const filename_t &filename,
                                                int hour = 0,
@@ -239,7 +239,7 @@ inline std::shared_ptr<logger> daily_logger_st(const std::string &logger_name,
                                                                truncate, max_files, event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> daily_logger_format_st(
     const std::string &logger_name,
     const filename_t &filename,

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -62,10 +62,10 @@ protected:
     }
 
     void set_pattern_(const std::string &pattern) override {
-        set_formatter_(details::make_unique<spdlog::pattern_formatter>(pattern));
+        set_formatter_(details::make_unique<pattern_formatter>(pattern));
     }
 
-    void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter) override {
+    void set_formatter_(std::unique_ptr<formatter> sink_formatter) override {
         base_sink<Mutex>::formatter_ = std::move(sink_formatter);
         for (auto &sub_sink : sinks_) {
             sub_sink->set_formatter(base_sink<Mutex>::formatter_->clone());

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -16,7 +16,7 @@
 // Distribution sink (mux). Stores a vector of sinks which get called when log
 // is called
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -78,4 +78,4 @@ using dist_sink_mt = dist_sink<std::mutex>;
 using dist_sink_st = dist_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -53,7 +53,7 @@ protected:
     log_clock::time_point last_msg_time_;
     std::string last_msg_payload_;
     size_t skip_counter_ = 0;
-    level::level_enum skipped_msg_log_level_ = spdlog::level::level_enum::off;
+    level::level_enum skipped_msg_log_level_ = level::level_enum::off;
 
     void sink_it_(const details::log_msg &msg) override {
         bool filtered = filter_(msg);

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -34,7 +34,7 @@
 //       [2019-06-25 17:50:56.512] [logger] [info] Skipped 3 duplicate messages..
 //       [2019-06-25 17:50:56.512] [logger] [info] Different Hello
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class dup_filter_sink : public dist_sink<Mutex> {
@@ -93,4 +93,4 @@ using dup_filter_sink_mt = dup_filter_sink<std::mutex>;
 using dup_filter_sink_st = dup_filter_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/hourly_file_sink.h
+++ b/include/spdlog/sinks/hourly_file_sink.h
@@ -119,7 +119,7 @@ private:
 
     tm now_tm(log_clock::time_point tp) {
         time_t tnow = log_clock::to_time_t(tp);
-        return spdlog::details::os::localtime(tnow);
+        return details::os::localtime(tnow);
     }
 
     log_clock::time_point next_rotation_tp_() {
@@ -171,7 +171,7 @@ using hourly_file_sink_st = hourly_file_sink<details::null_mutex>;
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> hourly_logger_mt(const std::string &logger_name,
                                                 const filename_t &filename,
                                                 bool truncate = false,
@@ -181,7 +181,7 @@ inline std::shared_ptr<logger> hourly_logger_mt(const std::string &logger_name,
                                                                 max_files, event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> hourly_logger_st(const std::string &logger_name,
                                                 const filename_t &filename,
                                                 bool truncate = false,

--- a/include/spdlog/sinks/hourly_file_sink.h
+++ b/include/spdlog/sinks/hourly_file_sink.h
@@ -18,7 +18,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -190,4 +190,4 @@ inline std::shared_ptr<logger> hourly_logger_st(const std::string &logger_name,
     return Factory::template create<sinks::hourly_file_sink_st>(logger_name, filename, truncate,
                                                                 max_files, event_handlers);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/kafka_sink.h
+++ b/include/spdlog/sinks/kafka_sink.h
@@ -21,7 +21,7 @@
 // kafka header
 #include <librdkafka/rdkafkacpp.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct kafka_sink_config {
@@ -116,4 +116,4 @@ inline std::shared_ptr<logger> kafka_logger_async_st(
     return Factory::template create<sinks::kafka_sink_st>(logger_name, config);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/kafka_sink.h
+++ b/include/spdlog/sinks/kafka_sink.h
@@ -88,31 +88,31 @@ private:
 };
 
 using kafka_sink_mt = kafka_sink<std::mutex>;
-using kafka_sink_st = kafka_sink<spdlog::details::null_mutex>;
+using kafka_sink_st = kafka_sink<details::null_mutex>;
 
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> kafka_logger_mt(const std::string &logger_name,
-                                               spdlog::sinks::kafka_sink_config config) {
+                                               sinks::kafka_sink_config config) {
     return Factory::template create<sinks::kafka_sink_mt>(logger_name, config);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> kafka_logger_st(const std::string &logger_name,
-                                               spdlog::sinks::kafka_sink_config config) {
+                                               sinks::kafka_sink_config config) {
     return Factory::template create<sinks::kafka_sink_st>(logger_name, config);
 }
 
-template <typename Factory = spdlog::async_factory>
-inline std::shared_ptr<spdlog::logger> kafka_logger_async_mt(
-    std::string logger_name, spdlog::sinks::kafka_sink_config config) {
+template <typename Factory = async_factory>
+inline std::shared_ptr<logger> kafka_logger_async_mt(
+    std::string logger_name, sinks::kafka_sink_config config) {
     return Factory::template create<sinks::kafka_sink_mt>(logger_name, config);
 }
 
-template <typename Factory = spdlog::async_factory>
-inline std::shared_ptr<spdlog::logger> kafka_logger_async_st(
-    std::string logger_name, spdlog::sinks::kafka_sink_config config) {
+template <typename Factory = async_factory>
+inline std::shared_ptr<logger> kafka_logger_async_st(
+    std::string logger_name, sinks::kafka_sink_config config) {
     return Factory::template create<sinks::kafka_sink_st>(logger_name, config);
 }
 

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -44,7 +44,7 @@ public:
           db_name_(db_name),
           coll_name_(collection_name) {
         try {
-            client_ = spdlog::details::make_unique<mongocxx::client>(mongocxx::uri{uri});
+            client_ = details::make_unique<mongocxx::client>(mongocxx::uri{uri});
         } catch (const std::exception &e) {
             throw_spdlog_ex(fmt_lib::format("Error opening database: {}", e.what()));
         }
@@ -81,11 +81,11 @@ private:
 #include "spdlog/details/null_mutex.h"
 #include <mutex>
 using mongo_sink_mt = mongo_sink<std::mutex>;
-using mongo_sink_st = mongo_sink<spdlog::details::null_mutex>;
+using mongo_sink_st = mongo_sink<details::null_mutex>;
 
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> mongo_logger_mt(
     const std::string &logger_name,
     const std::string &db_name,
@@ -95,7 +95,7 @@ inline std::shared_ptr<logger> mongo_logger_mt(
                                                           uri);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> mongo_logger_st(
     const std::string &logger_name,
     const std::string &db_name,

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -23,7 +23,7 @@
 #include <mongocxx/instance.hpp>
 #include <mongocxx/uri.hpp>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class mongo_sink : public base_sink<Mutex> {
@@ -105,4 +105,4 @@ inline std::shared_ptr<logger> mongo_logger_st(
                                                           uri);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -22,7 +22,7 @@ extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char *l
 #endif
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * MSVC sink (logging using OutputDebugStringA)
@@ -63,6 +63,6 @@ using windebug_sink_mt = msvc_sink_mt;
 using windebug_sink_st = msvc_sink_st;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #endif

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -9,7 +9,7 @@
 
 #include <mutex>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -38,4 +38,4 @@ inline std::shared_ptr<logger> null_logger_st(const std::string &logger_name) {
     return null_logger;
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -24,14 +24,14 @@ using null_sink_st = null_sink<details::null_mutex>;
 
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> null_logger_mt(const std::string &logger_name) {
     auto null_logger = Factory::template create<sinks::null_sink_mt>(logger_name);
     null_logger->set_level(level::off);
     return null_logger;
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> null_logger_st(const std::string &logger_name) {
     auto null_logger = Factory::template create<sinks::null_sink_st>(logger_name);
     null_logger->set_level(level::off);

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -9,7 +9,7 @@
 #include <mutex>
 #include <ostream>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class ostream_sink final : public base_sink<Mutex> {
@@ -40,4 +40,4 @@ using ostream_sink_mt = ostream_sink<std::mutex>;
 using ostream_sink_st = ostream_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -24,7 +24,7 @@
 //
 // qt_sink class
 //
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class qt_sink : public base_sink<Mutex> {
@@ -305,4 +305,4 @@ inline std::shared_ptr<logger> qt_color_logger_st(const std::string &logger_name
                                                              false, is_utf8);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -243,14 +243,14 @@ using qt_color_sink_st = qt_color_sink<details::null_mutex>;
 //
 
 // log to QTextEdit
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_mt(const std::string &logger_name,
                                             QTextEdit *qt_object,
                                             const std::string &meta_method = "append") {
     return Factory::template create<sinks::qt_sink_mt>(logger_name, qt_object, meta_method);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name,
                                             QTextEdit *qt_object,
                                             const std::string &meta_method = "append") {
@@ -258,28 +258,28 @@ inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name,
 }
 
 // log to QPlainTextEdit
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_mt(const std::string &logger_name,
                                             QPlainTextEdit *qt_object,
                                             const std::string &meta_method = "appendPlainText") {
     return Factory::template create<sinks::qt_sink_mt>(logger_name, qt_object, meta_method);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name,
                                             QPlainTextEdit *qt_object,
                                             const std::string &meta_method = "appendPlainText") {
     return Factory::template create<sinks::qt_sink_st>(logger_name, qt_object, meta_method);
 }
 // log to QObject
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_mt(const std::string &logger_name,
                                             QObject *qt_object,
                                             const std::string &meta_method) {
     return Factory::template create<sinks::qt_sink_mt>(logger_name, qt_object, meta_method);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name,
                                             QObject *qt_object,
                                             const std::string &meta_method) {
@@ -287,7 +287,7 @@ inline std::shared_ptr<logger> qt_logger_st(const std::string &logger_name,
 }
 
 // log to QTextEdit with colorized output
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_color_logger_mt(const std::string &logger_name,
                                                   QTextEdit *qt_text_edit,
                                                   int max_lines,
@@ -296,7 +296,7 @@ inline std::shared_ptr<logger> qt_color_logger_mt(const std::string &logger_name
                                                              false, is_utf8);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> qt_color_logger_st(const std::string &logger_name,
                                                   QTextEdit *qt_text_edit,
                                                   int max_lines,

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -12,7 +12,7 @@
 #include <string>
 #include <vector>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Ring buffer sink
@@ -68,4 +68,4 @@ using ringbuffer_sink_st = ringbuffer_sink<details::null_mutex>;
 
 }  // namespace sinks
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <tuple>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -176,4 +176,4 @@ SPDLOG_INLINE bool rotating_file_sink<Mutex>::rename_file_(const filename_t &src
 }
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 //
@@ -86,7 +86,7 @@ std::shared_ptr<logger> rotating_logger_st(const std::string &logger_name,
     return Factory::template create<sinks::rotating_file_sink_st>(
         logger_name, filename, max_file_size, max_files, rotate_on_open, event_handlers);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "rotating_file_sink-inl.h"

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -65,7 +65,7 @@ using rotating_file_sink_st = rotating_file_sink<details::null_mutex>;
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> rotating_logger_mt(const std::string &logger_name,
                                            const filename_t &filename,
                                            size_t max_file_size,
@@ -76,7 +76,7 @@ std::shared_ptr<logger> rotating_logger_mt(const std::string &logger_name,
         logger_name, filename, max_file_size, max_files, rotate_on_open, event_handlers);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> rotating_logger_st(const std::string &logger_name,
                                            const filename_t &filename,
                                            size_t max_file_size,

--- a/include/spdlog/sinks/sink-inl.h
+++ b/include/spdlog/sinks/sink-inl.h
@@ -9,6 +9,8 @@
 
 #include <spdlog/common.h>
 
+SPDLOG_NAMESPACE_BEGIN
+
 SPDLOG_INLINE bool sinks::sink::should_log(level::level_enum msg_level) const {
     return msg_level >= level_.load(std::memory_order_relaxed);
 }
@@ -20,3 +22,5 @@ SPDLOG_INLINE void sinks::sink::set_level(level::level_enum log_level) {
 SPDLOG_INLINE level::level_enum sinks::sink::level() const {
     return static_cast<level::level_enum>(level_.load(std::memory_order_relaxed));
 }
+
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/sink-inl.h
+++ b/include/spdlog/sinks/sink-inl.h
@@ -9,14 +9,14 @@
 
 #include <spdlog/common.h>
 
-SPDLOG_INLINE bool spdlog::sinks::sink::should_log(spdlog::level::level_enum msg_level) const {
+SPDLOG_INLINE bool sinks::sink::should_log(level::level_enum msg_level) const {
     return msg_level >= level_.load(std::memory_order_relaxed);
 }
 
-SPDLOG_INLINE void spdlog::sinks::sink::set_level(level::level_enum log_level) {
+SPDLOG_INLINE void sinks::sink::set_level(level::level_enum log_level) {
     level_.store(log_level, std::memory_order_relaxed);
 }
 
-SPDLOG_INLINE spdlog::level::level_enum spdlog::sinks::sink::level() const {
-    return static_cast<spdlog::level::level_enum>(level_.load(std::memory_order_relaxed));
+SPDLOG_INLINE level::level_enum sinks::sink::level() const {
+    return static_cast<level::level_enum>(level_.load(std::memory_order_relaxed));
 }

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -15,7 +15,7 @@ public:
     virtual void log(const details::log_msg &msg) = 0;
     virtual void flush() = 0;
     virtual void set_pattern(const std::string &pattern) = 0;
-    virtual void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) = 0;
+    virtual void set_formatter(std::unique_ptr<formatter> sink_formatter) = 0;
 
     void set_level(level::level_enum log_level);
     level::level_enum level() const;

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -6,7 +6,7 @@
 #include <spdlog/details/log_msg.h>
 #include <spdlog/formatter.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace sinks {
 class SPDLOG_API sink {
@@ -27,7 +27,7 @@ protected:
 };
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "sink-inl.h"

--- a/include/spdlog/sinks/stdout_color_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_color_sinks-inl.h
@@ -10,7 +10,7 @@
 #include <spdlog/common.h>
 #include <spdlog/logger.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 template <typename Factory>
 SPDLOG_INLINE std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name,
@@ -35,4 +35,4 @@ SPDLOG_INLINE std::shared_ptr<logger> stderr_color_st(const std::string &logger_
                                                       color_mode mode) {
     return Factory::template create<sinks::stderr_color_sink_st>(logger_name, mode);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -11,7 +11,7 @@
 
 #include <spdlog/details/synchronous_factory.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 #ifdef _WIN32
 using stdout_color_sink_mt = wincolor_stdout_sink_mt;
@@ -42,7 +42,7 @@ template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_color_st(const std::string &logger_name,
                                         color_mode mode = color_mode::automatic);
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "stdout_color_sinks-inl.h"

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -26,19 +26,19 @@ using stderr_color_sink_st = ansicolor_stderr_sink_st;
 #endif
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stdout_color_mt(const std::string &logger_name,
                                         color_mode mode = color_mode::automatic);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stdout_color_st(const std::string &logger_name,
                                         color_mode mode = color_mode::automatic);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_color_mt(const std::string &logger_name,
                                         color_mode mode = color_mode::automatic);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_color_st(const std::string &logger_name,
                                         color_mode mode = color_mode::automatic);
 

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -33,7 +33,7 @@ template <typename ConsoleMutex>
 SPDLOG_INLINE stdout_sink_base<ConsoleMutex>::stdout_sink_base(FILE *file)
     : mutex_(ConsoleMutex::mutex()),
       file_(file),
-      formatter_(details::make_unique<spdlog::pattern_formatter>()) {
+      formatter_(details::make_unique<pattern_formatter>()) {
 #ifdef _WIN32
     // get windows handle from the FILE* object
 
@@ -82,12 +82,12 @@ SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::flush() {
 template <typename ConsoleMutex>
 SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::set_pattern(const std::string &pattern) {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<formatter>(new pattern_formatter(pattern));
 }
 
 template <typename ConsoleMutex>
 SPDLOG_INLINE void stdout_sink_base<ConsoleMutex>::set_formatter(
-    std::unique_ptr<spdlog::formatter> sink_formatter) {
+    std::unique_ptr<formatter> sink_formatter) {
     std::lock_guard<mutex_t> lock(mutex_);
     formatter_ = std::move(sink_formatter);
 }

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -43,7 +43,7 @@ SPDLOG_INLINE stdout_sink_base<ConsoleMutex>::stdout_sink_base(FILE *file)
     // and let the log method to do nothing if (handle_ == INVALID_HANDLE_VALUE).
     // throw only if non stdout/stderr target is requested (probably regular file and not console).
     if (handle_ == INVALID_HANDLE_VALUE && file != stdout && file != stderr) {
-        throw_spdlog_ex("spdlog::stdout_sink_base: _get_osfhandle() failed", errno);
+        throw_spdlog_ex("stdout_sink_base: _get_osfhandle() failed", errno);
     }
 #endif  // _WIN32
 }

--- a/include/spdlog/sinks/stdout_sinks-inl.h
+++ b/include/spdlog/sinks/stdout_sinks-inl.h
@@ -25,7 +25,7 @@
 #include <stdio.h>  // _fileno(..)
 #endif              // _WIN32
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace sinks {
 
@@ -124,4 +124,4 @@ template <typename Factory>
 SPDLOG_INLINE std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name) {
     return Factory::template create<sinks::stderr_sink_st>(logger_name);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -12,7 +12,7 @@
 #include <spdlog/details/windows_include.h>
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace sinks {
 
@@ -77,7 +77,7 @@ std::shared_ptr<logger> stderr_logger_mt(const std::string &logger_name);
 template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name);
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "stdout_sinks-inl.h"

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -33,12 +33,12 @@ public:
     void flush() override;
     void set_pattern(const std::string &pattern) override;
 
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
+    void set_formatter(std::unique_ptr<formatter> sink_formatter) override;
 
 protected:
     mutex_t &mutex_;
     FILE *file_;
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<formatter> formatter_;
 #ifdef _WIN32
     HANDLE handle_;
 #endif  // WIN32
@@ -65,16 +65,16 @@ using stderr_sink_st = stderr_sink<details::console_nullmutex>;
 }  // namespace sinks
 
 // factory methods
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stdout_logger_mt(const std::string &logger_name);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stdout_logger_st(const std::string &logger_name);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_logger_mt(const std::string &logger_name);
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 std::shared_ptr<logger> stderr_logger_st(const std::string &logger_name);
 
 }  // namespace spdlog

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <syslog.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /**
  * Sink that write to syslog using the `syscall()` library call.
@@ -101,4 +101,4 @@ inline std::shared_ptr<logger> syslog_logger_st(const std::string &logger_name,
     return Factory::template create<sinks::syslog_sink_st>(logger_name, syslog_ident, syslog_option,
                                                            syslog_facility, enable_formatting);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -82,7 +82,7 @@ using syslog_sink_st = syslog_sink<details::null_mutex>;
 }  // namespace sinks
 
 // Create and register a syslog logger
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> syslog_logger_mt(const std::string &logger_name,
                                                 const std::string &syslog_ident = "",
                                                 int syslog_option = 0,
@@ -92,7 +92,7 @@ inline std::shared_ptr<logger> syslog_logger_mt(const std::string &logger_name,
                                                            syslog_facility, enable_formatting);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> syslog_logger_st(const std::string &logger_name,
                                                 const std::string &syslog_ident = "",
                                                 int syslog_option = 0,

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -138,7 +138,7 @@ using systemd_namespace_sink_mt = systemd_namespace_sink<std::mutex>;
 using systemd_namespace_sink_st = systemd_namespace_sink<details::null_mutex>;
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> systemd_namespace_logger_mt(const std::string &logger_name,
                                                            const std::string &ident,
                                                            const std::string &name_space,
@@ -147,7 +147,7 @@ inline std::shared_ptr<logger> systemd_namespace_logger_mt(const std::string &lo
         logger_name, ident, name_space, enable_formatting);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> systemd_namespace_logger_st(const std::string &logger_name,
                                                            const std::string &ident,
                                                            const std::string &name_space,

--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -11,7 +11,7 @@
 #include <systemd/sd-journal.h>
 #include <systemd/sd-daemon.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /**
@@ -155,4 +155,4 @@ inline std::shared_ptr<logger> systemd_namespace_logger_st(const std::string &lo
     return Factory::template create<sinks::systemd_namespace_sink_st>(
         logger_name, ident, name_space, enable_formatting);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -105,14 +105,14 @@ using systemd_sink_st = systemd_sink<details::null_mutex>;
 }  // namespace sinks
 
 // Create and register a syslog logger
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> systemd_logger_mt(const std::string &logger_name,
                                                  const std::string &ident = "",
                                                  bool enable_formatting = false) {
     return Factory::template create<sinks::systemd_sink_mt>(logger_name, ident, enable_formatting);
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> systemd_logger_st(const std::string &logger_name,
                                                  const std::string &ident = "",
                                                  bool enable_formatting = false) {

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -14,7 +14,7 @@
 #endif
 #include <systemd/sd-journal.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /**
@@ -118,4 +118,4 @@ inline std::shared_ptr<logger> systemd_logger_st(const std::string &logger_name,
                                                  bool enable_formatting = false) {
     return Factory::template create<sinks::systemd_sink_st>(logger_name, ident, enable_formatting);
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -25,7 +25,7 @@
 // If more complicated behaviour is needed (i.e get responses), you can inherit it and override the
 // sink_it_ method.
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct tcp_sink_config {
@@ -86,4 +86,4 @@ using tcp_sink_mt = tcp_sink<std::mutex>;
 using tcp_sink_st = tcp_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -41,7 +41,7 @@ struct tcp_sink_config {
 };
 
 template <typename Mutex>
-class tcp_sink : public spdlog::sinks::base_sink<Mutex> {
+class tcp_sink : public sinks::base_sink<Mutex> {
 public:
     // connect to tcp host/port or throw if failed
     // host can be hostname or ip address
@@ -68,9 +68,9 @@ public:
     ~tcp_sink() override = default;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override {
-        spdlog::memory_buf_t formatted;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+    void sink_it_(const details::log_msg &msg) override {
+        memory_buf_t formatted;
+        sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
         if (!client_.is_connected()) {
             client_.connect(config_.server_host, config_.server_port, config_.timeout_ms);
         }
@@ -83,7 +83,7 @@ protected:
 };
 
 using tcp_sink_mt = tcp_sink<std::mutex>;
-using tcp_sink_st = tcp_sink<spdlog::details::null_mutex>;
+using tcp_sink_st = tcp_sink<details::null_mutex>;
 
 }  // namespace sinks
 }  // namespace spdlog

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -33,7 +33,7 @@ struct udp_sink_config {
 };
 
 template <typename Mutex>
-class udp_sink : public spdlog::sinks::base_sink<Mutex> {
+class udp_sink : public sinks::base_sink<Mutex> {
 public:
     // host can be hostname or ip address
     explicit udp_sink(const udp_sink_config& sink_config)
@@ -42,9 +42,9 @@ public:
     ~udp_sink() override = default;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override {
-        spdlog::memory_buf_t formatted;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+    void sink_it_(const details::log_msg &msg) override {
+        memory_buf_t formatted;
+        sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
         client_.send(formatted.data(), formatted.size());
     }
 
@@ -53,14 +53,14 @@ protected:
 };
 
 using udp_sink_mt = udp_sink<std::mutex>;
-using udp_sink_st = udp_sink<spdlog::details::null_mutex>;
+using udp_sink_st = udp_sink<details::null_mutex>;
 
 }  // namespace sinks
 
 //
 // factory functions
 //
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> udp_logger_mt(const std::string &logger_name,
                                              sinks::udp_sink_config skin_config) {
     return Factory::template create<sinks::udp_sink_mt>(logger_name, skin_config);

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -62,8 +62,8 @@ using udp_sink_st = udp_sink<details::null_mutex>;
 //
 template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> udp_logger_mt(const std::string &logger_name,
-                                             sinks::udp_sink_config skin_config) {
-    return Factory::template create<sinks::udp_sink_mt>(logger_name, skin_config);
+                                             sinks::udp_sink_config sink_config) {
+    return Factory::template create<sinks::udp_sink_mt>(logger_name, sink_config);
 }
 
 SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -20,7 +20,7 @@
 // Simple udp client sink
 // Sends formatted log via udp
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct udp_sink_config {
@@ -66,4 +66,4 @@ inline std::shared_ptr<logger> udp_logger_mt(const std::string &logger_name,
     return Factory::template create<sinks::udp_sink_mt>(logger_name, skin_config);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/win_eventlog_sink.h
+++ b/include/spdlog/sinks/win_eventlog_sink.h
@@ -43,7 +43,7 @@ Windows Registry Editor Version 5.00
 #include <string>
 #include <vector>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 namespace win_eventlog {
@@ -257,4 +257,4 @@ using win_eventlog_sink_mt = win_eventlog::win_eventlog_sink<std::mutex>;
 using win_eventlog_sink_st = win_eventlog::win_eventlog_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -19,7 +19,7 @@ template <typename ConsoleMutex>
 SPDLOG_INLINE wincolor_sink<ConsoleMutex>::wincolor_sink(void *out_handle, color_mode mode)
     : out_handle_(out_handle),
       mutex_(ConsoleMutex::mutex()),
-      formatter_(details::make_unique<spdlog::pattern_formatter>()) {
+      formatter_(details::make_unique<pattern_formatter>()) {
     set_color_mode_impl(mode);
     // set level colors
     colors_[level::trace] = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE;  // white
@@ -82,12 +82,12 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::flush() {
 template <typename ConsoleMutex>
 void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_pattern(const std::string &pattern) {
     std::lock_guard<mutex_t> lock(mutex_);
-    formatter_ = std::unique_ptr<spdlog::formatter>(new pattern_formatter(pattern));
+    formatter_ = std::unique_ptr<formatter>(new pattern_formatter(pattern));
 }
 
 template <typename ConsoleMutex>
 void SPDLOG_INLINE
-wincolor_sink<ConsoleMutex>::set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) {
+wincolor_sink<ConsoleMutex>::set_formatter(std::unique_ptr<formatter> sink_formatter) {
     std::lock_guard<mutex_t> lock(mutex_);
     formatter_ = std::move(sink_formatter);
 }

--- a/include/spdlog/sinks/wincolor_sink-inl.h
+++ b/include/spdlog/sinks/wincolor_sink-inl.h
@@ -13,7 +13,7 @@
 #include <spdlog/common.h>
 #include <spdlog/pattern_formatter.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename ConsoleMutex>
 SPDLOG_INLINE wincolor_sink<ConsoleMutex>::wincolor_sink(void *out_handle, color_mode mode)
@@ -169,4 +169,4 @@ template <typename ConsoleMutex>
 SPDLOG_INLINE wincolor_stderr_sink<ConsoleMutex>::wincolor_stderr_sink(color_mode mode)
     : wincolor_sink<ConsoleMutex>(::GetStdHandle(STD_ERROR_HANDLE), mode) {}
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -14,7 +14,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Windows color console sink. Uses WriteConsoleA to write to the console with
@@ -75,7 +75,7 @@ using wincolor_stdout_sink_st = wincolor_stdout_sink<details::console_nullmutex>
 using wincolor_stderr_sink_mt = wincolor_stderr_sink<details::console_mutex>;
 using wincolor_stderr_sink_st = wincolor_stderr_sink<details::console_nullmutex>;
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #ifdef SPDLOG_HEADER_ONLY
 #include "wincolor_sink-inl.h"

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -34,7 +34,7 @@ public:
     void log(const details::log_msg &msg) override;
     void flush() override;
     void set_pattern(const std::string &pattern) override;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) override;
+    void set_formatter(std::unique_ptr<formatter> sink_formatter) override;
     void set_color_mode(color_mode mode);
 
 protected:
@@ -42,7 +42,7 @@ protected:
     void *out_handle_;
     mutex_t &mutex_;
     bool should_do_colors_;
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<formatter> formatter_;
     std::array<std::uint16_t, level::n_levels> colors_;
 
     // set foreground color and return the orig console attributes (for resetting later)

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -20,13 +20,13 @@ SPDLOG_INLINE std::shared_ptr<logger> get(const std::string &name) {
     return details::registry::instance().get(name);
 }
 
-SPDLOG_INLINE void set_formatter(std::unique_ptr<spdlog::formatter> formatter) {
+SPDLOG_INLINE void set_formatter(std::unique_ptr<formatter> formatter) {
     details::registry::instance().set_formatter(std::move(formatter));
 }
 
 SPDLOG_INLINE void set_pattern(std::string pattern, pattern_time_type time_type) {
     set_formatter(
-        std::unique_ptr<spdlog::formatter>(new pattern_formatter(std::move(pattern), time_type)));
+        std::unique_ptr<formatter>(new pattern_formatter(std::move(pattern), time_type)));
 }
 
 SPDLOG_INLINE void enable_backtrace(size_t n_messages) {
@@ -77,15 +77,15 @@ SPDLOG_INLINE void set_automatic_registration(bool automatic_registration) {
     details::registry::instance().set_automatic_registration(automatic_registration);
 }
 
-SPDLOG_INLINE std::shared_ptr<spdlog::logger> default_logger() {
+SPDLOG_INLINE std::shared_ptr<logger> default_logger() {
     return details::registry::instance().default_logger();
 }
 
-SPDLOG_INLINE spdlog::logger *default_logger_raw() {
+SPDLOG_INLINE logger *default_logger_raw() {
     return details::registry::instance().get_default_raw();
 }
 
-SPDLOG_INLINE void set_default_logger(std::shared_ptr<spdlog::logger> default_logger) {
+SPDLOG_INLINE void set_default_logger(std::shared_ptr<logger> default_logger) {
     details::registry::instance().set_default_logger(std::move(default_logger));
 }
 

--- a/include/spdlog/spdlog-inl.h
+++ b/include/spdlog/spdlog-inl.h
@@ -10,7 +10,7 @@
 #include <spdlog/common.h>
 #include <spdlog/pattern_formatter.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 SPDLOG_INLINE void initialize_logger(std::shared_ptr<logger> logger) {
     details::registry::instance().initialize_logger(std::move(logger));
@@ -93,4 +93,4 @@ SPDLOG_INLINE void apply_logger_env_levels(std::shared_ptr<logger> logger) {
     details::registry::instance().apply_logger_env_levels(std::move(logger));
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -31,7 +31,7 @@ using default_factory = synchronous_factory;
 // Example:
 //   spdlog::create<daily_file_sink_st>("logger_name", "dailylog_filename", 11, 59);
 template <typename Sink, typename... SinkArgs>
-inline std::shared_ptr<spdlog::logger> create(std::string logger_name, SinkArgs &&...sink_args) {
+inline std::shared_ptr<logger> create(std::string logger_name, SinkArgs &&...sink_args) {
     return default_factory::create<Sink>(std::move(logger_name),
                                          std::forward<SinkArgs>(sink_args)...);
 }
@@ -52,7 +52,7 @@ SPDLOG_API void initialize_logger(std::shared_ptr<logger> logger);
 SPDLOG_API std::shared_ptr<logger> get(const std::string &name);
 
 // Set global formatter. Each sink in each logger will get a clone of this object
-SPDLOG_API void set_formatter(std::unique_ptr<spdlog::formatter> formatter);
+SPDLOG_API void set_formatter(std::unique_ptr<formatter> formatter);
 
 // Set global format string.
 // example: spdlog::set_pattern("%Y-%m-%d %H:%M:%S.%e %l : %v");
@@ -130,11 +130,11 @@ SPDLOG_API void set_automatic_registration(bool automatic_registration);
 // set_default_logger() *should not* be used concurrently with the default API.
 // e.g., do not call set_default_logger() from one thread while calling spdlog::info() from another.
 
-SPDLOG_API std::shared_ptr<spdlog::logger> default_logger();
+SPDLOG_API std::shared_ptr<logger> default_logger();
 
-SPDLOG_API spdlog::logger *default_logger_raw();
+SPDLOG_API logger *default_logger_raw();
 
-SPDLOG_API void set_default_logger(std::shared_ptr<spdlog::logger> default_logger);
+SPDLOG_API void set_default_logger(std::shared_ptr<logger> default_logger);
 
 // Initialize logger level based on environment configs.
 //

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -290,16 +290,16 @@ SPDLOG_NAMESPACE_END
 
 #ifndef SPDLOG_NO_SOURCE_LOC
 #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-    (logger)->log(SPDLOG_NS__::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+    (logger)->log(SPDLOG_NAMESPACE::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-    (logger)->log(SPDLOG_NS__::source_loc{}, level, __VA_ARGS__)
+    (logger)->log(SPDLOG_NAMESPACE::source_loc{}, level, __VA_ARGS__)
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define SPDLOG_LOGGER_TRACE(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::trace, __VA_ARGS__)
-#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::trace, __VA_ARGS__)
+#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
 #define SPDLOG_TRACE(...) (void)0
@@ -307,32 +307,32 @@ SPDLOG_NAMESPACE_END
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
 #define SPDLOG_LOGGER_DEBUG(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::debug, __VA_ARGS__)
-#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::debug, __VA_ARGS__)
+#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
 #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::info, __VA_ARGS__)
-#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::info, __VA_ARGS__)
+#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
 #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::warn, __VA_ARGS__)
-#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::warn, __VA_ARGS__)
+#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
 #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::err, __VA_ARGS__)
-#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::err, __VA_ARGS__)
+#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
 #define SPDLOG_ERROR(...) (void)0
@@ -340,8 +340,8 @@ SPDLOG_NAMESPACE_END
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::critical, __VA_ARGS__)
-#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::critical, __VA_ARGS__)
+#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(SPDLOG_NAMESPACE::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 using default_factory = synchronous_factory;
 
@@ -273,7 +273,7 @@ inline void critical(const T &msg) {
     default_logger_raw()->critical(msg);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 //
 // enable/disable log calls at compile time according to global level.
@@ -290,16 +290,16 @@ inline void critical(const T &msg) {
 
 #ifndef SPDLOG_NO_SOURCE_LOC
 #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-    (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+    (logger)->log(SPDLOG_NS__::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-    (logger)->log(spdlog::source_loc{}, level, __VA_ARGS__)
+    (logger)->log(SPDLOG_NS__::source_loc{}, level, __VA_ARGS__)
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
 #define SPDLOG_LOGGER_TRACE(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__)
-#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::trace, __VA_ARGS__)
+#define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
 #define SPDLOG_TRACE(...) (void)0
@@ -307,32 +307,32 @@ inline void critical(const T &msg) {
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
 #define SPDLOG_LOGGER_DEBUG(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, spdlog::level::debug, __VA_ARGS__)
-#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::debug, __VA_ARGS__)
+#define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
 #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::info, __VA_ARGS__)
-#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::info, __VA_ARGS__)
+#define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
 #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::warn, __VA_ARGS__)
-#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::warn, __VA_ARGS__)
+#define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
 #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::err, __VA_ARGS__)
-#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::default_logger_raw(), __VA_ARGS__)
+#define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::err, __VA_ARGS__)
+#define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
 #define SPDLOG_ERROR(...) (void)0
@@ -340,8 +340,8 @@ inline void critical(const T &msg) {
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) \
-    SPDLOG_LOGGER_CALL(logger, spdlog::level::critical, __VA_ARGS__)
-#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::default_logger_raw(), __VA_ARGS__)
+    SPDLOG_LOGGER_CALL(logger, SPDLOG_NS__::level::critical, __VA_ARGS__)
+#define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(SPDLOG_NS__::default_logger_raw(), __VA_ARGS__)
 #else
 #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
 #define SPDLOG_CRITICAL(...) (void)0

--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -58,9 +58,9 @@ namespace
 {
 
 template <>
-struct formatter<SPDLOG_NS__::stopwatch> : formatter<double> {
+struct formatter<SPDLOG_NAMESPACE::stopwatch> : formatter<double> {
     template <typename FormatContext>
-    auto format(const SPDLOG_NS__::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
+    auto format(const SPDLOG_NAMESPACE::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
         return formatter<double>::format(sw.elapsed().count(), ctx);
     }
 };

--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/namespace.h>
 
 // Stopwatch support for spdlog  (using std::chrono::steady_clock).
 // Displays elapsed seconds since construction as double.
@@ -57,9 +58,9 @@ namespace
 {
 
 template <>
-struct formatter<spdlog::stopwatch> : formatter<double> {
+struct formatter<SPDLOG_NS__::stopwatch> : formatter<double> {
     template <typename FormatContext>
-    auto format(const spdlog::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
+    auto format(const SPDLOG_NS__::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
         return formatter<double>::format(sw.elapsed().count(), ctx);
     }
 };

--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -26,7 +26,7 @@
 // using std::chrono::milliseconds;
 // spdlog::info("Elapsed {}", duration_cast<milliseconds>(sw.elapsed())); => "Elapsed 5ms"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class stopwatch {
     using clock = std::chrono::steady_clock;
     std::chrono::time_point<clock> start_tp_;
@@ -45,7 +45,7 @@ public:
 
     void reset() { start_tp_ = clock::now(); }
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // Support for fmt formatting  (e.g. "{:012.9}" or just "{}")
 namespace

--- a/src/color_sinks.cpp
+++ b/src/color_sinks.cpp
@@ -14,42 +14,42 @@
 //
 #ifdef _WIN32
 #include <spdlog/sinks/wincolor_sink-inl.h>
-template class SPDLOG_API spdlog::sinks::wincolor_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_sink<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stdout_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stdout_sink<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stderr_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stderr_sink<spdlog::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stdout_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stdout_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stderr_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stderr_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
 #else
 #include "spdlog/sinks/ansicolor_sink-inl.h"
-template class SPDLOG_API spdlog::sinks::ansicolor_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_sink<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stdout_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stdout_sink<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stderr_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stderr_sink<spdlog::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stdout_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stdout_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stderr_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stderr_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
 #endif
 
 // factory methods for color loggers
 #include "spdlog/sinks/stdout_color_sinks-inl.h"
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stdout_color_mt<spdlog::synchronous_factory>(const std::string &logger_name,
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stdout_color_mt<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name,
                                                      color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stdout_color_st<spdlog::synchronous_factory>(const std::string &logger_name,
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stdout_color_st<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name,
                                                      color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stderr_color_mt<spdlog::synchronous_factory>(const std::string &logger_name,
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stderr_color_mt<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name,
                                                      color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stderr_color_st<spdlog::synchronous_factory>(const std::string &logger_name,
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stderr_color_st<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name,
                                                      color_mode mode);
 
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_color_mt<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stdout_color_mt<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name, color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_color_st<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stdout_color_st<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name, color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_color_mt<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stderr_color_mt<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name, color_mode mode);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_color_st<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stderr_color_st<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name, color_mode mode);

--- a/src/file_sinks.cpp
+++ b/src/file_sinks.cpp
@@ -12,9 +12,9 @@
 
 #include <mutex>
 
-template class SPDLOG_API spdlog::sinks::basic_file_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::basic_file_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::basic_file_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::basic_file_sink<SPDLOG_NAMESPACE::details::null_mutex>;
 
 #include <spdlog/sinks/rotating_file_sink-inl.h>
-template class SPDLOG_API spdlog::sinks::rotating_file_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::rotating_file_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::rotating_file_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -21,8 +21,8 @@
 #include <mutex>
 
 // template instantiate logger constructor with sinks init list
-template SPDLOG_API spdlog::logger::logger(std::string name,
+template SPDLOG_API SPDLOG_NAMESPACE::logger::logger(std::string name,
                                            sinks_init_list::iterator begin,
                                            sinks_init_list::iterator end);
-template class SPDLOG_API spdlog::sinks::base_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::base_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::base_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::base_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/stdout_sinks.cpp
+++ b/src/stdout_sinks.cpp
@@ -11,27 +11,27 @@
 #include <spdlog/details/null_mutex.h>
 #include <spdlog/sinks/stdout_sinks-inl.h>
 
-template class SPDLOG_API spdlog::sinks::stdout_sink_base<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::stdout_sink_base<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::stdout_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::stdout_sink<spdlog::details::console_nullmutex>;
-template class SPDLOG_API spdlog::sinks::stderr_sink<spdlog::details::console_mutex>;
-template class SPDLOG_API spdlog::sinks::stderr_sink<spdlog::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink_base<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink_base<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stderr_sink<SPDLOG_NAMESPACE::details::console_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stderr_sink<SPDLOG_NAMESPACE::details::console_nullmutex>;
 
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stdout_logger_mt<spdlog::synchronous_factory>(const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stdout_logger_st<spdlog::synchronous_factory>(const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stderr_logger_mt<spdlog::synchronous_factory>(const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger>
-spdlog::stderr_logger_st<spdlog::synchronous_factory>(const std::string &logger_name);
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stdout_logger_mt<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name);
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stdout_logger_st<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name);
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stderr_logger_mt<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name);
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger>
+SPDLOG_NAMESPACE::stderr_logger_st<SPDLOG_NAMESPACE::synchronous_factory>(const std::string &logger_name);
 
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_logger_mt<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stdout_logger_mt<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stdout_logger_st<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stdout_logger_st<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_logger_mt<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stderr_logger_mt<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name);
-template SPDLOG_API std::shared_ptr<spdlog::logger> spdlog::stderr_logger_st<spdlog::async_factory>(
+template SPDLOG_API std::shared_ptr<SPDLOG_NAMESPACE::logger> SPDLOG_NAMESPACE::stderr_logger_st<SPDLOG_NAMESPACE::async_factory>(
     const std::string &logger_name);


### PR DESCRIPTION
Enable defining custom namespace for spdlog

When spdlog is used by multiple components in the same process, 
each bundling their own copy, the linker or dynamic loader may resolve 
all spdlog:: symbols to whichever definition it finds first. This is an ODR 
(One Definition Rule) violation and can cause subtle misbehavior: 
loggers silently share state across components, or the program crashes 
when internal data structures disagree on their layout.
   
The SPDLOG_NAMESPACE macro lets a consumer place their copy of 
spdlog in a dedicated namespace, making its symbols distinct from any 
other copy in the process and avoiding ODR conflicts entirely.

For more sophisticated use cases, SPDLOG_NAMESPACE_BEGIN and 
SPDLOG_NAMESPACE_END can be overridden directly. One example is 
defining the namespace as inline, which keeps existing source code that 
refers to `spdlog::logger` or `spdlog::info(…)` compiling without 
changes, while the mangled symbol names still include the namespace 
and remain ABI-distinct from other copies.