### PR TITLE
Fix invalid spdlog::std::make_unique in mongo_sink

### DIFF
--- a/include/spdlog/sinks/mongo_sink.h
+++ b/include/spdlog/sinks/mongo_sink.h
@@ -44,7 +44,7 @@ public:
           db_name_(db_name),
           coll_name_(collection_name) {
         try {
-            client_ = spdlog::std::make_unique<mongocxx::client>(mongocxx::uri{uri});
+            client_ = std::make_unique<mongocxx::client>(mongocxx::uri{uri});
         } catch (const std::exception &e) {
             throw_spdlog_ex(fmt_lib::format("Error opening database: {}", e.what()));
         }


### PR DESCRIPTION
mongo_sink_config constructed its client with spdlog::std::make_unique, a stray spdlog:: prefix left over from a bulk find-and-replace in commit 19d4e605 ("Replaced details::make_unique with std::make_unique"), which rewrote details::make_unique to std::make_unique but left the leading spdlog:: on this line that originally read spdlog::details::make_unique.

It only resolved by accident via enclosing-namespace lookup of ::std, and would break outright if the namespace were renamed. Call std::make_unique directly.