### PR TITLE
Treat ENOENT as success in remove_if_exists

### DIFF
--- a/include/spdlog/details/os-inl.h
+++ b/include/spdlog/details/os-inl.h
@@ -162,7 +162,10 @@ SPDLOG_INLINE int remove(const filename_t &filename) SPDLOG_NOEXCEPT {
 }
 
 SPDLOG_INLINE int remove_if_exists(const filename_t &filename) SPDLOG_NOEXCEPT {
-    return path_exists(filename) ? remove(filename) : 0;
+    if (remove(filename) == 0)
+        return 0;
+
+    return (errno == ENOENT) ? 0 : -1;
 }
 
 SPDLOG_INLINE int rename(const filename_t &filename1, const filename_t &filename2) SPDLOG_NOEXCEPT {


### PR DESCRIPTION
remove_if_exists() now treats ENOENT from remove() as success.

This avoids a race condition where the file is deleted between the existence check and remove(), causing a false failure even though the file is already gone.

All other error cases are unchanged.