### PR TITLE
fix: avoid -Wdangling-reference false positives in bundled fmt locale helpers

### DIFF
--- a/include/spdlog/fmt/bundled/format-inl.h
+++ b/include/spdlog/fmt/bundled/format-inl.h
@@ -111,7 +111,8 @@ inline void fwrite_all(const void* ptr, size_t count, FILE* stream) {
 
 template <typename Char>
 FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
-  auto&& facet = use_facet<numpunct<Char>>(loc.get<locale>());
+  auto loc_copy = loc.get<locale>();
+  auto&& facet = use_facet<numpunct<Char>>(loc_copy);
   auto grouping = facet.grouping();
   auto thousands_sep = grouping.empty() ? Char() : facet.thousands_sep();
   return {std::move(grouping), thousands_sep};

--- a/include/spdlog/fmt/bundled/xchar.h
+++ b/include/spdlog/fmt/bundled/xchar.h
@@ -46,8 +46,8 @@ using format_string_char_t = typename format_string_char<S>::type;
 inline auto write_loc(basic_appender<wchar_t> out, loc_value value,
                       const format_specs& specs, locale_ref loc) -> bool {
 #if FMT_USE_LOCALE
-  auto& numpunct =
-      std::use_facet<std::numpunct<wchar_t>>(loc.get<std::locale>());
+  auto loc_copy = loc.get<std::locale>();
+  auto& numpunct = std::use_facet<std::numpunct<wchar_t>>(loc_copy);
   auto separator = std::wstring();
   auto grouping = numpunct.grouping();
   if (!grouping.empty()) separator = std::wstring(1, numpunct.thousands_sep());


### PR DESCRIPTION
GCC 13/14 warns in the bundled fmt when a precompiled header is used (see #3223):

    include/spdlog/fmt/bundled/format-inl.h:114: warning: possibly dangling reference
      to a temporary [-Wdangling-reference]
    include/spdlog/fmt/bundled/xchar.h:49: same

It is a false positive: `locale_ref::get<std::locale>()` returns a copy, and a facet
reference stays valid as long as any copy of that locale exists. GCC normally suppresses
it because `std::use_facet` is declared in a system header, but that suppression is lost
when the declaration comes from a PCH, reproducible with plain `<locale>` and no fmt
involved.

The fix binds the locale copy to a named variable at the two call sites, so no reference
is bound to a temporary. Same single copy, no behaviour change, and the lifetime becomes
explicit instead of relying on the "valid while any copy exists" guarantee.

Checked with GCC 13.4: warnings gone with a PCH, formatting output unchanged
(`{:L}` with a custom `numpunct`, narrow and wide).

These files are a vendored copy of fmt, so fixing it here is what actually removes the
warning for spdlog users.
