### PR TITLE
Use WSAStartup return value for error reporting

### DIFF
--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -32,7 +32,7 @@ class udp_client {
         WSADATA wsaData;
         auto rv = ::WSAStartup(MAKEWORD(2, 2), &wsaData);
         if (rv != 0) {
-            throw_winsock_error_("WSAStartup failed", ::WSAGetLastError());
+            throw_winsock_error_("WSAStartup failed", rv);
         }
     }
 

--- a/include/spdlog/details/udp_client-windows.h
+++ b/include/spdlog/details/udp_client-windows.h
@@ -90,7 +90,7 @@ public:
         socklen_t tolen = sizeof(struct sockaddr);
         if (::sendto(socket_, data, static_cast<int>(n_bytes), 0, (struct sockaddr *)&addr_,
                      tolen) == -1) {
-            throw_spdlog_ex("sendto(2) failed", errno);
+            throw_winsock_error_("sendto(2) failed", ::WSAGetLastError());
         }
     }
 };


### PR DESCRIPTION
WSAStartup() returns the error code directly when initialization fails. This change uses the returned value instead of WSAGetLastError() so the reported error matches the Winsock API behavior.