### PR TITLE
Reuse backtrace ring-buffer slots when recording messages

### DIFF
--- a/include/spdlog/details/backtracer-inl.h
+++ b/include/spdlog/details/backtracer-inl.h
@@ -42,7 +42,7 @@ SPDLOG_INLINE bool backtracer::enabled() const { return enabled_.load(std::memor
 
 SPDLOG_INLINE void backtracer::push_back(const log_msg &msg) {
     std::lock_guard<std::mutex> lock{mutex_};
-    messages_.push_back(log_msg_buffer{msg});
+    messages_.push_back_overwrite([&msg](log_msg_buffer &dest) { dest = msg; });
 }
 
 SPDLOG_INLINE bool backtracer::empty() const {

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -46,13 +46,15 @@ public:
     void push_back(T &&item) {
         if (max_items_ > 0) {
             v_[tail_] = std::move(item);
-            tail_ = (tail_ + 1) % max_items_;
+            advance_tail_();
+        }
+    }
 
-            if (tail_ == head_)  // overrun last item if full
-            {
-                head_ = (head_ + 1) % max_items_;
-                ++overrun_counter_;
-            }
+    template <typename F>
+    void push_back_overwrite(F &&write_item) {
+        if (max_items_ > 0) {
+            write_item(v_[tail_]);
+            advance_tail_();
         }
     }
 
@@ -97,6 +99,16 @@ public:
     void reset_overrun_counter() { overrun_counter_ = 0; }
 
 private:
+    void advance_tail_() {
+        tail_ = (tail_ + 1) % max_items_;
+
+        if (tail_ == head_)  // overrun last item if full
+        {
+            head_ = (head_ + 1) % max_items_;
+            ++overrun_counter_;
+        }
+    }
+
     // copy from other&& and reset it to disabled state
     void copy_moveable(circular_q &&other) SPDLOG_NOEXCEPT {
         max_items_ = other.max_items_;

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -35,6 +35,25 @@ SPDLOG_INLINE log_msg_buffer::log_msg_buffer(log_msg_buffer &&other) SPDLOG_NOEX
     update_string_views();
 }
 
+SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg &other) {
+    log_msg::operator=(other);
+    buffer.clear();
+
+    size_t needed = logger_name.size() + payload.size();
+    if (source.filename != nullptr) {
+        needed += std::strlen(source.filename) + 1;
+    }
+    if (source.funcname != nullptr) {
+        needed += std::strlen(source.funcname) + 1;
+    }
+    buffer.reserve(needed);
+    buffer.append(logger_name.begin(), logger_name.end());
+    buffer.append(payload.begin(), payload.end());
+    append_source();
+    update_string_views();
+    return *this;
+}
+
 SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg_buffer &other) {
     log_msg::operator=(other);
     buffer.clear();

--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -21,6 +21,7 @@ public:
     explicit log_msg_buffer(const log_msg &orig_msg);
     log_msg_buffer(const log_msg_buffer &other);
     log_msg_buffer(log_msg_buffer &&other) SPDLOG_NOEXCEPT;
+    log_msg_buffer &operator=(const log_msg &other);
     log_msg_buffer &operator=(const log_msg_buffer &other);
     log_msg_buffer &operator=(log_msg_buffer &&other) SPDLOG_NOEXCEPT;
 };


### PR DESCRIPTION
## Summary

When backtracing is enabled, each logged message is copied into a fixed-size
ring buffer. The current `backtracer::push_back()` path builds a temporary
`log_msg_buffer` and then move-assigns it into the next queue slot.

This change lets the backtracer write directly into the next existing
ring-buffer slot:

- `circular_q` gets an internal overwrite helper that advances the tail with
  the same overrun behavior as `push_back()`.
- `log_msg_buffer` gets assignment from `log_msg`, preserving the owned logger
  name, payload, and source-location strings.
- `backtracer::push_back()` uses that path to reuse the destination buffer
  capacity across overwrites.

Normal `log_msg_buffer` copy/move construction and assignment are left
unchanged.

## Why this helps

Backtrace buffers are fixed-size circular queues, so after the queue has warmed
up, each push usually overwrites an existing slot. Reusing that slot avoids the
temporary buffer and lets repeated backtrace messages reuse already allocated
payload storage.

## Validation

Correctness:

```sh
cmake -S . -B build -DSPDLOG_BUILD_TESTS=ON -DSPDLOG_BUILD_EXAMPLE=OFF -DSPDLOG_BUILD_BENCH=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build -j8
ctest --test-dir build --output-on-failure
```

Focused benchmark, measured locally with repeated `details::backtracer::push_back`
calls into a 32-entry backtrace buffer:

| Payload | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 64 bytes | 12.532 ns/push | 8.205 ns/push | 34.52% faster |
| 256 bytes | 22.024 ns/push | 11.637 ns/push | 47.16% faster |
| 1024 bytes | 35.303 ns/push | 22.625 ns/push | 35.91% faster |

The benchmark focuses on the path changed here and avoids file sink I/O noise.

