### PR TITLE
Improve robustness of daily_file_sink filename initialization

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -132,9 +132,9 @@ private:
         auto now = log_clock::now();
         while (filenames.size() < max_files_) {
             const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
-            if (!path_exists(new_filename)) {
-                break;
-            }
+            if (filenames.empty() && !path_exists(new_filename)) {
+    break;
+}
             filenames.emplace_back(new_filename);
             now -= std::chrono::hours(24);
         }


### PR DESCRIPTION
This change makes the filename history initialization in daily_file_sink more robust when older rotated log files are missing.

In some environments, log files may be removed externally while newer ones still exist. In such cases, the previous logic could stop scanning early.

This update ensures the scan behaves more consistently when files are missing due to external cleanup.

No change in normal logging behavior.