### PR TITLE
Buffer source_loc filename/funcname in log_msg_buffer

### DIFF
--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -7,6 +7,9 @@
 #include <spdlog/details/log_msg_buffer.h>
 #endif
 
+#include <cstring>
+#include <cstddef>
+
 SPDLOG_NAMESPACE_BEGIN
 namespace details {
 
@@ -14,6 +17,7 @@ SPDLOG_INLINE log_msg_buffer::log_msg_buffer(const log_msg &orig_msg)
     : log_msg{orig_msg} {
     buffer.append(logger_name.begin(), logger_name.end());
     buffer.append(payload.begin(), payload.end());
+    append_source();
     update_string_views();
 }
 
@@ -21,6 +25,7 @@ SPDLOG_INLINE log_msg_buffer::log_msg_buffer(const log_msg_buffer &other)
     : log_msg{other} {
     buffer.append(logger_name.begin(), logger_name.end());
     buffer.append(payload.begin(), payload.end());
+    append_source();
     update_string_views();
 }
 
@@ -45,9 +50,33 @@ SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(log_msg_buffer &&other) 
     return *this;
 }
 
+// Append the null-terminated source_loc strings to the buffer so that they are
+// owned by this log_msg_buffer. Without this, source.filename/source.funcname
+// would keep pointing at the caller's memory, which dangles once the message is
+// queued (async logging, ringbuffer_sink, ...) and outlives that memory.
+SPDLOG_INLINE void log_msg_buffer::append_source() {
+    if (source.filename != nullptr) {
+        buffer.append(source.filename, source.filename + std::strlen(source.filename) + 1);
+    }
+    if (source.funcname != nullptr) {
+        buffer.append(source.funcname, source.funcname + std::strlen(source.funcname) + 1);
+    }
+}
+
 SPDLOG_INLINE void log_msg_buffer::update_string_views() {
     logger_name = string_view_t{buffer.data(), logger_name.size()};
     payload = string_view_t{buffer.data() + logger_name.size(), payload.size()};
+
+    // Re-point the source strings into our buffer (in the same order they were
+    // appended by append_source). They are stored null-terminated.
+    size_t offset = logger_name.size() + payload.size();
+    if (source.filename != nullptr) {
+        source.filename = buffer.data() + offset;
+        offset += std::strlen(source.filename) + 1;
+    }
+    if (source.funcname != nullptr) {
+        source.funcname = buffer.data() + offset;
+    }
 }
 
 }  // namespace details

--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -13,6 +13,7 @@ namespace details {
 
 class SPDLOG_API log_msg_buffer : public log_msg {
     memory_buf_t buffer;
+    void append_source();
     void update_string_views();
 
 public:

--- a/tests/test_ringbuffer.cpp
+++ b/tests/test_ringbuffer.cpp
@@ -50,3 +50,29 @@ TEST_CASE("ringbuffer retrieval limit", "[ringbuffer]") {
     REQUIRE(formatted[0] == spdlog::fmt_lib::format("B{}", default_eol));
     REQUIRE(formatted[1] == spdlog::fmt_lib::format("C{}", default_eol));
 }
+
+// Regression test for #3195: source_loc filename/funcname must be buffered by
+// log_msg_buffer, otherwise they dangle once the caller's strings are gone.
+TEST_CASE("ringbuffer buffers source_loc strings", "[ringbuffer]") {
+    spdlog::sinks::ringbuffer_sink_st sink(2);
+    sink.set_pattern("%g:%# %! %v");
+
+    {
+        // filename/funcname from scoped strings that are destroyed before retrieval
+        std::string filename = std::string("dynamic_") + "source.cpp";
+        std::string funcname = std::string("dynamic_") + "function";
+        spdlog::source_loc loc{filename.c_str(), 123, funcname.c_str()};
+        sink.log(spdlog::details::log_msg{loc, "test", spdlog::level::info, "payload"});
+    }
+
+    // overwrite the freed stack memory
+    volatile char scratch[256];
+    for (size_t i = 0; i < sizeof(scratch); ++i) scratch[i] = static_cast<char>(i);
+
+    auto formatted = sink.last_formatted();
+    REQUIRE(formatted.size() == 1);
+    using spdlog::details::os::default_eol;
+    REQUIRE(formatted[0] ==
+            spdlog::fmt_lib::format("dynamic_source.cpp:123 dynamic_function payload{}",
+                                    default_eol));
+}


### PR DESCRIPTION
Fixes #3195.

`log_msg_buffer` copies `logger_name` and `payload` into its own buffer and re-points the string_views at that owned storage, precisely so a queued message does not depend on the caller's stack/temporary memory. The `source` field was left out: `source_loc` holds `const char* filename` and `const char* funcname`, and those pointers were copied as-is, so a buffered message keeps pointing at the caller's memory.

For the `SPDLOG_*` macros this is harmless because `__FILE__` / `SPDLOG_FUNCTION` are static string literals. But when the `source_loc` is built from non-static strings (a runtime `source_loc`, as with `ringbuffer_sink` in the issue, or async logging), those pointers dangle once the caller's strings go out of scope while the message is still buffered.

This appends `filename` and `funcname` (null-terminated) to the same buffer next to `logger_name`/`payload`, and re-points `source.filename`/`source.funcname` into it in `update_string_views()`, mirroring how the existing string_views are handled. `nullptr` filename/funcname are preserved as-is.

## Reproduction (AddressSanitizer)

Logging a message whose `source_loc` strings live on the stack, then retrieving it after they go out of scope:

- **before:** `AddressSanitizer: stack-use-after-scope READ of size 17 ... in strrchr` (the pattern formatter reading `source.filename`)
- **after:** clean, and the filename/funcname format correctly.

## Testing

- Added `ringbuffer buffers source_loc strings` in `tests/test_ringbuffer.cpp`: logs with a scoped runtime `source_loc`, lets the strings go out of scope, overwrites the freed stack, then asserts the buffered message still formats `%g:%# %!` with the original filename/funcname. Fails under ASan (`SPDLOG_SANITIZE_ADDRESS`) without the fix, passes with it.
- Full `spdlog-utests` suite passes with ASan enabled.
