### PR TITLE
Use WSAGetLastError for UDP send errors on Windows

### DIFF
--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -90,7 +90,7 @@ public:
         socklen_t tolen = sizeof(struct sockaddr);
         if (::sendto(socket_, data, static_cast<int>(n_bytes), 0, (struct sockaddr *)&addr_,
                      tolen) == -1) {
-            throw_spdlog_ex("sendto(2) failed", errno);
+            throw_winsock_error_("sendto(2) failed", ::WSAGetLastError());
         }
     }
 };


### PR DESCRIPTION
### Summary

This change updates the Windows UDP client to use `WSAGetLastError()` when `sendto()` fails.

Winsock APIs report socket errors through `WSAGetLastError()`, while the current implementation uses `errno`, which may produce an incorrect or misleading error message. This change uses the existing `throw_winsock_error_()` helper so that the reported exception contains the actual Winsock error.
