### PR TITLE
Enable defining custom namespace for spdlog

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,4 +57,51 @@ jobs:
             -DSPDLOG_SANITIZE_ADDRESS=${{ matrix.config.asan || 'OFF' }} \
             -DSPDLOG_SANITIZE_THREAD=${{ matrix.config.tsan || 'OFF' }}
           make -j 4
-          ctest -j 4 --output-on-failure          
+          ctest -j 4 --output-on-failure
+
+  # -----------------------------------------------------------------------
+  # Namespace customization regression tests
+  # -----------------------------------------------------------------------
+  build_namespace_override:
+    runs-on: ubuntu-latest
+    container: gcc:12
+    defaults:
+      run:
+        shell: bash
+    name: "Namespace override"
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup
+        run: |
+          apt-get update
+          apt-get install -y curl git pkg-config libsystemd-dev
+          CMAKE_VERSION="3.24.2"
+          curl -sSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh -o install-cmake.sh
+          chmod +x install-cmake.sh
+          ./install-cmake.sh --prefix=/usr/local --skip-license
+      - name: "Strict rename — library compile-only"
+        run: |
+          mkdir -p build/ns-rename && cd build/ns-rename
+          cmake ../.. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DSPDLOG_BUILD_SHARED=ON \
+            -DCMAKE_CXX_FLAGS="-DSPDLOG_NAMESPACE=spdlog_ns_ci_test"
+          make spdlog -j 4
+      - name: "Inline-namespace wrap — full build and tests"
+        run: |
+          mkdir -p build/ns-inline
+          cat > build/ns_inline_wrap.h <<'EOF'
+          #pragma once
+          #define SPDLOG_NAMESPACE_BEGIN namespace spdlog { inline namespace ns_ci_test {
+          #define SPDLOG_NAMESPACE_END } }
+          EOF
+          cd build/ns-inline
+          cmake ../.. \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DSPDLOG_BUILD_EXAMPLE=ON \
+            -DSPDLOG_BUILD_TESTS=ON \
+            -DCMAKE_CXX_FLAGS="-include $GITHUB_WORKSPACE/build/ns_inline_wrap.h"
+          make -j 4
+          ctest -j 4 --output-on-failure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -55,7 +55,6 @@ jobs:
             -DSPDLOG_BUILD_BENCH=OFF \
             -DSPDLOG_BUILD_TESTS=ON \
             -DSPDLOG_SANITIZE_ADDRESS=${{ matrix.config.asan || 'OFF' }} \
