### PR TITLE
Handle EEXIST when creating directories

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -508,8 +508,10 @@ SPDLOG_INLINE bool create_dir(const filename_t &path) {
 #endif
 
         if (!subdir.empty() && !path_exists(subdir) && !mkdir_(subdir)) {
-            return false;  // return error if failed creating dir
-        }
+                if (errno != EEXIST) {
+                        return false;  // return error if failed creating dir
+                }
+    }
         search_offset = token_pos + 1;
     } while (search_offset < path.size());
 


### PR DESCRIPTION
This change treats EEXIST from mkdir() as a successful case in create_dir(). When multiple threads try to create the same directory at the same time, one thread may see EEXIST even though the directory already exists. Instead of treating that as a failure, the code now continues creating the remaining subdirectories.

I also ran the existing test suite after this change, and all tests passed.