### PR TITLE
docs: correct daily/hourly sink filename format in comments

### DIFF
--- a/include/spdlog/sinks/daily_file_sink.h
+++ b/include/spdlog/sinks/daily_file_sink.h
@@ -24,10 +24,10 @@ SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
- * Generator of daily log file names in format basename.YYYY-MM-DD.ext
+ * Generator of daily log file names in format basename_YYYY-MM-DD.ext
  */
 struct daily_filename_calculator {
-    // Create filename for the form basename.YYYY-MM-DD
+    // Create filename of the form basename_YYYY-MM-DD.ext
     static filename_t calc_filename(const filename_t &filename, const tm &now_tm) {
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extension(filename);

--- a/include/spdlog/sinks/hourly_file_sink.h
+++ b/include/spdlog/sinks/hourly_file_sink.h
@@ -22,10 +22,10 @@ SPDLOG_NAMESPACE_BEGIN
 namespace sinks {
 
 /*
- * Generator of Hourly log file names in format basename.YYYY-MM-DD-HH.ext
+ * Generator of Hourly log file names in format basename_YYYY-MM-DD_HH.ext
  */
 struct hourly_filename_calculator {
-    // Create filename for the form basename.YYYY-MM-DD-H
+    // Create filename of the form basename_YYYY-MM-DD_HH.ext
     static filename_t calc_filename(const filename_t &filename, const tm &now_tm) {
         filename_t basename, ext;
         std::tie(basename, ext) = details::file_helper::split_by_extension(filename);


### PR DESCRIPTION
The `daily_filename_calculator` and `hourly_filename_calculator` build filenames with an underscore separator (`basename_YYYY-MM-DD.ext` and `basename_YYYY-MM-DD_HH.ext`), but the accompanying comments described the format with a dot separator — and, for the hourly sink, a dash before the hour. This updates the comments to match the output actually produced by `calc_filename` (see the regex in `tests/test_daily_logger.cpp`). Comments only; no behavior change.
