### PR TITLE
Add missing `#include <unistd.h>` in `systemd_namespace_sink.h`

### DIFF
--- a/include/spdlog/sinks/systemd_namespace_sink.h
+++ b/include/spdlog/sinks/systemd_namespace_sink.h
@@ -8,6 +8,7 @@
 #include <spdlog/sinks/base_sink.h>
 
 #include <array>
+#include <unistd.h>
 #include <systemd/sd-journal.h>
 #include <systemd/sd-daemon.h>
 


### PR DESCRIPTION
Related #3616

Fixed a bug where the `close()` symbol could not be resolved because `unistd.h` was not included.