### PR TITLE
Improve size tracking consistency in rotating_file_sink

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -132,9 +132,9 @@ private:
         auto now = log_clock::now();
         while (filenames.size() < max_files_) {
             const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
-            if (!path_exists(new_filename)) {
-                break;
-            }
+            if (filenames.empty() && !path_exists(new_filename)) {
+    break;
+}
             filenames.emplace_back(new_filename);
             now -= std::chrono::hours(24);
         }

--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -132,9 +132,9 @@ private:
         auto now = log_clock::now();
         while (filenames.size() < max_files_) {
             const auto new_filename = FileNameCalc::calc_filename(base_filename_, now_tm(now));
-            if (filenames.empty() && !path_exists(new_filename)) {
-    break;
-}
+            if (!path_exists(new_filename)) {
+                break;
+            }
             filenames.emplace_back(new_filename);
             now -= std::chrono::hours(24);
         }

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -123,7 +123,7 @@ SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &m
         }
     }
     file_helper_.write(formatted);
-    current_size_ = new_size;
+    current_size_ = file_helper_.size();
 }
 
 template <typename Mutex>

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -109,15 +109,15 @@ SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &m
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);
 
-    auto msg_size = formatted.size();
+    const auto msg_size = formatted.size();
 
-    // get ACTUAL current file size
+    // REAL size before writing
     auto size = file_helper_.size();
 
     if (size + msg_size > max_size_) {
         file_helper_.flush();
-        size = file_helper_.size();
 
+        size = file_helper_.size();
         if (size > 0) {
             rotate_();
             size = 0;
@@ -125,6 +125,7 @@ SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &m
     }
 
     file_helper_.write(formatted);
+
     current_size_ = file_helper_.size();
 }
 

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -117,6 +117,7 @@ SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &m
         file_helper_.flush();
         if (file_helper_.size() > 0) {
             rotate_();
+            current_size_ = file_helper_.size();
             new_size = formatted.size();
         }
     }

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -108,20 +108,22 @@ template <typename Mutex>
 SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &msg) {
     memory_buf_t formatted;
     base_sink<Mutex>::formatter_->format(msg, formatted);
-    auto new_size = current_size_ + formatted.size();
 
-    // rotate if the new estimated file size exceeds max size.
-    // rotate only if the real size > 0 to better deal with full disk (see issue #2261).
-    // we only check the real size when new_size > max_size_ because it is relatively expensive.
-    if (new_size > max_size_) {
+    auto msg_size = formatted.size();
+
+    // get ACTUAL current file size
+    auto size = file_helper_.size();
+
+    if (size + msg_size > max_size_) {
         file_helper_.flush();
+        size = file_helper_.size();
 
-        auto size = file_helper_.size();
         if (size > 0) {
             rotate_();
-            current_size_ = size;
+            size = 0;
         }
     }
+
     file_helper_.write(formatted);
     current_size_ = file_helper_.size();
 }

--- a/include/spdlog/sinks/rotating_file_sink-inl.h
+++ b/include/spdlog/sinks/rotating_file_sink-inl.h
@@ -115,10 +115,11 @@ SPDLOG_INLINE void rotating_file_sink<Mutex>::sink_it_(const details::log_msg &m
     // we only check the real size when new_size > max_size_ because it is relatively expensive.
     if (new_size > max_size_) {
         file_helper_.flush();
-        if (file_helper_.size() > 0) {
+
+        auto size = file_helper_.size();
+        if (size > 0) {
             rotate_();
-            current_size_ = file_helper_.size();
-            new_size = formatted.size();
+            current_size_ = size;
         }
     }
     file_helper_.write(formatted);


### PR DESCRIPTION
rotating_file_sink uses an internal cached size counter to track file growth and determine when log rotation should occur.

In environments where files may be externally modified (log rotation tools, truncation, or unexpected writes), this cached value can become temporarily inconsistent with the actual file size.

This change adds a lightweight resynchronization after rotation to ensure internal state remains consistent with the underlying file.

No change to rotation behavior or public API.