### PR TITLE
Make null_mutex compliant with "Mutex" named requirement

### DIFF
--- a/include/spdlog/details/null_mutex.h
+++ b/include/spdlog/details/null_mutex.h
@@ -12,8 +12,18 @@
 SPDLOG_NAMESPACE_BEGIN
 namespace details {
 struct null_mutex {
+    null_mutex() noexcept {}
+    ~null_mutex() {}
+
+    null_mutex(const null_mutex&) = delete;
+    null_mutex(null_mutex&&) = delete;
+
+    null_mutex& operator=(const null_mutex&) = delete;
+    null_mutex& operator=(null_mutex&&) = delete;
+
     void lock() const {}
     void unlock() const {}
+    bool try_lock() const noexcept { return true; }
 };
 
 struct null_atomic_int {


### PR DESCRIPTION
I know this does not add that much value but I just stumbled over the fact that `null_mutex` is not fully compliant with the [Mutex named requirement](https://en.cppreference.com/cpp/named_req/Mutex).

I build locally and ran `ctest` with no errors.

Feel free to just delete this if this is just noise but I thought "why not shoot your shot" :)