### PR TITLE
Reuse backtrace ring-buffer slots when recording messages

### DIFF
--- a/include/spdlog/details/backtracer-inl.h
+++ b/include/spdlog/details/backtracer-inl.h
@@ -42,7 +42,7 @@ SPDLOG_INLINE bool backtracer::enabled() const { return enabled_.load(std::memor
 
 SPDLOG_INLINE void backtracer::push_back(const log_msg &msg) {
     std::lock_guard<std::mutex> lock{mutex_};
-    messages_.push_back(log_msg_buffer{msg});
+    messages_.push_back_overwrite([&msg](log_msg_buffer &dest) { dest = msg; });
 }
 
 SPDLOG_INLINE bool backtracer::empty() const {

--- a/include/spdlog/details/circular_q.h
+++ b/include/spdlog/details/circular_q.h
@@ -46,13 +46,15 @@ public:
     void push_back(T &&item) {
         if (max_items_ > 0) {
             v_[tail_] = std::move(item);
-            tail_ = (tail_ + 1) % max_items_;
+            advance_tail_();
+        }
+    }
 
-            if (tail_ == head_)  // overrun last item if full
-            {
-                head_ = (head_ + 1) % max_items_;
-                ++overrun_counter_;
-            }
+    template <typename F>
+    void push_back_overwrite(F &&write_item) {
+        if (max_items_ > 0) {
+            write_item(v_[tail_]);
+            advance_tail_();
         }
     }
 
@@ -97,6 +99,16 @@ public:
     void reset_overrun_counter() { overrun_counter_ = 0; }
 
 private:
+    void advance_tail_() {
+        tail_ = (tail_ + 1) % max_items_;
+
+        if (tail_ == head_)  // overrun last item if full
+        {
+            head_ = (head_ + 1) % max_items_;
+            ++overrun_counter_;
+        }
+    }
+
     // copy from other&& and reset it to disabled state
     void copy_moveable(circular_q &&other) SPDLOG_NOEXCEPT {
         max_items_ = other.max_items_;

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -35,6 +35,25 @@ SPDLOG_INLINE log_msg_buffer::log_msg_buffer(log_msg_buffer &&other) SPDLOG_NOEX
     update_string_views();
 }
 
+SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg &other) {
+    log_msg::operator=(other);
+    buffer.clear();
+
+    size_t needed = logger_name.size() + payload.size();
+    if (source.filename != nullptr) {
+        needed += std::strlen(source.filename) + 1;
+    }
+    if (source.funcname != nullptr) {
+        needed += std::strlen(source.funcname) + 1;
+    }
+    buffer.reserve(needed);
+    buffer.append(logger_name.begin(), logger_name.end());
+    buffer.append(payload.begin(), payload.end());
+    append_source();
+    update_string_views();
+    return *this;
+}
+
 SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg_buffer &other) {
     log_msg::operator=(other);
     buffer.clear();

--- a/include/spdlog/details/log_msg_buffer-inl.h
+++ b/include/spdlog/details/log_msg_buffer-inl.h
@@ -36,6 +36,10 @@ SPDLOG_INLINE log_msg_buffer::log_msg_buffer(log_msg_buffer &&other) SPDLOG_NOEX
 }
 
 SPDLOG_INLINE log_msg_buffer &log_msg_buffer::operator=(const log_msg &other) {
+    if (static_cast<const log_msg *>(this) == &other) {
+        return *this;
+    }
+
     log_msg::operator=(other);
     buffer.clear();
 

--- a/include/spdlog/details/log_msg_buffer.h
+++ b/include/spdlog/details/log_msg_buffer.h
@@ -21,6 +21,7 @@ public:
     explicit log_msg_buffer(const log_msg &orig_msg);
     log_msg_buffer(const log_msg_buffer &other);
     log_msg_buffer(log_msg_buffer &&other) SPDLOG_NOEXCEPT;
+    log_msg_buffer &operator=(const log_msg &other);
     log_msg_buffer &operator=(const log_msg_buffer &other);
     log_msg_buffer &operator=(log_msg_buffer &&other) SPDLOG_NOEXCEPT;
 };

--- a/tests/test_backtrace.cpp
+++ b/tests/test_backtrace.cpp
@@ -28,6 +28,29 @@ TEST_CASE("bactrace1", "[bactrace]") {
     REQUIRE(test_sink->lines()[7] == "****************** Backtrace End ********************");
 }
 
+TEST_CASE("backtrace reuses overwritten message storage", "[backtrace]") {
+    using spdlog::sinks::test_sink_st;
+    auto test_sink = std::make_shared<test_sink_st>();
+
+    spdlog::logger logger("test-backtrace", test_sink);
+    logger.set_pattern("%g:%# %! %v");
+    logger.enable_backtrace(2);
+
+    for (int i = 0; i < 4; ++i) {
+        std::string filename = "source-file-" + std::to_string(i) + ".cpp";
+        std::string funcname = "source_function_" + std::to_string(i);
+        std::string payload = i < 2 ? std::string(128, static_cast<char>('a' + i))
+                                    : "message " + std::to_string(i);
+        logger.log(spdlog::source_loc{filename.c_str(), i + 10, funcname.c_str()},
+                   spdlog::level::debug, payload);
+    }
+
+    logger.dump_backtrace();
+    REQUIRE(test_sink->lines().size() == 4);
+    REQUIRE(test_sink->lines()[1] == "source-file-2.cpp:12 source_function_2 message 2");
+    REQUIRE(test_sink->lines()[2] == "source-file-3.cpp:13 source_function_3 message 3");
+}
+
 TEST_CASE("bactrace-empty", "[bactrace]") {
     using spdlog::sinks::test_sink_st;
     auto test_sink = std::make_shared<test_sink_st>();

--- a/tests/test_circular_q.cpp
+++ b/tests/test_circular_q.cpp
@@ -48,3 +48,18 @@ TEST_CASE("test_empty", "[circular_q]") {
     q.push_back(1);
     REQUIRE(q.empty());
 }
+
+TEST_CASE("test_push_back_overwrite", "[circular_q]") {
+    const size_t q_size = 3;
+    q_type q(q_size);
+
+    for (size_t i = 0; i < q_size + 2; i++) {
+        q.push_back_overwrite([i](size_t &dest) { dest = i; });
+    }
+
+    REQUIRE(q.size() == q_size);
+    REQUIRE(q.overrun_counter() == 2);
+    REQUIRE(q.at(0) == 2);
+    REQUIRE(q.at(1) == 3);
+    REQUIRE(q.at(2) == 4);
+}


### PR DESCRIPTION
## Summary

Reuse the allocated storage in full backtrace ring-buffer slots instead of constructing and moving a fresh `log_msg_buffer` for every recorded message.

## Motivation

Once a backtrace buffer reaches its configured capacity, every new message overwrites the oldest slot. The current path still constructs a temporary `log_msg_buffer` and then move-assigns it into that slot. This discards the slot's existing allocation even though the same storage can be reused for the new logger name, payload, and source-location strings.

## Implementation

This adds a circular-queue operation that lets a caller update the tail slot before advancing the queue. The backtracer uses it to assign the incoming `log_msg` directly into the existing `log_msg_buffer`.

The assignment preserves the destination buffer's capacity while rebuilding all owned string views, including the source filename and function name. It also handles self-aliasing. Queue ordering, capacity, and overrun accounting are unchanged.

## Validation

The circular-queue test covers ordering and overrun counts for the new operation. An end-to-end backtrace test repeatedly overwrites a two-slot trace using dynamic payload and source-location strings, destroys the caller-owned strings, and then verifies the retained messages and source metadata. Long messages are replaced by shorter ones to exercise buffer reuse and string-view length updates.

After rebasing onto the current `v1.x` branch, the complete CTest suite passes in all three configurations I tested:

```text
C++11 Release: 100% tests passed, 0 failed
C++17 Debug:   100% tests passed, 0 failed
C++20 Release: 100% tests passed, 0 failed
```

`git diff --check` also passes.

## Benchmark

I used spdlog's existing `bench/latency` executable and its two backtrace cases. Baseline and candidate were built from the same `v1.x` revision with GCC 12.3, C++11 Release, bundled fmt, and CPU affinity fixed to one core. Each case ran for at least five seconds with five repetitions.

```sh
taskset -c 0 ./build/bench/latency \
  --benchmark_filter='^(disabled-at-runtime/backtrace|null_sink_st/backtrace)$' \
  --benchmark_min_time=5s \
  --benchmark_repetitions=5 \
  --benchmark_report_aggregates_only=true
```

Mean wall time from the reverse-order confirmation run:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| `disabled-at-runtime/backtrace` | 73.44 ns | 67.90 ns | 7.54% faster |
| `null_sink_st/backtrace` | 73.78 ns | 64.53 ns | 12.54% faster |

The coefficients of variation in this run were at most 2.3%. A baseline-first run also favored the candidate, but its first baseline case had higher variance, so I used the lower-gain reverse-order results above.
