### PR TITLE
Add a pkg-config file for header-only usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,19 @@ if(SPDLOG_INSTALL)
     configure_file("cmake/${PROJECT_NAME}.pc.in" "${pkg_config}" @ONLY)
     install(FILES "${pkg_config}" DESTINATION "${pkgconfig_install_dir}")
 
+    # Header-only pkg-config file: no libspdlog to link and no SPDLOG_COMPILED_LIB,
+    # so header-only consumers get the correct flags.
+    set(pkg_config_header_only "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_header_only.pc")
+    get_target_property(PKG_CONFIG_HO_DEFINES spdlog_header_only INTERFACE_COMPILE_DEFINITIONS)
+    if(PKG_CONFIG_HO_DEFINES)
+        string(REPLACE ";" " -D" PKG_CONFIG_HO_DEFINES "${PKG_CONFIG_HO_DEFINES}")
+        string(CONCAT PKG_CONFIG_HO_DEFINES "-D" "${PKG_CONFIG_HO_DEFINES}")
+    else()
+        set(PKG_CONFIG_HO_DEFINES "")
+    endif()
+    configure_file("cmake/${PROJECT_NAME}_header_only.pc.in" "${pkg_config_header_only}" @ONLY)
+    install(FILES "${pkg_config_header_only}" DESTINATION "${pkgconfig_install_dir}")
+
     # ---------------------------------------------------------------------------------------
     # Install CMake config files
     # ---------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ if(SPDLOG_INSTALL)
 
     # Header-only pkg-config file: no libspdlog to link and no SPDLOG_COMPILED_LIB,
     # so header-only consumers get the correct flags.
-    set(pkg_config_header_only "${CMAKE_BINARY_DIR}/${PROJECT_NAME}_header_only.pc")
+    set(pkg_config_header_only "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_header_only.pc")
     get_target_property(PKG_CONFIG_HO_DEFINES spdlog_header_only INTERFACE_COMPILE_DEFINITIONS)
     if(PKG_CONFIG_HO_DEFINES)
         string(REPLACE ";" " -D" PKG_CONFIG_HO_DEFINES "${PKG_CONFIG_HO_DEFINES}")

--- a/cmake/spdlog_header_only.pc.in
+++ b/cmake/spdlog_header_only.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+includedir=@PKG_CONFIG_INCLUDEDIR@
+libdir=@PKG_CONFIG_LIBDIR@
+
+Name: lib@PROJECT_NAME@_header_only
+Description: Fast C++ logging library. (header-only)
+URL: https://github.com/gabime/@PROJECT_NAME@
+Version: @SPDLOG_VERSION@
+CFlags: -I${includedir} @PKG_CONFIG_HO_DEFINES@
+Libs: -L${libdir} -pthread
+Requires: @PKG_CONFIG_REQUIRES@


### PR DESCRIPTION
Closes #3106.

`spdlog.pc` describes the compiled library: its `CFlags` include `-DSPDLOG_COMPILED_LIB` and its `Libs` link `-lspdlog`. A header-only consumer that pulls flags from `pkg-config --cflags --libs spdlog` therefore gets `-DSPDLOG_COMPILED_LIB` (which makes the headers expect a library to link) and `-lspdlog` (which may not be built), breaking the build.

This installs a companion `spdlog_header_only.pc`, generated from the `spdlog_header_only` INTERFACE target, so its defines and libs match header-only use: no `-DSPDLOG_COMPILED_LIB`, no `-lspdlog` (just the include dir and `-pthread`, plus `SPDLOG_FMT_EXTERNAL` / `Requires: fmt` when external fmt is selected, mirroring the existing `.pc`).

Verified the generated files with `cmake -DSPDLOG_INSTALL=ON`:
- `spdlog.pc` — unchanged.
- `spdlog_header_only.pc` — `CFlags: -I${includedir}`, `Libs: -L${libdir} -pthread`.