### PR TITLE
chore: improve spdlog maintenance path

### DIFF
--- a/tests/test_create_dir.cpp
+++ b/tests/test_create_dir.cpp
@@ -48,6 +48,17 @@ TEST_CASE("create_invalid_dir", "[create_dir]") {
 #endif
 }
 
+TEST_CASE("path_exists", "[create_dir]") {
+    REQUIRE(path_exists(SPDLOG_FILENAME_T("")) == false);
+    REQUIRE(path_exists(SPDLOG_FILENAME_T("non_existing_path_xyz")) == false);
+    prepare_logdir();
+    REQUIRE(create_dir(SPDLOG_FILENAME_T("test_logs/dir1/dir2")) == true);
+    REQUIRE(path_exists(SPDLOG_FILENAME_T("test_logs/dir1/dir2")) == true);
+    REQUIRE(create_dir(SPDLOG_FILENAME_T("test_logs/dir1/dir2")) == true);  // already existing nested
+    REQUIRE(create_dir(SPDLOG_FILENAME_T("test_logs/dir1/dir3///")) == true);  // trailing separator
+    REQUIRE(path_exists(SPDLOG_FILENAME_T("test_logs/dir1/dir3")) == true);
+}
+
 TEST_CASE("dir_name", "[create_dir]") {
     using spdlog::details::os::dir_name;
     REQUIRE(dir_name(SPDLOG_FILENAME_T("")).empty());


### PR DESCRIPTION
Summary:
- Add a small set of edge-case unit tests for spdlog::details::os path/dir helpers (e.g., create_dir on a trailing-separator path, create_dir on an already-existing nested path, path_exists on an empty string) inside the existing tests/test_create_dir.cpp using the project's existing Catch2 TEST_CASE macros, mirroring the style of neighboring tests; no library code changes required.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.