-            -DSPDLOG_SANITIZE_ADDRESS=${{ matrix.config.asan || 'OFF' }} \
             -DSPDLOG_SANITIZE_THREAD=${{ matrix.config.tsan || 'OFF' }}
           make -j 4
           ctest -j 4 --output-on-failure          

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ set(SPDLOG_HEADERS
         "include/spdlog/formatter.h"
         "include/spdlog/fwd.h"
         "include/spdlog/logger.h"
+        "include/spdlog/namespace.h"
         "include/spdlog/pattern_formatter.h"
         "include/spdlog/source_loc.h"
         "include/spdlog/spdlog.h"

--- a/include/spdlog/bin_to_hex.h
+++ b/include/spdlog/bin_to_hex.h
@@ -37,7 +37,7 @@
 // logger->info("Some buffer {:X}", spdlog::to_hex(std::begin(buf), std::end(buf)));
 // logger->info("Some buffer {:X}", spdlog::to_hex(std::begin(buf), std::end(buf), 16));
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 template <typename It>
@@ -86,10 +86,10 @@ inline details::dump_info<It> to_hex(const It range_begin, const It range_end, s
     return details::dump_info<It>(range_begin, range_end, size_per_line);
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 template <typename T>
-struct fmt::formatter<spdlog::details::dump_info<T>, char> {
+struct fmt::formatter<SPDLOG_NAMESPACE::details::dump_info<T>, char> {
     char delimiter = ' ';
     bool put_newlines = true;
     bool put_delimiters = true;
@@ -131,7 +131,7 @@ struct fmt::formatter<spdlog::details::dump_info<T>, char> {
 
     // format the given bytes range as hex
     template <typename FormatContext, typename Container>
-    auto format(const spdlog::details::dump_info<Container> &the_range, FormatContext &ctx) const -> decltype(ctx.out()) {
+    auto format(const SPDLOG_NAMESPACE::details::dump_info<Container> &the_range, FormatContext &ctx) const -> decltype(ctx.out()) {
         constexpr const char *hex_upper = "0123456789ABCDEF";
         constexpr const char *hex_lower = "0123456789abcdef";
         const char *hex_chars = use_uppercase ? hex_upper : hex_lower;
@@ -198,7 +198,7 @@ struct fmt::formatter<spdlog::details::dump_info<T>, char> {
         *inserter++ = '\n';
 
         if (put_positions) {
-            spdlog::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
+            SPDLOG_NAMESPACE::fmt_lib::format_to(inserter, SPDLOG_FMT_STRING("{:04X}: "), pos);
         }
     }
 };  // namespace fmt

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -97,15 +97,15 @@ constexpr std::array<std::string_view, levels_count> level_string_views{"trace",
                                                                         "error", "critical", "off"};
 constexpr std::array<std::string_view, levels_count> short_level_names{"T", "D", "I", "W", "E", "C", "O"};
 
-[[nodiscard]] constexpr std::string_view to_string_view(spdlog::level lvl) noexcept {
+[[nodiscard]] constexpr std::string_view to_string_view(level lvl) noexcept {
     return level_string_views.at(level_to_number(lvl));
 }
 
-[[nodiscard]] constexpr std::string_view to_short_string_view(spdlog::level lvl) noexcept {
+[[nodiscard]] constexpr std::string_view to_short_string_view(level lvl) noexcept {
     return short_level_names.at(level_to_number(lvl));
 }
 
-[[nodiscard]] SPDLOG_API spdlog::level level_from_str(const std::string &name) noexcept;
+[[nodiscard]] SPDLOG_API level level_from_str(const std::string &name) noexcept;
 
 //
 // Color mode used by sinks with color support.

--- a/include/spdlog/common.h
+++ b/include/spdlog/common.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 
+#include "./namespace.h"
 #include "./source_loc.h"
 #include "fmt/base.h"
 #include "fmt/xchar.h"
@@ -41,7 +42,7 @@
     #define SPDLOG_FUNCTION static_cast<const char *>(__FUNCTION__)
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 class formatter;
 
@@ -138,4 +139,4 @@ private:
 [[noreturn]] SPDLOG_API void throw_spdlog_ex(const std::string &msg, int last_errno);
 [[noreturn]] SPDLOG_API void throw_spdlog_ex(std::string msg);
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/async_log_msg.h
+++ b/include/spdlog/details/async_log_msg.h
@@ -7,7 +7,7 @@
 
 #include "./log_msg.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // Extend log_msg with internal buffer to store its payload.
@@ -32,4 +32,4 @@ private:
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -9,7 +9,7 @@
 
 #include <spdlog/common.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 template <typename T>
 class circular_q {
@@ -118,4 +118,4 @@ private:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/err_helper.h
+++ b/include/spdlog/details/err_helper.h
@@ -11,7 +11,7 @@
 #include "spdlog/common.h"
 
 // by default, prints the error to stderr, at max rate of 1/sec thread safe
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class SPDLOG_API err_helper {
     err_handler custom_err_handler_;
@@ -28,4 +28,4 @@ public:
     void set_err_handler(err_handler handler);
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/file_helper.h
+++ b/include/spdlog/details/file_helper.h
@@ -8,7 +8,7 @@
 #include "../common.h"
 #include "../file_event_handlers.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // Helper class for file sinks.
@@ -41,4 +41,4 @@ private:
     file_event_handlers event_handlers_;
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -13,7 +13,7 @@ SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace fmt_helper {
 
-inline void append_string_view(spdlog::string_view_t view, memory_buf_t &dest) {
+inline void append_string_view(string_view_t view, memory_buf_t &dest) {
     const auto *buf_ptr = view.data();
     dest.append(buf_ptr, buf_ptr + view.size());
 }

--- a/include/spdlog/details/fmt_helper.h
+++ b/include/spdlog/details/fmt_helper.h
@@ -9,7 +9,7 @@
 #include "../common.h"
 
 // Some fmt helpers to efficiently format and pad ints and strings
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace fmt_helper {
 
@@ -113,4 +113,4 @@ ToDuration time_fraction(log_clock::time_point tp) {
 
 }  // namespace fmt_helper
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -7,7 +7,7 @@
 
 #include "../common.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 struct SPDLOG_API log_msg {
     log_msg() = default;
@@ -30,4 +30,4 @@ struct SPDLOG_API log_msg {
     string_view_t payload;
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -16,7 +16,7 @@
 
 #include "./circular_q.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 template <typename T>
@@ -169,4 +169,4 @@ private:
     std::atomic<size_t> discard_counter_{0};
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/mpmc_blocking_q.h
+++ b/include/spdlog/details/mpmc_blocking_q.h
@@ -165,7 +165,7 @@ private:
     std::mutex queue_mutex_;
     std::condition_variable push_cv_;
     std::condition_variable pop_cv_;
-    spdlog::details::circular_q<T> q_;
+    circular_q<T> q_;
     std::atomic<size_t> discard_counter_{0};
 };
 }  // namespace details

--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <spdlog/namespace.h>
+
 #include <atomic>
 #include <utility>
 
 // null, no cost dummy "mutex" and dummy "atomic" log level
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 struct null_mutex {
     void lock() const {}
@@ -34,4 +36,4 @@ struct null_atomic {
 };
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -9,7 +9,7 @@
 #include "../common.h"
 #include "../filename_t.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
@@ -125,4 +125,4 @@ SPDLOG_API std::string filename_to_str(const filename_t &filename);
 
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/os.h
+++ b/include/spdlog/details/os.h
@@ -13,7 +13,7 @@ SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
-SPDLOG_API spdlog::log_clock::time_point now() noexcept;
+SPDLOG_API log_clock::time_point now() noexcept;
 
 SPDLOG_API std::tm localtime(const std::time_t &time_tt) noexcept;
 

--- a/include/spdlog/details/tcp_client_unix.h
+++ b/include/spdlog/details/tcp_client_unix.h
@@ -25,7 +25,7 @@
 #include "../common.h"
 #include "./os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class tcp_client_unix {
     int socket_ = -1;
@@ -198,4 +198,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/tcp_client_windows.h
+++ b/include/spdlog/details/tcp_client_windows.h
@@ -20,7 +20,7 @@
 #pragma comment(lib, "Mswsock.lib")
 #pragma comment(lib, "AdvApi32.lib")
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class tcp_client_unix {
     SOCKET socket_ = INVALID_SOCKET;
@@ -206,4 +206,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/udp_client_unix.h
+++ b/include/spdlog/details/udp_client_unix.h
@@ -23,7 +23,7 @@
 #include <cstring>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 class udp_client_unix {
@@ -78,4 +78,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/details/udp_client_windows.h
+++ b/include/spdlog/details/udp_client_windows.h
@@ -23,7 +23,7 @@
     #pragma comment(lib, "AdvApi32.lib")
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 class udp_client_unix {
     static constexpr int TX_BUFFER_SIZE = 1024 * 10;
@@ -95,4 +95,4 @@ public:
     }
 };
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/file_event_handlers.h
+++ b/include/spdlog/file_event_handlers.h
@@ -3,8 +3,9 @@
 #include <functional>
 
 #include "./filename_t.h"
+#include "./namespace.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 struct file_event_handlers {
     file_event_handlers()
         : before_open(nullptr),
@@ -17,4 +18,4 @@ struct file_event_handlers {
     std::function<void(const filename_t &filename, std::FILE *file_stream)> before_close;
     std::function<void(const filename_t &filename)> after_close;
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/filename_t.h
+++ b/include/spdlog/filename_t.h
@@ -5,6 +5,8 @@
 
 #include <filesystem>
 
+#include "./namespace.h"
+
 #ifdef _WIN32
     // In windows, add L prefix for filename literals (e.g. L"filename.txt")
     #define SPDLOG_FILENAME_T_INNER(s) L##s
@@ -13,6 +15,6 @@
     #define SPDLOG_FILENAME_T(s) s
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 using filename_t = std::filesystem::path;
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/formatter.h
+++ b/include/spdlog/formatter.h
@@ -5,7 +5,7 @@
 
 #include "./details/log_msg.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 class formatter {
 public:
@@ -13,4 +13,4 @@ public:
     virtual void format(const details::log_msg &msg, memory_buf_t &dest) = 0;
     virtual std::unique_ptr<formatter> clone() const = 0;
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/fwd.h
+++ b/include/spdlog/fwd.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
-namespace spdlog {
+#include "./namespace.h"
+
+SPDLOG_NAMESPACE_BEGIN
 class logger;
 class formatter;
 enum class level;
@@ -12,4 +14,4 @@ namespace sinks {
 class sink;
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/logger.h
+++ b/include/spdlog/logger.h
@@ -20,7 +20,7 @@
 #include "details/log_msg.h"
 #include "sinks/sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 class SPDLOG_API logger {
 public:
@@ -207,4 +207,4 @@ private:
     void flush_() noexcept;
 };
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/namespace.h
+++ b/include/spdlog/namespace.h
@@ -1,0 +1,27 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+// SPDLOG_NAMESPACE is the outermost namespace token used to qualify spdlog names
+// in contexts outside a SPDLOG_NAMESPACE_BEGIN block (e.g. logging macros).
+// Override it to rename the outer namespace.
+#ifndef SPDLOG_NAMESPACE
+    #define SPDLOG_NAMESPACE spdlog
+#endif
+// SPDLOG_NAMESPACE_BEGIN / SPDLOG_NAMESPACE_END delimit every spdlog
+// declaration, defaulting to "namespace SPDLOG_NAMESPACE { ... }".
+// Override both to use a more complex namespace expression, e.g. to wrap
+// symbols in an inline sub-namespace (keeps "spdlog::" accessible).
+// In C++17:
+//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog { inline namespace my_copy {
+//   #define SPDLOG_NAMESPACE_END    } }
+// In C++20, the nested inline-namespace syntax may be used instead:
+//   #define SPDLOG_NAMESPACE_BEGIN  namespace spdlog::inline my_copy {
+//   #define SPDLOG_NAMESPACE_END    }
+#ifndef SPDLOG_NAMESPACE_BEGIN
+    #define SPDLOG_NAMESPACE_BEGIN namespace SPDLOG_NAMESPACE {
+#endif
+#ifndef SPDLOG_NAMESPACE_END
+    #define SPDLOG_NAMESPACE_END }
+#endif

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -63,12 +63,12 @@ public:
 
     explicit pattern_formatter(std::string pattern,
                                pattern_time_type time_type = pattern_time_type::local,
-                               std::string eol = spdlog::details::os::default_eol,
+                               std::string eol = details::os::default_eol,
                                custom_flags custom_user_flags = custom_flags());
 
     // use default pattern is not given
     explicit pattern_formatter(pattern_time_type time_type = pattern_time_type::local,
-                               std::string eol = spdlog::details::os::default_eol);
+                               std::string eol = details::os::default_eol);
 
     pattern_formatter(const pattern_formatter &other) = delete;
     pattern_formatter &operator=(const pattern_formatter &other) = delete;

--- a/include/spdlog/pattern_formatter.h
+++ b/include/spdlog/pattern_formatter.h
@@ -15,7 +15,7 @@
 #include "./details/os.h"
 #include "./formatter.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 // padding information.
@@ -105,4 +105,4 @@ private:
 
     void compile_pattern_(const std::string &pattern);
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -87,19 +87,19 @@ private:
         return __android_log_buf_write(ID, prio, tag, text);
     }
 
-    static android_LogPriority convert_to_android_(spdlog::level level) {
+    static android_LogPriority convert_to_android_(level level) {
         switch (level) {
-            case spdlog::level::trace:
+            case level::trace:
                 return ANDROID_LOG_VERBOSE;
-            case spdlog::level::debug:
+            case level::debug:
                 return ANDROID_LOG_DEBUG;
-            case spdlog::level::info:
+            case level::info:
                 return ANDROID_LOG_INFO;
-            case spdlog::level::warn:
+            case level::warn:
                 return ANDROID_LOG_WARN;
-            case spdlog::level::err:
+            case level::err:
                 return ANDROID_LOG_ERROR;
-            case spdlog::level::critical:
+            case level::critical:
                 return ANDROID_LOG_FATAL;
             default:
                 return ANDROID_LOG_DEFAULT;

--- a/include/spdlog/sinks/android_sink.h
+++ b/include/spdlog/sinks/android_sink.h
@@ -22,7 +22,7 @@
         #define SPDLOG_ANDROID_RETRIES 2
     #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -119,6 +119,6 @@ template <int BufferId = log_id::LOG_ID_MAIN>
 using android_sink_buf_st = android_sink<details::null_mutex, BufferId>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 #endif  // __ANDROID__

--- a/include/spdlog/sinks/ansicolor_sink.h
+++ b/include/spdlog/sinks/ansicolor_sink.h
@@ -10,7 +10,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /**
@@ -102,4 +102,4 @@ using ansicolor_stderr_sink_mt = ansicolor_stderr_sink<std::mutex>;
 using ansicolor_stderr_sink_st = ansicolor_stderr_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/async_sink.h
+++ b/include/spdlog/sinks/async_sink.h
@@ -15,12 +15,14 @@
 // The worker thread dequeues the messages and sends them to the dist_sink to perform the actual logging.
 // Once the sink is destroyed, the worker thread empties the queue and exits.
 
-namespace spdlog::details {  // forward declaration
+SPDLOG_NAMESPACE_BEGIN
+namespace details {  // forward declaration
 template <typename T>
 class mpmc_blocking_queue;
-}
+}  // namespace details
+SPDLOG_NAMESPACE_END
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 class SPDLOG_API async_sink final : public sink {
@@ -111,4 +113,4 @@ private:
 };
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -19,7 +19,7 @@ template <typename Mutex>
 class SPDLOG_API base_sink : public sink {
 public:
     base_sink();
-    explicit base_sink(std::unique_ptr<spdlog::formatter> formatter);
+    explicit base_sink(std::unique_ptr<formatter> formatter);
     ~base_sink() override = default;
 
     base_sink(const base_sink &) = delete;
@@ -31,17 +31,17 @@ public:
     void log(const details::log_msg &msg) final override;
     void flush() final override;
     void set_pattern(const std::string &pattern) final override;
-    void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) final override;
+    void set_formatter(std::unique_ptr<formatter> sink_formatter) final override;
 
 protected:
     // sink formatter
-    std::unique_ptr<spdlog::formatter> formatter_;
+    std::unique_ptr<formatter> formatter_;
     mutable Mutex mutex_;
 
     virtual void sink_it_(const details::log_msg &msg) = 0;
     virtual void flush_() = 0;
     virtual void set_pattern_(const std::string &pattern);
-    virtual void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter);
+    virtual void set_formatter_(std::unique_ptr<formatter> sink_formatter);
 };
 
 }  // namespace sinks

--- a/include/spdlog/sinks/base_sink.h
+++ b/include/spdlog/sinks/base_sink.h
@@ -13,7 +13,7 @@
 #include "../details/log_msg.h"
 #include "./sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class SPDLOG_API base_sink : public sink {
@@ -45,4 +45,4 @@ protected:
 };
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/basic_file_sink.h
+++ b/include/spdlog/sinks/basic_file_sink.h
@@ -10,7 +10,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Trivial file sink with single file as target
@@ -34,4 +34,4 @@ using basic_file_sink_mt = basic_file_sink<std::mutex>;
 using basic_file_sink_st = basic_file_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/callback_sink.h
+++ b/include/spdlog/sinks/callback_sink.h
@@ -9,7 +9,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // callbacks type
 typedef std::function<void(const details::log_msg &msg)> custom_log_callback;
@@ -36,4 +36,4 @@ using callback_sink_mt = callback_sink<std::mutex>;
 using callback_sink_st = callback_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -17,7 +17,7 @@
 #include "../details/os.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -188,4 +188,4 @@ using daily_file_format_sink_mt = daily_file_sink<std::mutex, daily_filename_for
 using daily_file_format_sink_st = daily_file_sink<details::null_mutex, daily_filename_format_calculator>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -137,7 +137,7 @@ private:
 
     tm now_tm(log_clock::time_point tp) {
         time_t tnow = log_clock::to_time_t(tp);
-        return spdlog::details::os::localtime(tnow);
+        return details::os::localtime(tnow);
     }
 
     log_clock::time_point next_rotation_tp_() {

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -16,7 +16,7 @@
 // Distribution sink (mux). Stores a vector of sinks which get called when log
 // is called
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -78,4 +78,4 @@ using dist_sink_mt = dist_sink<std::mutex>;
 using dist_sink_st = dist_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/dist_sink.h
+++ b/include/spdlog/sinks/dist_sink.h
@@ -62,10 +62,10 @@ protected:
     }
 
     void set_pattern_(const std::string &pattern) override {
-        set_formatter_(std::make_unique<spdlog::pattern_formatter>(pattern));
+        set_formatter_(std::make_unique<pattern_formatter>(pattern));
     }
 
-    void set_formatter_(std::unique_ptr<spdlog::formatter> sink_formatter) override {
+    void set_formatter_(std::unique_ptr<formatter> sink_formatter) override {
         base_sink<Mutex>::formatter_ = std::move(sink_formatter);
         for (auto &sub_sink : sinks_) {
             sub_sink->set_formatter(base_sink<Mutex>::formatter_->clone());

--- a/include/spdlog/sinks/dup_filter_sink.h
+++ b/include/spdlog/sinks/dup_filter_sink.h
@@ -36,7 +36,7 @@
 //       [2019-06-25 17:50:56.512] [logger] [info] Skipped 3 duplicate messages..
 //       [2019-06-25 17:50:56.512] [logger] [info] Different Hello
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class dup_filter_sink final : public dist_sink<Mutex> {
@@ -110,4 +110,4 @@ using dup_filter_sink_mt = dup_filter_sink<std::mutex>;
 using dup_filter_sink_st = dup_filter_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/hourly_file_sink.h
+++ b/include/spdlog/sinks/hourly_file_sink.h
@@ -16,7 +16,7 @@
 #include "../details/os.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
@@ -165,4 +165,4 @@ using hourly_file_sink_mt = hourly_file_sink<std::mutex>;
 using hourly_file_sink_st = hourly_file_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/hourly_file_sink.h
+++ b/include/spdlog/sinks/hourly_file_sink.h
@@ -118,7 +118,7 @@ private:
 
     tm now_tm(log_clock::time_point tp) {
         time_t tnow = log_clock::to_time_t(tp);
-        return spdlog::details::os::localtime(tnow);
+        return details::os::localtime(tnow);
     }
 
     log_clock::time_point next_rotation_tp_() {

--- a/include/spdlog/sinks/kafka_sink.h
+++ b/include/spdlog/sinks/kafka_sink.h
@@ -20,7 +20,7 @@
 // kafka header
 #include <librdkafka/rdkafkacpp.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct kafka_sink_config {
@@ -87,4 +87,4 @@ using kafka_sink_mt = kafka_sink<std::mutex>;
 using kafka_sink_st = kafka_sink<spdlog::details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/kafka_sink.h
+++ b/include/spdlog/sinks/kafka_sink.h
@@ -84,7 +84,7 @@ private:
 };
 
 using kafka_sink_mt = kafka_sink<std::mutex>;
-using kafka_sink_st = kafka_sink<spdlog::details::null_mutex>;
+using kafka_sink_st = kafka_sink<details::null_mutex>;
 
 }  // namespace sinks
 SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -23,7 +23,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class mongo_sink : public base_sink<Mutex> {
@@ -80,4 +80,4 @@ using mongo_sink_mt = mongo_sink<std::mutex>;
 using mongo_sink_st = mongo_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/msvc_sink.h
+++ b/include/spdlog/sinks/msvc_sink.h
@@ -12,7 +12,7 @@
 extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(const char *lpOutputString);
 extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * MSVC sink (logging using OutputDebugStringA)
@@ -47,4 +47,4 @@ using windebug_sink_mt = msvc_sink_mt;
 using windebug_sink_st = msvc_sink_st;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/null_sink.h
+++ b/include/spdlog/sinks/null_sink.h
@@ -6,7 +6,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -20,4 +20,4 @@ using null_sink_mt = null_sink<details::null_mutex>;
 using null_sink_st = null_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/ostream_sink.h
+++ b/include/spdlog/sinks/ostream_sink.h
@@ -9,7 +9,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class ostream_sink final : public base_sink<Mutex> {
@@ -40,4 +40,4 @@ using ostream_sink_mt = ostream_sink<std::mutex>;
 using ostream_sink_st = ostream_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -84,7 +84,7 @@ public:
         colors_.at(level::info) = format;
         // warn
         format.setForeground(dark_colors ? Qt::darkYellow : Qt::yellow);
-        colors_.at(spdlog::level::warn) = format;
+        colors_.at(level::warn) = format;
         // err
         format.setForeground(Qt::red);
         colors_.at(level::err) = format;

--- a/include/spdlog/sinks/qt_sinks.h
+++ b/include/spdlog/sinks/qt_sinks.h
@@ -22,7 +22,7 @@
 //
 // qt_sink class
 //
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class qt_sink : public base_sink<Mutex> {
@@ -225,4 +225,4 @@ using qt_color_sink_mt = qt_color_sink<std::mutex>;
 using qt_color_sink_st = qt_color_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/ringbuffer_sink.h
+++ b/include/spdlog/sinks/ringbuffer_sink.h
@@ -12,7 +12,7 @@
 #include "../details/null_mutex.h"
 #include "base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Ring buffer sink. Holds fixed amount of log messages in memory. When the buffer is full, new
@@ -63,4 +63,4 @@ using ringbuffer_sink_mt = ringbuffer_sink<std::mutex>;
 using ringbuffer_sink_st = ringbuffer_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/rotating_file_sink.h
+++ b/include/spdlog/sinks/rotating_file_sink.h
@@ -12,7 +12,7 @@
 
 // Rotating file sink based on size
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 class rotating_file_sink final : public base_sink<Mutex> {
@@ -54,4 +54,4 @@ using rotating_file_sink_mt = rotating_file_sink<std::mutex>;
 using rotating_file_sink_st = rotating_file_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -6,7 +6,7 @@
 #include "../details/log_msg.h"
 #include "../formatter.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 class SPDLOG_API sink {
 public:
@@ -26,4 +26,4 @@ protected:
 };
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/sink.h
+++ b/include/spdlog/sinks/sink.h
@@ -14,7 +14,7 @@ public:
     virtual void log(const details::log_msg &msg) = 0;
     virtual void flush() = 0;
     virtual void set_pattern(const std::string &pattern) = 0;
-    virtual void set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) = 0;
+    virtual void set_formatter(std::unique_ptr<formatter> sink_formatter) = 0;
 
     void set_level(level level) { level_.store(level, std::memory_order_relaxed); }
     level log_level() const { return level_.load(std::memory_order_relaxed); }

--- a/include/spdlog/sinks/stdout_color_sinks.h
+++ b/include/spdlog/sinks/stdout_color_sinks.h
@@ -9,7 +9,7 @@
     #include "./ansicolor_sink.h"
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 #ifdef _WIN32
 using stdout_color_sink_mt = wincolor_stdout_sink_mt;
@@ -24,4 +24,4 @@ using stderr_color_sink_st = ansicolor_stderr_sink_st;
 #endif
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/stdout_sinks.h
+++ b/include/spdlog/sinks/stdout_sinks.h
@@ -14,7 +14,7 @@
     #include "../details/windows_include.h"
 #endif
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace sinks {
 
@@ -58,4 +58,4 @@ using stderr_sink_mt = stderr_sink<std::mutex>;
 using stderr_sink_st = stderr_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/syslog_sink.h
+++ b/include/spdlog/sinks/syslog_sink.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <string>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /**
  * Sink that write to syslog using the `syscall()` library call.
@@ -81,4 +81,4 @@ using syslog_sink_mt = syslog_sink<std::mutex>;
 using syslog_sink_st = syslog_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/systemd_sink.h
+++ b/include/spdlog/sinks/systemd_sink.h
@@ -13,7 +13,7 @@
 #endif
 #include <systemd/sd-journal.h>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /**
@@ -91,4 +91,4 @@ using systemd_sink_mt = systemd_sink<std::mutex>;
 using systemd_sink_st = systemd_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -23,7 +23,7 @@
 // If more complicated behaviour is needed (i.e get responses), you can inherit it and override the
 // sink_it_ method.
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct tcp_sink_config {
@@ -83,4 +83,4 @@ using tcp_sink_mt = tcp_sink<std::mutex>;
 using tcp_sink_st = tcp_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/tcp_sink.h
+++ b/include/spdlog/sinks/tcp_sink.h
@@ -38,7 +38,7 @@ struct tcp_sink_config {
 };
 
 template <typename Mutex>
-class tcp_sink final : public spdlog::sinks::base_sink<Mutex> {
+class tcp_sink final : public base_sink<Mutex> {
 public:
     // connect to tcp host/port or throw if failed
     // host can be hostname or ip address
@@ -65,9 +65,9 @@ public:
     ~tcp_sink() override = default;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override {
-        spdlog::memory_buf_t formatted;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+    void sink_it_(const details::log_msg &msg) override {
+        memory_buf_t formatted;
+        base_sink<Mutex>::formatter_->format(msg, formatted);
         if (!client_.is_connected()) {
             client_.connect(config_.server_host, config_.server_port, config_.timeout_ms);
         }

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -20,7 +20,7 @@
 // Simple udp client sink
 // Sends formatted log via udp
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct udp_sink_config {
@@ -56,4 +56,4 @@ using udp_sink_mt = udp_sink<std::mutex>;
 using udp_sink_st = udp_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/udp_sink.h
+++ b/include/spdlog/sinks/udp_sink.h
@@ -42,9 +42,9 @@ public:
     ~udp_sink() override = default;
 
 protected:
-    void sink_it_(const spdlog::details::log_msg &msg) override {
-        spdlog::memory_buf_t formatted;
-        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+    void sink_it_(const details::log_msg &msg) override {
+        memory_buf_t formatted;
+        base_sink<Mutex>::formatter_->format(msg, formatted);
         client_.send(formatted.data(), formatted.size());
     }
 

--- a/include/spdlog/sinks/win_eventlog_sink.h
+++ b/include/spdlog/sinks/win_eventlog_sink.h
@@ -44,7 +44,7 @@ Windows Registry Editor Version 5.00
 #include <vector>
 // clang-format on
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 namespace win_eventlog {
@@ -243,4 +243,4 @@ using win_eventlog_sink_mt = win_eventlog::win_eventlog_sink<std::mutex>;
 using win_eventlog_sink_st = win_eventlog::win_eventlog_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/win_eventlog_sink.h
+++ b/include/spdlog/sinks/win_eventlog_sink.h
@@ -159,7 +159,7 @@ struct eventlog {
             case level::info:
                 return EVENTLOG_INFORMATION_TYPE;
 
-            case spdlog::level::warn:
+            case level::warn:
                 return EVENTLOG_WARNING_TYPE;
 
             case level::err:

--- a/include/spdlog/sinks/wincolor_sink.h
+++ b/include/spdlog/sinks/wincolor_sink.h
@@ -13,7 +13,7 @@
 #include "../details/null_mutex.h"
 #include "./base_sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 /*
  * Windows color console sink. Uses WriteConsoleA to write to the console with
@@ -70,4 +70,4 @@ using wincolor_stderr_sink_mt = wincolor_stderr_sink<std::mutex>;
 using wincolor_stderr_sink_st = wincolor_stderr_sink<details::null_mutex>;
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/source_loc.h
+++ b/include/spdlog/source_loc.h
@@ -4,7 +4,9 @@
 #pragma once
 #include <cstdint>
 
-namespace spdlog {  // source location
+#include "./namespace.h"
+
+SPDLOG_NAMESPACE_BEGIN  // source location
 struct source_loc {
     constexpr source_loc() = default;
     constexpr source_loc(const char *filename_in, std::uint_least32_t line_in, const char *funcname_in)
@@ -36,4 +38,4 @@ struct source_loc {
         return file;
     }
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/spdlog.h
+++ b/include/spdlog/spdlog.h
@@ -16,7 +16,7 @@
 #include "./common.h"
 #include "./logger.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // Create a logger with a templated sink type
 // Example:
@@ -131,7 +131,7 @@ inline void error(std::string_view msg) { log(level::err, msg); }
 
 inline void critical(std::string_view msg) { log(level::critical, msg); }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 //
 // enable/disable log calls at compile time according to global level.
@@ -148,54 +148,54 @@ inline void critical(std::string_view msg) { log(level::critical, msg); }
 
 #ifndef SPDLOG_NO_SOURCE_LOC
     #define SPDLOG_LOGGER_CALL(logger, level, ...) \
-        (logger)->log(spdlog::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
+        (logger)->log(SPDLOG_NAMESPACE::source_loc{__FILE__, __LINE__, SPDLOG_FUNCTION}, level, __VA_ARGS__)
 #else
-    #define SPDLOG_LOGGER_CALL(logger, level, ...) (logger)->log(spdlog::source_loc{}, level, __VA_ARGS__)
+    #define SPDLOG_LOGGER_CALL(logger, level, ...) (logger)->log(SPDLOG_NAMESPACE::source_loc{}, level, __VA_ARGS__)
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_TRACE
-    #define SPDLOG_LOGGER_TRACE(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::trace, __VA_ARGS__)
-    #define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(spdlog::global_logger_raw(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_TRACE(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::trace, __VA_ARGS__)
+    #define SPDLOG_TRACE(...) SPDLOG_LOGGER_TRACE(SPDLOG_NAMESPACE::global_logger_raw(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_TRACE(logger, ...) (void)0
     #define SPDLOG_TRACE(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
-    #define SPDLOG_LOGGER_DEBUG(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::debug, __VA_ARGS__)
-    #define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(spdlog::global_logger(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_DEBUG(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::debug, __VA_ARGS__)
+    #define SPDLOG_DEBUG(...) SPDLOG_LOGGER_DEBUG(SPDLOG_NAMESPACE::global_logger(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_DEBUG(logger, ...) (void)0
     #define SPDLOG_DEBUG(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_INFO
-    #define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::info, __VA_ARGS__)
-    #define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(spdlog::global_logger(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_INFO(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::info, __VA_ARGS__)
+    #define SPDLOG_INFO(...) SPDLOG_LOGGER_INFO(SPDLOG_NAMESPACE::global_logger(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_INFO(logger, ...) (void)0
     #define SPDLOG_INFO(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_WARN
-    #define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::warn, __VA_ARGS__)
-    #define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(spdlog::global_logger(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_WARN(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::warn, __VA_ARGS__)
+    #define SPDLOG_WARN(...) SPDLOG_LOGGER_WARN(SPDLOG_NAMESPACE::global_logger(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_WARN(logger, ...) (void)0
     #define SPDLOG_WARN(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_ERROR
-    #define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::err, __VA_ARGS__)
-    #define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(spdlog::global_logger(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_ERROR(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::err, __VA_ARGS__)
+    #define SPDLOG_ERROR(...) SPDLOG_LOGGER_ERROR(SPDLOG_NAMESPACE::global_logger(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_ERROR(logger, ...) (void)0
     #define SPDLOG_ERROR(...) (void)0
 #endif
 
 #if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_CRITICAL
-    #define SPDLOG_LOGGER_CRITICAL(logger, ...) SPDLOG_LOGGER_CALL(logger, spdlog::level::critical, __VA_ARGS__)
-    #define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(spdlog::global_logger(), __VA_ARGS__)
+    #define SPDLOG_LOGGER_CRITICAL(logger, ...) SPDLOG_LOGGER_CALL(logger, SPDLOG_NAMESPACE::level::critical, __VA_ARGS__)
+    #define SPDLOG_CRITICAL(...) SPDLOG_LOGGER_CRITICAL(SPDLOG_NAMESPACE::global_logger(), __VA_ARGS__)
 #else
     #define SPDLOG_LOGGER_CRITICAL(logger, ...) (void)0
     #define SPDLOG_CRITICAL(...) (void)0

--- a/include/spdlog/stopwatch.h
+++ b/include/spdlog/stopwatch.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 
+#include "./namespace.h"
 #include "fmt/base.h"
 
 // Stopwatch support for spdlog  (using std::chrono::steady_clock).
@@ -27,7 +28,7 @@
 // using std::chrono::milliseconds;
 // spdlog::info("Elapsed {}", duration_cast<milliseconds>(sw.elapsed())); => "Elapsed 5ms"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 class stopwatch {
     using clock = std::chrono::steady_clock;
     std::chrono::time_point<clock> start_tp_;
@@ -48,13 +49,13 @@ public:
 
     void reset() { start_tp_ = clock::now(); }
 };
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // Support for fmt formatting  (e.g. "{:012.9}" or just "{}")
 template <>
-struct fmt::formatter<spdlog::stopwatch> : formatter<double> {
+struct fmt::formatter<SPDLOG_NAMESPACE::stopwatch> : formatter<double> {
     template <typename FormatContext>
-    auto format(const spdlog::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
+    auto format(const SPDLOG_NAMESPACE::stopwatch &sw, FormatContext &ctx) const -> decltype(ctx.out()) {
         return formatter<double>::format(sw.elapsed().count(), ctx);
     }
 };  // namespace fmt

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -19,7 +19,7 @@ bool iequals(const std::string &a, const std::string &b) {
 }
 }  // namespace
 
-spdlog::level level_from_str(const std::string &name) noexcept {
+level level_from_str(const std::string &name) noexcept {
     const auto it =
         std::find_if(std::begin(level_string_views), std::end(level_string_views),
                      [&name](const string_view_t &level_name) {
@@ -36,7 +36,7 @@ spdlog::level level_from_str(const std::string &name) noexcept {
 
     // check also for "warn" and "err" before giving up
     if (iequals(name, "warn")) {
-        return spdlog::level::warn;
+        return level::warn;
     }
     if (iequals(name, "err")) {
         return level::err;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -7,7 +7,7 @@
 #include <cctype>
 #include <iterator>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 namespace {
 bool iequals(const std::string &a, const std::string &b) {
@@ -59,4 +59,4 @@ void throw_spdlog_ex(const std::string &msg, int last_errno) { throw(spdlog_ex(m
 
 void throw_spdlog_ex(std::string msg) { throw(spdlog_ex(std::move(msg))); }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/async_log_msg.cpp
+++ b/src/details/async_log_msg.cpp
@@ -3,7 +3,7 @@
 
 #include "spdlog/details/async_log_msg.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 async_log_msg::async_log_msg(const type type)
@@ -61,4 +61,4 @@ void async_log_msg::update_string_views() {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/err_helper.cpp
+++ b/src/details/err_helper.cpp
@@ -5,7 +5,7 @@
 
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 err_helper::err_helper(const err_helper &other) {
@@ -65,4 +65,4 @@ void err_helper::set_err_handler(err_handler handler) {
 }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/file_helper.cpp
+++ b/src/details/file_helper.cpp
@@ -11,7 +11,7 @@
 #include "spdlog/common.h"
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 file_helper::file_helper(file_event_handlers event_handlers)
@@ -111,4 +111,4 @@ size_t file_helper::size() const {
 const filename_t &file_helper::filename() const { return filename_; }
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/log_msg.cpp
+++ b/src/details/log_msg.cpp
@@ -5,7 +5,7 @@
 
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 log_msg::log_msg(const log_clock::time_point log_time,
@@ -32,4 +32,4 @@ log_msg::log_msg(const string_view_t logger_name, const level lvl, const string_
     : log_msg(os::now(), source_loc{}, logger_name, lvl, msg) {}
 
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/os_filesystem.cpp
+++ b/src/details/os_filesystem.cpp
@@ -7,7 +7,7 @@
 #include "spdlog/common.h"
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
@@ -61,4 +61,4 @@ std::tuple<filename_t, filename_t> split_by_extension(const filename_t &fname) {
 }
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/os_unix.cpp
+++ b/src/details/os_unix.cpp
@@ -47,7 +47,7 @@ SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
-spdlog::log_clock::time_point now() noexcept {
+log_clock::time_point now() noexcept {
 #if defined __linux__ && defined SPDLOG_CLOCK_COARSE
     timespec ts;
     ::clock_gettime(CLOCK_REALTIME_COARSE, &ts);

--- a/src/details/os_unix.cpp
+++ b/src/details/os_unix.cpp
@@ -43,7 +43,7 @@
 #endif
 
 // clang-format on
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 
@@ -293,4 +293,4 @@ bool fwrite_bytes(const void *ptr, const size_t n_bytes, FILE *fp) {
 
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/os_windows.cpp
+++ b/src/details/os_windows.cpp
@@ -33,7 +33,7 @@
 #include <direct.h>  // for _mkdir/_wmkdir
 
 // clang-format on
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
 spdlog::log_clock::time_point now() noexcept { return log_clock::now(); }
@@ -253,4 +253,4 @@ bool fwrite_bytes(const void *ptr, const size_t n_bytes, FILE *fp) {
 }
 }  // namespace os
 }  // namespace details
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/details/os_windows.cpp
+++ b/src/details/os_windows.cpp
@@ -36,7 +36,7 @@
 SPDLOG_NAMESPACE_BEGIN
 namespace details {
 namespace os {
-spdlog::log_clock::time_point now() noexcept { return log_clock::now(); }
+log_clock::time_point now() noexcept { return log_clock::now(); }
 
 std::tm localtime(const std::time_t &time_tt) noexcept {
     std::tm tm;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -6,7 +6,7 @@
 #include "spdlog/pattern_formatter.h"
 #include "spdlog/sinks/sink.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 // public methods
 logger::logger(const logger &other)
@@ -81,4 +81,4 @@ void logger::flush_() noexcept {
         }
     }
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/pattern_formatter.cpp
+++ b/src/pattern_formatter.cpp
@@ -18,7 +18,7 @@
 #include "spdlog/details/os.h"
 #include "spdlog/formatter.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
 ///////////////////////////////////////////////////////////////////////
@@ -1222,4 +1222,4 @@ void pattern_formatter::compile_pattern_(const std::string &pattern) {
         formatters_.push_back(std::move(user_chars));
     }
 }
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/sinks/ansicolor_sink.cpp
+++ b/src/sinks/ansicolor_sink.cpp
@@ -8,7 +8,7 @@
 #include "spdlog/details/os.h"
 #include "spdlog/pattern_formatter.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -112,13 +112,13 @@ ansicolor_stderr_sink<Mutex>::ansicolor_stderr_sink(color_mode mode)
     : ansicolor_sink<Mutex>(stderr, mode) {}
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::ansicolor_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_sink<spdlog::details::null_mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stdout_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stdout_sink<spdlog::details::null_mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stderr_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::ansicolor_stderr_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_sink<SPDLOG_NAMESPACE::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stdout_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stdout_sink<SPDLOG_NAMESPACE::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stderr_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::ansicolor_stderr_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/sinks/async_sink.cpp
+++ b/src/sinks/async_sink.cpp
@@ -13,7 +13,7 @@
 #include "spdlog/pattern_formatter.h"
 #include "spdlog/spdlog.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 async_sink::async_sink(config async_config)
@@ -157,4 +157,4 @@ void async_sink::backend_flush_() {
     }
 }
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/src/sinks/base_sink.cpp
+++ b/src/sinks/base_sink.cpp
@@ -9,7 +9,7 @@
 #include "spdlog/common.h"
 #include "spdlog/pattern_formatter.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -55,9 +55,9 @@ void base_sink<Mutex>::set_formatter_(std::unique_ptr<formatter> sink_formatter)
 }
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::base_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::base_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::base_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::base_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/sinks/base_sink.cpp
+++ b/src/sinks/base_sink.cpp
@@ -14,10 +14,10 @@ namespace sinks {
 
 template <typename Mutex>
 base_sink<Mutex>::base_sink()
-    : formatter_{std::make_unique<spdlog::pattern_formatter>()} {}
+    : formatter_{std::make_unique<pattern_formatter>()} {}
 
 template <typename Mutex>
-base_sink<Mutex>::base_sink(std::unique_ptr<spdlog::formatter> formatter)
+base_sink<Mutex>::base_sink(std::unique_ptr<formatter> formatter)
     : formatter_{std::move(formatter)} {}
 
 template <typename Mutex>
@@ -39,7 +39,7 @@ void base_sink<Mutex>::set_pattern(const std::string &pattern) {
 }
 
 template <typename Mutex>
-void base_sink<Mutex>::set_formatter(std::unique_ptr<spdlog::formatter> sink_formatter) {
+void base_sink<Mutex>::set_formatter(std::unique_ptr<formatter> sink_formatter) {
     std::lock_guard<Mutex> lock(mutex_);
     set_formatter_(std::move(sink_formatter));
 }

--- a/src/sinks/basic_file_sink.cpp
+++ b/src/sinks/basic_file_sink.cpp
@@ -7,7 +7,7 @@
 
 #include "spdlog/common.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -40,9 +40,9 @@ void basic_file_sink<Mutex>::flush_() {
 }
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::basic_file_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::basic_file_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::basic_file_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::basic_file_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/sinks/rotating_file_sink.cpp
+++ b/src/sinks/rotating_file_sink.cpp
@@ -13,7 +13,7 @@
 #include "spdlog/details/file_helper.h"
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -138,9 +138,9 @@ bool rotating_file_sink<Mutex>::rename_file_(const filename_t &src_filename, con
 }
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::rotating_file_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::rotating_file_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::rotating_file_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::rotating_file_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/sinks/stdout_sinks.cpp
+++ b/src/sinks/stdout_sinks.cpp
@@ -24,7 +24,7 @@
 #endif                  // _WIN32
 
 // clang-format on
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 template <typename Mutex>
@@ -83,11 +83,11 @@ stderr_sink<Mutex>::stderr_sink()
     : stdout_sink_base<Mutex>(stderr) {}
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::stdout_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::stdout_sink<spdlog::details::null_mutex>;
-template class SPDLOG_API spdlog::sinks::stderr_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::stderr_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stdout_sink<SPDLOG_NAMESPACE::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stderr_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::stderr_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/sinks/wincolor_sink.cpp
+++ b/src/sinks/wincolor_sink.cpp
@@ -12,7 +12,7 @@
 #include "spdlog/common.h"
 #include "spdlog/details/os.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 template <typename Mutex>
 wincolor_sink<Mutex>::wincolor_sink(void *out_handle, color_mode mode)
@@ -141,11 +141,11 @@ wincolor_stderr_sink<Mutex>::wincolor_stderr_sink(color_mode mode)
     : wincolor_sink<Mutex>(::GetStdHandle(STD_ERROR_HANDLE), mode) {}
 
 }  // namespace sinks
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END
 
 // template instantiations
 #include "spdlog/details/null_mutex.h"
-template class SPDLOG_API spdlog::sinks::wincolor_stdout_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stdout_sink<spdlog::details::null_mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stderr_sink<std::mutex>;
-template class SPDLOG_API spdlog::sinks::wincolor_stderr_sink<spdlog::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stdout_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stdout_sink<SPDLOG_NAMESPACE::details::null_mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stderr_sink<std::mutex>;
+template class SPDLOG_API SPDLOG_NAMESPACE::sinks::wincolor_stderr_sink<SPDLOG_NAMESPACE::details::null_mutex>;

--- a/src/spdlog.cpp
+++ b/src/spdlog.cpp
@@ -11,7 +11,7 @@
 #include "spdlog/pattern_formatter.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 
 #ifndef SPDLOG_DISABLE_GLOBAL_LOGGER
 static std::shared_ptr<logger> s_logger = std::make_shared<logger>("", std::make_shared<sinks::stdout_color_sink_mt>());
@@ -43,4 +43,4 @@ void set_error_handler(void (*handler)(const std::string &msg)) { global_logger(
 
 void shutdown() { s_logger.reset(); }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END


### PR DESCRIPTION
Enable defining custom namespace for spdlog

When spdlog is used by multiple components in the same process, 
each bundling their own copy, the linker or dynamic loader may resolve 
all spdlog:: symbols to whichever definition it finds first. This is an ODR 
(One Definition Rule) violation and can cause subtle misbehavior: 
loggers silently share state across components, or the program crashes 
when internal data structures disagree on their layout.
   
The SPDLOG_NAMESPACE macro lets a consumer place their copy of 
spdlog in a dedicated namespace, making its symbols distinct from any 
other copy in the process and avoiding ODR conflicts entirely.

For more sophisticated use cases, SPDLOG_NAMESPACE_BEGIN and 
SPDLOG_NAMESPACE_END can be overridden directly. One example is 
defining the namespace as inline, which keeps existing source code that 
refers to `spdlog::logger` or `spdlog::info(…)` compiling without 
changes, while the mangled symbol names still include the namespace 
and remain ABI-distinct from other copies.