### PR TITLE
Grafana Loki sink

### DIFF
--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -61,6 +61,7 @@ public:
         // Users can call set_pattern() to include additional context (e.g. thread id).
         base_sink<Mutex>::set_formatter_(
             details::make_unique<pattern_formatter>("%v", pattern_time_type::local, ""));
+        client_.set_keep_alive(true);
         if (config_.timeout_seconds > 0) {
             client_.set_connection_timeout(config_.timeout_seconds);
             client_.set_read_timeout(config_.timeout_seconds);

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -15,8 +15,9 @@
 // For production use, prefer loki_logger_async_mt: sink_it_() makes a blocking
 // HTTP call and should not run on the caller's thread.
 //
-// TODO: batching multiple log entries per HTTP request for high-throughput use cases.
-// TODO: TLS support and Authorization header for Grafana Cloud / auth-protected setups.
+// Limitations:
+// - Sends one log entry per HTTP request (no batching).
+// - No TLS/auth header support (e.g. Grafana Cloud / auth-protected setups).
 
 #include <spdlog/async.h>
 #include <spdlog/common.h>

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -93,7 +93,7 @@ private:
         if (ns < 0) ns = 0;
 
         nlohmann::json labels = labels_json_;
-        if (config_.add_level_label) {
+        if (config_.add_level_label && !labels.contains("level")) {
             auto sv = level::to_string_view(msg.level);
             labels["level"] = std::string(sv.data(), sv.size());
         }

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -34,7 +34,7 @@
 #include <string_view>
 #include <unordered_map>
 
-namespace spdlog {
+SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 struct loki_sink_config {
@@ -138,4 +138,4 @@ inline std::shared_ptr<logger> loki_logger_async_st(const std::string &logger_na
     return Factory::template create<sinks::loki_sink_st>(logger_name, std::move(config));
 }
 
-}  // namespace spdlog
+SPDLOG_NAMESPACE_END

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -113,25 +113,25 @@ using loki_sink_st = loki_sink<details::null_mutex>;
 
 }  // namespace sinks
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> loki_logger_mt(const std::string &logger_name,
                                                sinks::loki_sink_config config) {
     return Factory::template create<sinks::loki_sink_mt>(logger_name, std::move(config));
 }
 
-template <typename Factory = spdlog::synchronous_factory>
+template <typename Factory = synchronous_factory>
 inline std::shared_ptr<logger> loki_logger_st(const std::string &logger_name,
                                                sinks::loki_sink_config config) {
     return Factory::template create<sinks::loki_sink_st>(logger_name, std::move(config));
 }
 
-template <typename Factory = spdlog::async_factory>
+template <typename Factory = async_factory>
 inline std::shared_ptr<logger> loki_logger_async_mt(const std::string &logger_name,
                                                      sinks::loki_sink_config config) {
     return Factory::template create<sinks::loki_sink_mt>(logger_name, std::move(config));
 }
 
-template <typename Factory = spdlog::async_factory>
+template <typename Factory = async_factory>
 inline std::shared_ptr<logger> loki_logger_async_st(const std::string &logger_name,
                                                      sinks::loki_sink_config config) {
     return Factory::template create<sinks::loki_sink_st>(logger_name, std::move(config));

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -88,6 +88,10 @@ protected:
 
     void flush_() override {}
 
+    void set_pattern_(const std::string &pattern) override {
+        this->set_formatter_(details::make_unique<pattern_formatter>(pattern, pattern_time_type::local, ""));
+    }
+
 private:
     std::string build_json_(const details::log_msg &msg, const std::string &line) const {
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -6,7 +6,7 @@
 // Grafana Loki sink - sends log messages to Loki via the HTTP push API.
 // Requires nlohmann/json (https://github.com/nlohmann/json) and
 // cpp-httplib (https://github.com/yhirose/cpp-httplib).
-// Docs: https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki
+// Docs: https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs
 //
 // The default pattern is "%v" (message text only) because Loki stores the timestamp separately and
 // (by default) the log level is sent as a "level" stream label. Override with set_pattern() to include

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -31,7 +31,6 @@
 #include <chrono>
 #include <mutex>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 
 SPDLOG_NAMESPACE_BEGIN
@@ -77,7 +76,7 @@ protected:
     void sink_it_(const details::log_msg &msg) override {
         memory_buf_t formatted;
         base_sink<Mutex>::formatter_->format(msg, formatted);
-        auto body = build_json_(msg, std::string_view(formatted.data(), formatted.size()));
+        auto body = build_json_(msg, std::string(formatted.data(), formatted.size()));
         auto res = client_.Post("/loki/api/v1/push", body, "application/json");
         if (!res || res->status != 204)
             throw_spdlog_ex("loki_sink: " + (res ? res->reason : "connection failed"));
@@ -86,7 +85,7 @@ protected:
     void flush_() override {}
 
 private:
-    std::string build_json_(const details::log_msg &msg, std::string_view line) const {
+    std::string build_json_(const details::log_msg &msg, const std::string &line) const {
         auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
                       msg.time.time_since_epoch())
                       .count();
@@ -95,7 +94,7 @@ private:
         nlohmann::json labels = labels_json_;
         if (config_.add_level_label) {
             auto sv = level::to_string_view(msg.level);
-            labels["level"] = std::string_view(sv.data(), sv.size());
+            labels["level"] = std::string(sv.data(), sv.size());
         }
 
         return nlohmann::json{{"streams", {{

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -8,8 +8,8 @@
 // cpp-httplib (https://github.com/yhirose/cpp-httplib).
 // Docs: https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki
 //
-// The default pattern is "%v" (message text only) because timestamp and level are
-// already stored as Loki structured fields. Override with set_pattern() to include
+// The default pattern is "%v" (message text only) because Loki stores the timestamp separately and
+// (by default) the log level is sent as a "level" stream label. Override with set_pattern() to include
 // additional context in the log line (e.g. "%t %v" to prepend the thread id).
 //
 // For production use, prefer loki_logger_async_mt: sink_it_() makes a blocking

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -79,8 +79,11 @@ protected:
         base_sink<Mutex>::formatter_->format(msg, formatted);
         auto body = build_json_(msg, std::string(formatted.data(), formatted.size()));
         auto res = client_.Post("/loki/api/v1/push", body, "application/json");
-        if (!res || res->status != 204)
-            throw_spdlog_ex("loki_sink: " + (res ? res->reason : "connection failed"));
+        if (!res)
+            throw_spdlog_ex("loki_sink: connection failed");
+        if (res->status != 204)
+            throw_spdlog_ex("loki_sink: HTTP " + std::to_string(res->status) + " " + res->reason +
+                            (res->body.empty() ? "" : ": " + res->body));
     }
 
     void flush_() override {}

--- a/include/spdlog/sinks/loki_sink.h
+++ b/include/spdlog/sinks/loki_sink.h
@@ -1,0 +1,141 @@
+// Copyright(c) 2015-present, Gabi Melman & spdlog contributors.
+// Distributed under the MIT License (http://opensource.org/licenses/MIT)
+
+#pragma once
+
+// Grafana Loki sink - sends log messages to Loki via the HTTP push API.
+// Requires nlohmann/json (https://github.com/nlohmann/json) and
+// cpp-httplib (https://github.com/yhirose/cpp-httplib).
+// Docs: https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki
+//
+// The default pattern is "%v" (message text only) because timestamp and level are
+// already stored as Loki structured fields. Override with set_pattern() to include
+// additional context in the log line (e.g. "%t %v" to prepend the thread id).
+//
+// For production use, prefer loki_logger_async_mt: sink_it_() makes a blocking
+// HTTP call and should not run on the caller's thread.
+//
+// TODO: batching multiple log entries per HTTP request for high-throughput use cases.
+// TODO: TLS support and Authorization header for Grafana Cloud / auth-protected setups.
+
+#include <spdlog/async.h>
+#include <spdlog/common.h>
+#include <spdlog/details/null_mutex.h>
+#include <spdlog/details/synchronous_factory.h>
+#include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/base_sink.h>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace spdlog {
+namespace sinks {
+
+struct loki_sink_config {
+    std::string server_host;
+    int server_port;
+    std::unordered_map<std::string, std::string> labels;
+    bool add_level_label = true;
+    // 0 = use cpp-httplib defaults (300s connect, 300s read/write). Set explicitly
+    // when using the synchronous factory to bound blocking time in sink_it_().
+    int timeout_seconds = 0;
+
+    loki_sink_config(std::string host, int port)
+        : server_host{std::move(host)},
+          server_port{port} {}
+};
+
+template <typename Mutex>
+class loki_sink : public base_sink<Mutex> {
+public:
+    explicit loki_sink(loki_sink_config config)
+        : config_{std::move(config)},
+          client_(config_.server_host, config_.server_port),
+          labels_json_(config_.labels) {
+        // Timestamp and level go into Loki structured fields, so default to message text only.
+        // Users can call set_pattern() to include additional context (e.g. thread id).
+        base_sink<Mutex>::set_formatter_(
+            details::make_unique<pattern_formatter>("%v", pattern_time_type::local, ""));
+        if (config_.timeout_seconds > 0) {
+            client_.set_connection_timeout(config_.timeout_seconds);
+            client_.set_read_timeout(config_.timeout_seconds);
+            client_.set_write_timeout(config_.timeout_seconds);
+        }
+    }
+
+    ~loki_sink() override = default;
+    loki_sink(const loki_sink &) = delete;
+    loki_sink &operator=(const loki_sink &) = delete;
+
+protected:
+    void sink_it_(const details::log_msg &msg) override {
+        memory_buf_t formatted;
+        base_sink<Mutex>::formatter_->format(msg, formatted);
+        auto body = build_json_(msg, std::string_view(formatted.data(), formatted.size()));
+        auto res = client_.Post("/loki/api/v1/push", body, "application/json");
+        if (!res || res->status != 204)
+            throw_spdlog_ex("loki_sink: " + (res ? res->reason : "connection failed"));
+    }
+
+    void flush_() override {}
+
+private:
+    std::string build_json_(const details::log_msg &msg, std::string_view line) const {
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                      msg.time.time_since_epoch())
+                      .count();
+        if (ns < 0) ns = 0;
+
+        nlohmann::json labels = labels_json_;
+        if (config_.add_level_label) {
+            auto sv = level::to_string_view(msg.level);
+            labels["level"] = std::string_view(sv.data(), sv.size());
+        }
+
+        return nlohmann::json{{"streams", {{
+            {"stream", labels},
+            {"values", nlohmann::json::array({nlohmann::json::array({std::to_string(ns), line})})}
+        }}}}.dump();
+    }
+
+    loki_sink_config config_;
+    httplib::Client client_;
+    nlohmann::json labels_json_;
+};
+
+using loki_sink_mt = loki_sink<std::mutex>;
+using loki_sink_st = loki_sink<details::null_mutex>;
+
+}  // namespace sinks
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> loki_logger_mt(const std::string &logger_name,
+                                               sinks::loki_sink_config config) {
+    return Factory::template create<sinks::loki_sink_mt>(logger_name, std::move(config));
+}
+
+template <typename Factory = spdlog::synchronous_factory>
+inline std::shared_ptr<logger> loki_logger_st(const std::string &logger_name,
+                                               sinks::loki_sink_config config) {
+    return Factory::template create<sinks::loki_sink_st>(logger_name, std::move(config));
+}
+
+template <typename Factory = spdlog::async_factory>
+inline std::shared_ptr<logger> loki_logger_async_mt(const std::string &logger_name,
+                                                     sinks::loki_sink_config config) {
+    return Factory::template create<sinks::loki_sink_mt>(logger_name, std::move(config));
+}
+
+template <typename Factory = spdlog::async_factory>
+inline std::shared_ptr<logger> loki_logger_async_st(const std::string &logger_name,
+                                                     sinks::loki_sink_config config) {
+    return Factory::template create<sinks::loki_sink_st>(logger_name, std::move(config));
+}
+
+}  // namespace spdlog


### PR DESCRIPTION
Adds a sink that pushes log entries to Grafana Loki via its HTTP push API. Consistent with `kafka_sink` and `mongo_sink` — header-only, requires two external dependencies. Default pattern is `%v` (message text only): timestamp and log level go into Loki structured fields rather than the log line

https://grafana.com/docs/loki/latest/reference/loki-http-api/#ingest-logs

**Usage**
```cpp
#include "spdlog/sinks/loki_sink.h"

spdlog::sinks::loki_sink_config config("localhost", 3100);
config.labels          = {{"job", "myapp"}, {"env", "production"}};
config.add_level_label = true;   // adds level="info" etc. as a stream label
config.timeout_seconds = 5;

auto logger = spdlog::loki_logger_async_mt("loki", config);
logger->info("Hello from spdlog!");
```

**Dependencies**
- https://github.com/nlohmann/json
- https://github.com/yhirose/cpp-httplib